### PR TITLE
feat: support zero-amount RGB payment amount in sendpayment

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2128,6 +2128,15 @@ components:
         invoice:
           type: string
           example: lnbcrt30u1pjv6yzndqud3jxktt5w46x7unfv9kz6mn0v3jsnp4qdpc280eur52luxppv6f3nnj8l6vnd9g2hnv3qv6mjhmhvlzf6327pp5tjjasx6g9dqptea3fhm6yllq5wxzycnnvp8l6wcq3d6j2uvpryuqsp5l8az8x3g8fe05dg7cmgddld3da09nfjvky8xftwsk4cj8p2l7kfq9qyysgqcqpcxqzdylzlwfnkyw3jv344x4rzwgkk53ng0fhxy5rdduk4g5tpvea8xa6rfckkza35va28xjn2tqkhgarcxep5umm4x5k56wfcdvu95eq7qzp20vrl4xz76syapsa3c09j7lg5gerkaj63llj0ark7ph8hfketn6fkqzm8laf66dhsncm23wkwm5l5377we9e8lnlknnkwje5eefkccusqm6rqt8
+        amt_msat:
+          type: integer
+          example: 3000000
+        asset_id:
+          type: string
+          example: rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ8
+        asset_amount:
+          type: integer
+          example: 100
     SendPaymentResponse:
       type: object
       properties:

