### PR TITLE
Uniffi API mismatach followup

### DIFF
--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -178,6 +178,7 @@ dictionary Payment {
     u64 created_at;
     u64 updated_at;
     PublicKey payee_pubkey;
+    string? preimage;
 };
 
 enum HtlcStatus {

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -505,6 +505,7 @@ pub(crate) struct PaymentData {
     pub(crate) created_at: u64,
     pub(crate) updated_at: u64,
     pub(crate) payee_pubkey: String,
+    pub(crate) preimage: Option<String>,
 }
 
 pub(crate) struct ChannelData {
@@ -2860,6 +2861,7 @@ pub(crate) async fn list_payments(state: Arc<AppState>) -> Result<Vec<PaymentDat
             created_at: payment_info.created_at,
             updated_at: payment_info.updated_at,
             payee_pubkey: payment_info.payee_pubkey.to_string(),
+            preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
         });
     }
 
@@ -2886,6 +2888,7 @@ pub(crate) async fn list_payments(state: Arc<AppState>) -> Result<Vec<PaymentDat
             created_at: payment_info.created_at,
             updated_at: payment_info.updated_at,
             payee_pubkey: payment_info.payee_pubkey.to_string(),
+            preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
         });
     }
 
@@ -2931,6 +2934,7 @@ pub(crate) async fn get_payment(
                 created_at: payment_info.created_at,
                 updated_at: payment_info.updated_at,
                 payee_pubkey: payment_info.payee_pubkey.to_string(),
+                preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
             });
         }
     }
@@ -2958,6 +2962,7 @@ pub(crate) async fn get_payment(
                 created_at: payment_info.created_at,
                 updated_at: payment_info.updated_at,
                 payee_pubkey: payment_info.payee_pubkey.to_string(),
+                preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
             });
         }
     }

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -121,6 +121,7 @@ fn map_payment_data(data: crate::sdk::PaymentData) -> Result<Payment, RlnError> 
         created_at: data.created_at,
         updated_at: data.updated_at,
         payee_pubkey,
+        preimage: data.preimage,
     })
 }
 

--- a/src/uniffi_api/state.rs
+++ b/src/uniffi_api/state.rs
@@ -117,27 +117,81 @@ pub(crate) fn map_api_error(err: APIError) -> RlnError {
         | APIError::UnknownContractId
         | APIError::UnknownLNInvoice
         | APIError::UnknownTemporaryChannelId => RlnError::NotFound,
-        APIError::AlreadyInitialized
+        APIError::AllocationsAlreadyAvailable
+        | APIError::AlreadyInitialized
         | APIError::AlreadyUnlocked
+        | APIError::AuthenticationDisabled
         | APIError::UnlockedNode
+        | APIError::CannotCloseChannel(_)
+        | APIError::CannotEstimateFees
         | APIError::ChangingState
         | APIError::OpenChannelInProgress
+        | APIError::FailedBdkSync(_)
+        | APIError::FailedBitcoindConnection(_)
+        | APIError::FailedBroadcast(_)
+        | APIError::FailedPeerConnection
+        | APIError::InsufficientAssets
+        | APIError::InsufficientCapacity(_)
+        | APIError::InsufficientFunds(_)
+        | APIError::InvalidIndexer(_)
+        | APIError::InvalidProxyEndpoint
+        | APIError::InvalidProxyProtocol(_)
+        | APIError::MaxFeeExceeded(_)
+        | APIError::MinFeeNotMet(_)
+        | APIError::NetworkMismatch(_, _)
+        | APIError::NoAvailableUtxos
+        | APIError::NoRoute
         | APIError::DuplicatePayment(_)
         | APIError::RecipientIDAlreadyUsed
         | APIError::TemporaryChannelIdAlreadyUsed
+        | APIError::UnsupportedLayer1(_)
+        | APIError::UnsupportedTransportType
         | APIError::CannotFailBatchTransfer => RlnError::Conflict,
-        APIError::InvalidAddress(_)
+        APIError::AnchorsRequired
+        | APIError::ExpiredSwapOffer
+        | APIError::IncompleteRGBInfo
+        | APIError::InvalidAddress(_)
         | APIError::InvalidAmount(_)
+        | APIError::InvalidAnnounceAddresses(_)
+        | APIError::InvalidAnnounceAlias(_)
         | APIError::InvalidAssetID(_)
+        | APIError::InvalidAssignment
+        | APIError::InvalidAttachments(_)
+        | APIError::InvalidBackupPath
+        | APIError::InvalidBiscuitToken
         | APIError::InvalidChannelID
+        | APIError::InvalidDetails(_)
+        | APIError::InvalidEstimationBlocks
+        | APIError::InvalidFeeRate(_)
         | APIError::InvalidInvoice(_)
+        | APIError::InvalidMediaDigest
+        | APIError::InvalidMnemonic(_)
+        | APIError::InvalidName(_)
+        | APIError::InvalidNodeIds(_)
+        | APIError::InvalidOnionData(_)
         | APIError::InvalidPaymentHash(_)
+        | APIError::InvalidPaymentSecret
+        | APIError::InvalidPassword(_)
+        | APIError::InvalidPeerInfo(_)
+        | APIError::InvalidPrecision(_)
+        | APIError::InvalidPubkey
         | APIError::InvalidRecipientData(_)
         | APIError::InvalidRecipientID
         | APIError::InvalidRecipientNetwork
+        | APIError::InvalidRequest(_)
+        | APIError::InvalidSwap(_)
+        | APIError::InvalidSwapString(_, _)
+        | APIError::InvalidTicker(_)
+        | APIError::InvalidTlvType(_)
         | APIError::InvalidTransportEndpoint(_)
         | APIError::InvalidTransportEndpoints(_)
-        | APIError::IncompleteRGBInfo => RlnError::InvalidRequest,
+        | APIError::MediaFileEmpty
+        | APIError::MediaFileNotProvided
+        | APIError::MissingSwapPaymentPreimage
+        | APIError::OutputBelowDustLimit
+        | APIError::WrongPassword
+        | APIError::UnsupportedBackupVersion { .. } => RlnError::InvalidRequest,
+        APIError::Network(_) | APIError::NoValidTransportEndpoint => RlnError::Conflict,
         _ => RlnError::Internal,
     }
 }

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -204,9 +204,50 @@ mod uniffi_smoke_tests {
         ));
         assert!(matches!(
             super::super::state::map_api_error(crate::error::APIError::IO(std::io::Error::other(
-                "boom"
+                "invalid"
             ))),
             RlnError::Internal
         ));
+        assert!(matches!(
+            super::super::state::map_api_error(crate::error::APIError::InvalidPeerInfo(
+                "invalid peer".to_string()
+            )),
+            RlnError::InvalidRequest
+        ));
+        assert!(matches!(
+            super::super::state::map_api_error(crate::error::APIError::NoAvailableUtxos),
+            RlnError::Conflict
+        ));
+        assert!(matches!(
+            super::super::state::map_api_error(crate::error::APIError::NoValidTransportEndpoint),
+            RlnError::Conflict
+        ));
+        assert!(matches!(
+            super::super::state::map_api_error(crate::error::APIError::WrongPassword),
+            RlnError::InvalidRequest
+        ));
+    }
+
+    #[test]
+    fn map_payment_data_preserves_preimage() {
+        let payment_hash_hex = [7u8; 32].as_hex().to_string();
+        let expected_preimage = Some("11".repeat(32));
+        let data = crate::sdk::PaymentData {
+            amt_msat: Some(1000),
+            asset_amount: None,
+            asset_id: None,
+            payment_hash: payment_hash_hex.clone(),
+            inbound: false,
+            status: crate::sdk::HtlcStatus::Succeeded,
+            created_at: 1,
+            updated_at: 2,
+            payee_pubkey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+                .to_string(),
+            preimage: expected_preimage.clone(),
+        };
+
+        let mapped = map_payment_data(data).expect("payment mapping should succeed");
+        assert_eq!(mapped.payment_hash.0, [7u8; 32]);
+        assert_eq!(mapped.preimage, expected_preimage);
     }
 }

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -91,6 +91,7 @@ pub struct Payment {
     pub created_at: u64,
     pub updated_at: u64,
     pub payee_pubkey: PublicKey,
+    pub preimage: Option<String>,
 }
 
 pub enum HtlcStatus {


### PR DESCRIPTION
- Added full UniFFI SDK surface for RLN (UDL, UniFFI API layer, SDK module, exposed types, and lifecycle state bridge).
- Added UniFFI binding infrastructure and automation (build.rs, UniFFI configs, bindgen helper crate, generation scripts for Python/Kotlin/Swift/Android, CI artifact workflow).
- Added SDK-facing documentation and Python interop example covering node init/unlock/funding, UTXO creation, asset issuance, channel open, invoice creation, payment send, and status checks.
- Introduced supporting library/test structure updates to run SDK logic as a library and validate UniFFI behavior.
- Aligned UniFFI payment model with backend by adding preimage propagation end-to-end (SDK data -> UniFFI mapping -> exported type -> UDL).
- Expanded UniFFI API error mapping to cover a broader set of backend errors with consistent RlnError categories (NotFound / Conflict / InvalidRequest / Internal).
- Added tests validating the updated error mapping behavior and payment preimage mapping correctness.