--- a/src/test/concurrent_btc_payments.rs
+++ b/src/test/concurrent_btc_payments.rs
@@ -73,6 +73,8 @@ async fn concurrent_btc_payments() {
     let payload_1 = SendPaymentRequest {
         invoice: invoice_1.clone(),
         amt_msat: None,
+        asset_id: None,
+        asset_amount: None,
     };
     let res_1 = reqwest::Client::new()
         .post(format!("http://{node3_addr}/sendpayment"))
@@ -86,6 +88,8 @@ async fn concurrent_btc_payments() {
     let payload_2 = SendPaymentRequest {
         invoice: invoice_2.clone(),
         amt_msat: None,
+        asset_id: None,
+        asset_amount: None,
     };
     let res_2 = reqwest::Client::new()
         .post(format!("http://{node4_addr}/sendpayment"))

--- a/src/test/invoice.rs
+++ b/src/test/invoice.rs
@@ -121,6 +121,8 @@ async fn zero_amount_invoice() {
     let payload = SendPaymentRequest {
         invoice: invoice.clone(),
         amt_msat: Some(payment_amount),
+        asset_id: None,
+        asset_amount: None,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node1_addr}/sendpayment"))
@@ -140,4 +142,195 @@ async fn zero_amount_invoice() {
 
     // Wait for payment to complete
     wait_for_ln_payment(node1_addr, &decoded.payment_hash, HTLCStatus::Succeeded).await;
+    wait_for_ln_payment(node2_addr, &decoded.payment_hash, HTLCStatus::Succeeded).await;
+
+    // Verify that both sender and receiver payments record the actual amount
+    let payment_sender = get_payment(node1_addr, &decoded.payment_hash).await;
+    assert_eq!(
+        payment_sender.amt_msat,
+        Some(payment_amount),
+        "Sender payment should have the amount that was sent"
+    );
+    assert_eq!(payment_sender.status, HTLCStatus::Succeeded);
+
+    let payment_receiver = get_payment(node2_addr, &decoded.payment_hash).await;
+    assert_eq!(
+        payment_receiver.amt_msat,
+        Some(payment_amount),
+        "Receiver payment should have the amount that was received, not zero"
+    );
+    assert_eq!(payment_receiver.status, HTLCStatus::Succeeded);
+
+    // Also cover RGB invoice payment where RGB amount is provided at send time.
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        None,
+        Some(3_500_000),
+        Some(600),
+        Some(&asset_id),
+    )
+    .await;
+
+    let payload = LNInvoiceRequest {
+        amt_msat: Some(3_000_000),
+        expiry_sec: 900,
+        asset_id: Some(asset_id.clone()),
+        asset_amount: None,
+    };
+    let invoice_without_amount = reqwest::Client::new()
+        .post(format!("http://{node2_addr}/lninvoice"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap()
+        .json::<LNInvoiceResponse>()
+        .await
+        .unwrap()
+        .invoice;
+
+    let decoded_without_amount = decode_ln_invoice(node1_addr, &invoice_without_amount).await;
+    assert_eq!(decoded_without_amount.asset_id, Some(asset_id.clone()));
+    assert_eq!(decoded_without_amount.asset_amount, None);
+
+    // If the RGB invoice already includes asset_id and asset_amount, sendpayment can omit both.
+    let payload = LNInvoiceRequest {
+        amt_msat: Some(3_000_000),
+        expiry_sec: 900,
+        asset_id: Some(asset_id.clone()),
+        asset_amount: Some(50),
+    };
+    let invoice_with_amount = reqwest::Client::new()
+        .post(format!("http://{node2_addr}/lninvoice"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap()
+        .json::<LNInvoiceResponse>()
+        .await
+        .unwrap()
+        .invoice;
+
+    let decoded_with_amount = decode_ln_invoice(node1_addr, &invoice_with_amount).await;
+    assert_eq!(decoded_with_amount.asset_id, Some(asset_id.clone()));
+    assert_eq!(decoded_with_amount.asset_amount, Some(50));
+
+    let payload = SendPaymentRequest {
+        invoice: invoice_with_amount,
+        amt_msat: Some(3_000_000),
+        asset_id: None,
+        asset_amount: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/sendpayment"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap()
+        .json::<SendPaymentResponse>()
+        .await
+        .unwrap();
+    wait_for_ln_payment(
+        node2_addr,
+        &res.payment_hash.unwrap(),
+        HTLCStatus::Succeeded,
+    )
+    .await;
+    let payment = get_payment(node2_addr, &decoded_with_amount.payment_hash).await;
+    assert_eq!(payment.asset_id, Some(asset_id.clone()));
+    assert_eq!(payment.asset_amount, Some(50));
+
+    // Attempting to pay without both RGB fields should fail.
+    let payload = SendPaymentRequest {
+        invoice: invoice_without_amount.clone(),
+        amt_msat: Some(3_000_000),
+        asset_id: None,
+        asset_amount: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/sendpayment"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::BAD_REQUEST,
+        "both asset_id and asset_amount must be set",
+        "IncompleteRGBInfo",
+    )
+    .await;
+
+    // Providing an invalid RGB asset_id format should fail.
+    let payload = SendPaymentRequest {
+        invoice: invoice_without_amount.clone(),
+        amt_msat: Some(3_000_000),
+        asset_id: Some(s!("not-a-valid-contract-id")),
+        asset_amount: Some(100),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/sendpayment"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::BAD_REQUEST,
+        "Invalid asset ID",
+        "InvalidAssetID",
+    )
+    .await;
+
+    // Providing a different but valid RGB asset_id should fail with contract mismatch.
+    let other_asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    let payload = SendPaymentRequest {
+        invoice: invoice_without_amount.clone(),
+        amt_msat: Some(3_000_000),
+        asset_id: Some(other_asset_id),
+        asset_amount: Some(100),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/sendpayment"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::BAD_REQUEST,
+        "contract ID doesn't match the requested one",
+        "InvalidInvoice",
+    )
+    .await;
+
+    // Providing the RGB fields in sendpayment should succeed.
+    let payload = SendPaymentRequest {
+        invoice: invoice_without_amount,
+        amt_msat: Some(3_000_000),
+        asset_id: Some(asset_id),
+        asset_amount: Some(100),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/sendpayment"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        reqwest::StatusCode::OK,
+        "paying RGB invoice by providing asset_amount in sendpayment should succeed"
+    );
+    let res = res.json::<SendPaymentResponse>().await.unwrap();
+    wait_for_ln_payment(
+        node2_addr,
+        &res.payment_hash.unwrap(),
+        HTLCStatus::Succeeded,
+    )
+    .await;
+    let payment = get_payment(node2_addr, &decoded_without_amount.payment_hash).await;
+    assert_eq!(payment.asset_amount, Some(100));
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1416,6 +1416,8 @@ async fn send_payment_raw(node_address: SocketAddr, invoice: String) -> SendPaym
     let payload = SendPaymentRequest {
         invoice,
         amt_msat: None,
+        asset_id: None,
+        asset_amount: None,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node_address}/sendpayment"))

--- a/src/test/payment.rs
+++ b/src/test/payment.rs
@@ -256,6 +256,8 @@ async fn same_invoice_twice() {
     let payload = SendPaymentRequest {
         invoice: invoice.clone(),
         amt_msat: None,
+        asset_id: None,
+        asset_amount: None,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node1_addr}/sendpayment"))


### PR DESCRIPTION
This fix is needed for this issue https://github.com/orgs/UTEXO-Protocol/projects/2/views/1?pane=issue&itemId=160010122&issue=BoostyLabs%7Ctricorn%7C1798. Code cherrypicked from here https://github.com/RGB-Tools/rgb-lightning-node/pull/101/changes.