### PR TITLE
Port hodl invoice in uniffi sdk

### DIFF
--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -105,6 +105,12 @@ interface SdkNode {
     [Throws=RlnError]
     LnInvoiceResponse ln_invoice(LnInvoiceRequest request);
     [Throws=RlnError]
+    void cancelhodlinvoice(CancelHodlInvoiceRequest request);
+    [Throws=RlnError]
+    ClaimHodlInvoiceResponse claimhodlinvoice(ClaimHodlInvoiceRequest request);
+    [Throws=RlnError]
+    InflateResponse inflate(InflateRequest request);
+    [Throws=RlnError]
     SendRgbResponse send_rgb(SendRgbRequest request);
 };
 
@@ -175,12 +181,18 @@ dictionary Payment {
     u64? asset_amount;
     ContractId? asset_id;
     PaymentHash payment_hash;
-    boolean inbound;
+    PaymentType payment_type;
     HtlcStatus status;
     u64 created_at;
     u64 updated_at;
     PublicKey payee_pubkey;
     string? preimage;
+};
+
+enum PaymentType {
+    "Outbound",
+    "InboundAutoClaim",
+    "InboundHodl",
 };
 
 enum HtlcStatus {
@@ -476,10 +488,35 @@ dictionary LnInvoiceRequest {
     u32 expiry_sec;
     ContractId? asset_id;
     u64? asset_amount;
+    PaymentHash? payment_hash;
 };
 
 dictionary LnInvoiceResponse {
     Bolt11Invoice invoice;
+};
+
+dictionary CancelHodlInvoiceRequest {
+    PaymentHash payment_hash;
+};
+
+dictionary ClaimHodlInvoiceRequest {
+    PaymentHash payment_hash;
+    string payment_preimage;
+};
+
+dictionary ClaimHodlInvoiceResponse {
+    boolean changed;
+};
+
+dictionary InflateRequest {
+    ContractId asset_id;
+    sequence<u64> inflation_amounts;
+    u64 fee_rate;
+    u8 min_confirmations;
+};
+
+dictionary InflateResponse {
+    Txid txid;
 };
 
 dictionary SdkInitRequest {

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -11,7 +11,8 @@ use crate::utils::{
     check_already_initialized, check_channel_id, check_password_strength, check_password_validity,
     connect_peer_if_necessary, encrypt_and_save_mnemonic, get_current_timestamp,
     get_max_local_rgb_amount, get_mnemonic_path, get_route, hex_str, hex_str_to_vec,
-    parse_peer_info, AppState, UserOnionMessageContents,
+    parse_peer_info, validate_and_parse_payment_hash, validate_and_parse_payment_preimage,
+    AppState, UserOnionMessageContents,
 };
 use amplify::{map, s};
 use bitcoin::hashes::sha256::Hash as Sha256;
@@ -538,12 +539,36 @@ pub(crate) struct PaymentData {
     pub(crate) asset_amount: Option<u64>,
     pub(crate) asset_id: Option<String>,
     pub(crate) payment_hash: String,
-    pub(crate) inbound: bool,
+    pub(crate) payment_type: PaymentType,
     pub(crate) status: HtlcStatus,
     pub(crate) created_at: u64,
     pub(crate) updated_at: u64,
     pub(crate) payee_pubkey: String,
     pub(crate) preimage: Option<String>,
+}
+
+pub(crate) struct CancelHodlInvoiceRequestData {
+    pub(crate) payment_hash: String,
+}
+
+pub(crate) struct ClaimHodlInvoiceRequestData {
+    pub(crate) payment_hash: String,
+    pub(crate) payment_preimage: String,
+}
+
+pub(crate) struct ClaimHodlInvoiceResponseData {
+    pub(crate) changed: bool,
+}
+
+pub(crate) struct InflateRequestData {
+    pub(crate) asset_id: String,
+    pub(crate) inflation_amounts: Vec<u64>,
+    pub(crate) fee_rate: u64,
+    pub(crate) min_confirmations: u8,
+}
+
+pub(crate) struct InflateResponseData {
+    pub(crate) txid: String,
 }
 
 pub(crate) struct ChannelData {
@@ -647,6 +672,13 @@ pub(crate) enum ChannelStatus {
 }
 
 pub(crate) type HtlcStatus = crate::core_types::HTLCStatus;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum PaymentType {
+    Outbound,
+    InboundAutoClaim,
+    InboundHodl,
+}
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum InvoiceStatus {
@@ -3096,6 +3128,7 @@ pub(crate) async fn create_ln_invoice(
     expiry_sec: u32,
     asset_id: Option<String>,
     asset_amount: Option<u64>,
+    payment_hash: Option<String>,
 ) -> Result<LnInvoiceData, APIError> {
     let guard = check_unlocked(&state).await?;
     let unlocked_state = guard.as_ref().unwrap();
@@ -3113,9 +3146,25 @@ pub(crate) async fn create_ln_invoice(
         )));
     }
 
+    let created_at = get_current_timestamp();
+    let requested_payment_hash = match payment_hash {
+        Some(payment_hash) => {
+            let payment_hash = validate_and_parse_payment_hash(&payment_hash)?;
+            if unlocked_state
+                .inbound_payments()
+                .contains_key(&payment_hash)
+            {
+                return Err(APIError::PaymentHashAlreadyUsed);
+            }
+            Some(payment_hash)
+        }
+        None => None,
+    };
+
     let invoice_params = Bolt11InvoiceParameters {
         amount_msats: amt_msat,
         invoice_expiry_delta_secs: Some(expiry_sec),
+        payment_hash: requested_payment_hash,
         contract_id,
         asset_amount,
         ..Default::default()
@@ -3129,8 +3178,13 @@ pub(crate) async fn create_ln_invoice(
         Err(e) => return Err(APIError::FailedInvoiceCreation(e.to_string())),
     };
 
-    let payment_hash = PaymentHash((*invoice.payment_hash()).to_byte_array());
-    let created_at = get_current_timestamp();
+    let (payment_hash, invoice_type) = match requested_payment_hash {
+        Some(payment_hash) => (payment_hash, InvoiceType::Hodl),
+        None => (
+            PaymentHash((*invoice.payment_hash()).to_byte_array()),
+            InvoiceType::AutoClaim,
+        ),
+    };
     unlocked_state.add_inbound_payment(
         payment_hash,
         PaymentInfo {
@@ -3143,13 +3197,20 @@ pub(crate) async fn create_ln_invoice(
             updated_at: created_at,
             payee_pubkey: unlocked_state.channel_manager.get_our_node_id(),
             expires_at: Some(created_at + expiry_sec as u64),
-            invoice_type: Some(InvoiceType::AutoClaim),
+            invoice_type: Some(invoice_type),
         },
     );
 
     Ok(LnInvoiceData {
         invoice: invoice.to_string(),
     })
+}
+
+fn payment_type_from_invoice(invoice_type: Option<InvoiceType>) -> PaymentType {
+    match invoice_type.unwrap_or(InvoiceType::AutoClaim) {
+        InvoiceType::AutoClaim => PaymentType::InboundAutoClaim,
+        InvoiceType::Hodl => PaymentType::InboundHodl,
+    }
 }
 
 pub(crate) async fn list_payments(state: Arc<AppState>) -> Result<Vec<PaymentData>, APIError> {
@@ -3177,7 +3238,7 @@ pub(crate) async fn list_payments(state: Arc<AppState>) -> Result<Vec<PaymentDat
             asset_amount,
             asset_id,
             payment_hash: hex_str(&payment_hash.0),
-            inbound: true,
+            payment_type: payment_type_from_invoice(payment_info.invoice_type),
             status: payment_info.status,
             created_at: payment_info.created_at,
             updated_at: payment_info.updated_at,
@@ -3204,7 +3265,7 @@ pub(crate) async fn list_payments(state: Arc<AppState>) -> Result<Vec<PaymentDat
             asset_amount,
             asset_id,
             payment_hash: hex_str(&payment_hash.0),
-            inbound: false,
+            payment_type: PaymentType::Outbound,
             status: payment_info.status,
             created_at: payment_info.created_at,
             updated_at: payment_info.updated_at,
@@ -3250,7 +3311,7 @@ pub(crate) async fn get_payment(
                 asset_amount,
                 asset_id,
                 payment_hash: hex_str(&payment_hash.0),
-                inbound: true,
+                payment_type: payment_type_from_invoice(payment_info.invoice_type),
                 status: payment_info.status,
                 created_at: payment_info.created_at,
                 updated_at: payment_info.updated_at,
@@ -3278,7 +3339,7 @@ pub(crate) async fn get_payment(
                 asset_amount,
                 asset_id,
                 payment_hash: hex_str(&payment_hash.0),
-                inbound: false,
+                payment_type: PaymentType::Outbound,
                 status: payment_info.status,
                 created_at: payment_info.created_at,
                 updated_at: payment_info.updated_at,
@@ -3289,6 +3350,125 @@ pub(crate) async fn get_payment(
     }
 
     Err(APIError::PaymentNotFound(payment_hash_hex))
+}
+
+pub(crate) async fn cancel_hodl_invoice(
+    state: Arc<AppState>,
+    request: CancelHodlInvoiceRequestData,
+) -> Result<(), APIError> {
+    let guard = check_unlocked(&state).await?;
+    let unlocked_state = guard.as_ref().unwrap();
+
+    let payment_hash = validate_and_parse_payment_hash(&request.payment_hash)?;
+    let payment_info = unlocked_state
+        .get_inbound_payments()
+        .payments
+        .get(&payment_hash)
+        .cloned()
+        .ok_or(APIError::UnknownLNInvoice)?;
+    if !matches!(payment_info.invoice_type, Some(InvoiceType::Hodl)) {
+        return Err(APIError::InvoiceNotHodl);
+    }
+    match payment_info.status {
+        HtlcStatus::Succeeded => return Err(APIError::InvoiceAlreadyClaimed),
+        HtlcStatus::Claimable => {}
+        HtlcStatus::Claiming => return Err(APIError::InvoiceSettlingInProgress),
+        _ => return Err(APIError::InvoiceNotClaimable),
+    }
+
+    unlocked_state
+        .fail_htlc_backwards_and_update_inbound_payment(payment_hash, HtlcStatus::Cancelled);
+    Ok(())
+}
+
+pub(crate) async fn claim_hodl_invoice(
+    state: Arc<AppState>,
+    request: ClaimHodlInvoiceRequestData,
+) -> Result<ClaimHodlInvoiceResponseData, APIError> {
+    let guard = check_unlocked(&state).await?;
+    let unlocked_state = guard.as_ref().unwrap();
+
+    let payment_hash = validate_and_parse_payment_hash(&request.payment_hash)?;
+    let preimage = validate_and_parse_payment_preimage(&request.payment_preimage, &payment_hash)?;
+
+    {
+        let mut inbound = unlocked_state.get_inbound_payments();
+        let Some(existing_payment_mut) = inbound.payments.get_mut(&payment_hash) else {
+            return Err(APIError::UnknownLNInvoice);
+        };
+
+        if !matches!(existing_payment_mut.invoice_type, Some(InvoiceType::Hodl)) {
+            return Err(APIError::InvoiceNotHodl);
+        }
+
+        match existing_payment_mut.status {
+            HtlcStatus::Succeeded => {
+                let computed_hash = PaymentHash(Sha256::hash(&preimage.0).to_byte_array());
+                if computed_hash != payment_hash {
+                    return Err(APIError::InvalidPaymentPreimage);
+                }
+                if let Some(stored_preimage) = existing_payment_mut.preimage {
+                    if stored_preimage != preimage {
+                        return Err(APIError::InvalidPaymentPreimage);
+                    }
+                }
+                return Ok(ClaimHodlInvoiceResponseData { changed: false });
+            }
+            HtlcStatus::Claiming => return Err(APIError::InvoiceSettlingInProgress),
+            HtlcStatus::Claimable => {}
+            _ => return Err(APIError::InvoiceNotClaimable),
+        }
+
+        let current_height = unlocked_state.channel_manager.current_best_block().height;
+        let now_ts = get_current_timestamp();
+
+        if let Some(deadline_height) = existing_payment_mut.claim_deadline_height {
+            if current_height >= deadline_height {
+                return Err(APIError::ClaimDeadlineExceeded);
+            }
+        }
+
+        if let Some(expiry) = existing_payment_mut.expires_at {
+            if now_ts >= expiry {
+                return Err(APIError::InvoiceExpired);
+            }
+        }
+
+        existing_payment_mut.status = HtlcStatus::Claiming;
+        existing_payment_mut.updated_at = now_ts;
+        unlocked_state.save_inbound_payments(inbound);
+    }
+
+    unlocked_state.channel_manager.claim_funds(preimage);
+    Ok(ClaimHodlInvoiceResponseData { changed: true })
+}
+
+pub(crate) async fn inflate(
+    state: Arc<AppState>,
+    request: InflateRequestData,
+) -> Result<InflateResponseData, APIError> {
+    let guard = check_unlocked(&state).await?;
+    let unlocked_state = guard.as_ref().unwrap();
+
+    if *unlocked_state.rgb_send_lock.lock().unwrap() {
+        return Err(APIError::OpenChannelInProgress);
+    }
+
+    let unlocked_state_copy = unlocked_state.clone();
+    let inflate_result = tokio::task::spawn_blocking(move || {
+        unlocked_state_copy.rgb_inflate(
+            request.asset_id,
+            request.inflation_amounts,
+            request.fee_rate,
+            request.min_confirmations,
+        )
+    })
+    .await
+    .unwrap()?;
+
+    Ok(InflateResponseData {
+        txid: inflate_result.txid,
+    })
 }
 
 fn map_swap(

--- a/src/test/lib_core.rs
+++ b/src/test/lib_core.rs
@@ -57,6 +57,7 @@ fn locked_state_does_not_bypass_unlock_guards() {
         expiry_sec: 3600,
         asset_id: None,
         asset_amount: None,
+        payment_hash: None,
     });
     assert!(matches!(invoice, Err(RlnError::NotInitialized)));
 

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -5,7 +5,8 @@ use std::str::FromStr;
 
 use crate::sdk;
 use crate::{NodeConfig, NodeHandle};
-
+use bitcoin::hex::DisplayHex;
+use bitcoin::hex::FromHex;
 use state::{
     block_on_app, block_on_sdk, clear_uniffi_node_handle, get_uniffi_app_state,
     is_uniffi_app_state_initialized, set_uniffi_node_handle,
@@ -279,8 +280,6 @@ impl SdkNode {
     }
 
     pub fn closechannel(&self, request: SdkCloseChannelRequest) -> Result<(), RlnError> {
-        use bitcoin::hex::DisplayHex;
-
         let state = self.handle.app_state();
         block_on_sdk(sdk::close_channel(
             state,
@@ -591,9 +590,6 @@ impl SdkNode {
         &self,
         request: SdkOpenChannelRequest,
     ) -> Result<SdkOpenChannelResponse, RlnError> {
-        use bitcoin::hex::DisplayHex;
-        use bitcoin::hex::FromHex;
-
         let state = self.handle.app_state();
         let response = block_on_sdk(sdk::open_channel(
             state,
@@ -726,9 +722,6 @@ impl SdkNode {
     }
 
     pub fn get_channel_id(&self, temporary_channel_id: ChannelId) -> Result<ChannelId, RlnError> {
-        use bitcoin::hex::DisplayHex;
-        use bitcoin::hex::FromHex;
-
         let state = self.handle.app_state();
         let data = block_on_sdk(sdk::get_channel_id(
             state,
@@ -744,8 +737,6 @@ impl SdkNode {
     }
 
     pub fn get_payment(&self, payment_hash: PaymentHash) -> Result<Payment, RlnError> {
-        use bitcoin::hex::DisplayHex;
-
         let state = self.handle.app_state();
         let data = block_on_sdk(sdk::get_payment(state, payment_hash.0.as_hex().to_string()))?;
         map_payment_data(data)
@@ -758,8 +749,6 @@ impl SdkNode {
     }
 
     pub fn get_swap(&self, payment_hash: PaymentHash, taker: bool) -> Result<Swap, RlnError> {
-        use bitcoin::hex::DisplayHex;
-
         let state = self.handle.app_state();
         let data = block_on_sdk(sdk::get_swap(
             state,
@@ -786,8 +775,6 @@ impl SdkNode {
     }
 
     pub fn list_channels(&self) -> Result<Vec<Channel>, RlnError> {
-        use bitcoin::hex::FromHex;
-
         let state = self.handle.app_state();
         let channels = block_on_sdk(sdk::list_channels(state))?;
         channels
@@ -1238,8 +1225,6 @@ impl SdkNode {
     }
 
     pub fn ln_invoice(&self, request: LnInvoiceRequest) -> Result<LnInvoiceResponse, RlnError> {
-        use bitcoin::hex::DisplayHex;
-
         let state = self.handle.app_state();
         let asset_id = request.asset_id.map(|a| a.to_string());
         let payment_hash = request.payment_hash.map(|h| h.0.as_hex().to_string());
@@ -1256,8 +1241,6 @@ impl SdkNode {
     }
 
     pub fn cancelhodlinvoice(&self, request: CancelHodlInvoiceRequest) -> Result<(), RlnError> {
-        use bitcoin::hex::DisplayHex;
-
         let state = self.handle.app_state();
         block_on_sdk(sdk::cancel_hodl_invoice(
             state,
@@ -1272,8 +1255,6 @@ impl SdkNode {
         &self,
         request: ClaimHodlInvoiceRequest,
     ) -> Result<ClaimHodlInvoiceResponse, RlnError> {
-        use bitcoin::hex::DisplayHex;
-
         let state = self.handle.app_state();
         let response = block_on_sdk(sdk::claim_hodl_invoice(
             state,

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -107,6 +107,11 @@ fn map_payment_data(data: crate::sdk::PaymentData) -> Result<Payment, RlnError> 
     };
     let payment_hash = <PaymentHash as UniffiCustomTypeConverter>::into_custom(data.payment_hash)
         .map_err(|_| RlnError::Internal)?;
+    let payment_type = match data.payment_type {
+        crate::sdk::PaymentType::Outbound => PaymentType::Outbound,
+        crate::sdk::PaymentType::InboundAutoClaim => PaymentType::InboundAutoClaim,
+        crate::sdk::PaymentType::InboundHodl => PaymentType::InboundHodl,
+    };
     let status = match data.status {
         crate::sdk::HtlcStatus::Pending => HtlcStatus::Pending,
         crate::sdk::HtlcStatus::Claimable => HtlcStatus::Claimable,
@@ -121,7 +126,7 @@ fn map_payment_data(data: crate::sdk::PaymentData) -> Result<Payment, RlnError> 
         asset_amount: data.asset_amount,
         asset_id,
         payment_hash,
-        inbound: data.inbound,
+        payment_type,
         status,
         created_at: data.created_at,
         updated_at: data.updated_at,
@@ -1233,17 +1238,68 @@ impl SdkNode {
     }
 
     pub fn ln_invoice(&self, request: LnInvoiceRequest) -> Result<LnInvoiceResponse, RlnError> {
+        use bitcoin::hex::DisplayHex;
+
         let state = self.handle.app_state();
         let asset_id = request.asset_id.map(|a| a.to_string());
+        let payment_hash = request.payment_hash.map(|h| h.0.as_hex().to_string());
         let data = block_on_sdk(sdk::create_ln_invoice(
             state,
             request.amt_msat,
             request.expiry_sec,
             asset_id,
             request.asset_amount,
+            payment_hash,
         ))?;
         let invoice = Bolt11Invoice::from_str(&data.invoice).map_err(|_| RlnError::Internal)?;
         Ok(LnInvoiceResponse { invoice })
+    }
+
+    pub fn cancelhodlinvoice(&self, request: CancelHodlInvoiceRequest) -> Result<(), RlnError> {
+        use bitcoin::hex::DisplayHex;
+
+        let state = self.handle.app_state();
+        block_on_sdk(sdk::cancel_hodl_invoice(
+            state,
+            sdk::CancelHodlInvoiceRequestData {
+                payment_hash: request.payment_hash.0.as_hex().to_string(),
+            },
+        ))?;
+        Ok(())
+    }
+
+    pub fn claimhodlinvoice(
+        &self,
+        request: ClaimHodlInvoiceRequest,
+    ) -> Result<ClaimHodlInvoiceResponse, RlnError> {
+        use bitcoin::hex::DisplayHex;
+
+        let state = self.handle.app_state();
+        let response = block_on_sdk(sdk::claim_hodl_invoice(
+            state,
+            sdk::ClaimHodlInvoiceRequestData {
+                payment_hash: request.payment_hash.0.as_hex().to_string(),
+                payment_preimage: request.payment_preimage,
+            },
+        ))?;
+        Ok(ClaimHodlInvoiceResponse {
+            changed: response.changed,
+        })
+    }
+
+    pub fn inflate(&self, request: InflateRequest) -> Result<InflateResponse, RlnError> {
+        let state = self.handle.app_state();
+        let response = block_on_sdk(sdk::inflate(
+            state,
+            sdk::InflateRequestData {
+                asset_id: request.asset_id.to_string(),
+                inflation_amounts: request.inflation_amounts,
+                fee_rate: request.fee_rate,
+                min_confirmations: request.min_confirmations,
+            },
+        ))?;
+        let txid = Txid::from_str(&response.txid).map_err(|_| RlnError::Internal)?;
+        Ok(InflateResponse { txid })
     }
 
     pub fn send_rgb(&self, request: SendRgbRequest) -> Result<SendRgbResponse, RlnError> {
@@ -1397,6 +1453,23 @@ pub fn sdk_list_unspents(skip_sync: bool) -> Result<Vec<Unspent>, RlnError> {
 pub fn sdk_ln_invoice(request: LnInvoiceRequest) -> Result<LnInvoiceResponse, RlnError> {
     let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
     SdkNode { handle }.ln_invoice(request)
+}
+
+pub fn sdk_cancelhodlinvoice(request: CancelHodlInvoiceRequest) -> Result<(), RlnError> {
+    let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
+    SdkNode { handle }.cancelhodlinvoice(request)
+}
+
+pub fn sdk_claimhodlinvoice(
+    request: ClaimHodlInvoiceRequest,
+) -> Result<ClaimHodlInvoiceResponse, RlnError> {
+    let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
+    SdkNode { handle }.claimhodlinvoice(request)
+}
+
+pub fn sdk_inflate(request: InflateRequest) -> Result<InflateResponse, RlnError> {
+    let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
+    SdkNode { handle }.inflate(request)
 }
 
 pub fn sdk_send_rgb(request: SendRgbRequest) -> Result<SendRgbResponse, RlnError> {

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -33,8 +33,31 @@ mod uniffi_smoke_tests {
             expiry_sec: 3600,
             asset_id: None,
             asset_amount: None,
+            payment_hash: None,
         });
         assert!(matches!(invoice, Err(RlnError::NotInitialized)));
+
+        let hodl_hash = lightning::types::payment::PaymentHash([3u8; 32]);
+        let cancel_hodl = sdk_cancelhodlinvoice(CancelHodlInvoiceRequest {
+            payment_hash: hodl_hash,
+        });
+        assert!(matches!(cancel_hodl, Err(RlnError::NotInitialized)));
+
+        let claim_hodl = sdk_claimhodlinvoice(ClaimHodlInvoiceRequest {
+            payment_hash: hodl_hash,
+            payment_preimage: "11".repeat(32),
+        });
+        assert!(matches!(claim_hodl, Err(RlnError::NotInitialized)));
+
+        let inflate_asset_id =
+            ContractId::from_str("rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ8").unwrap();
+        let inflate = sdk_inflate(InflateRequest {
+            asset_id: inflate_asset_id,
+            inflation_amounts: vec![1],
+            fee_rate: 1,
+            min_confirmations: 1,
+        });
+        assert!(matches!(inflate, Err(RlnError::NotInitialized)));
 
         let send_rgb = sdk_send_rgb(SendRgbRequest {
             donation: false,
@@ -80,6 +103,16 @@ mod uniffi_smoke_tests {
         assert!(matches!(node_info, Err(RlnError::NotInitialized)));
         let channel_id = sdk_get_channel_id(lightning::ln::types::ChannelId([0u8; 32]));
         assert!(matches!(channel_id, Err(RlnError::NotInitialized)));
+        let hodl_hash = lightning::types::payment::PaymentHash([4u8; 32]);
+        let cancel_hodl = sdk_cancelhodlinvoice(CancelHodlInvoiceRequest {
+            payment_hash: hodl_hash,
+        });
+        assert!(matches!(cancel_hodl, Err(RlnError::NotInitialized)));
+        let claim_hodl = sdk_claimhodlinvoice(ClaimHodlInvoiceRequest {
+            payment_hash: hodl_hash,
+            payment_preimage: "22".repeat(32),
+        });
+        assert!(matches!(claim_hodl, Err(RlnError::NotInitialized)));
 
         let send_rgb = sdk_send_rgb(SendRgbRequest {
             donation: false,
@@ -103,6 +136,16 @@ mod uniffi_smoke_tests {
         };
         let node_info = node.node_info();
         assert!(matches!(node_info, Err(RlnError::NotInitialized)));
+        let hodl_hash = lightning::types::payment::PaymentHash([5u8; 32]);
+        let cancel_hodl = node.cancelhodlinvoice(CancelHodlInvoiceRequest {
+            payment_hash: hodl_hash,
+        });
+        assert!(matches!(cancel_hodl, Err(RlnError::NotInitialized)));
+        let claim_hodl = node.claimhodlinvoice(ClaimHodlInvoiceRequest {
+            payment_hash: hodl_hash,
+            payment_preimage: "33".repeat(32),
+        });
+        assert!(matches!(claim_hodl, Err(RlnError::NotInitialized)));
 
         let send_rgb = node.send_rgb(SendRgbRequest {
             donation: false,
@@ -239,7 +282,7 @@ mod uniffi_smoke_tests {
             asset_amount: None,
             asset_id: None,
             payment_hash: payment_hash_hex.clone(),
-            inbound: false,
+            payment_type: crate::sdk::PaymentType::InboundHodl,
             status: crate::sdk::HtlcStatus::Succeeded,
             created_at: 1,
             updated_at: 2,
@@ -251,5 +294,6 @@ mod uniffi_smoke_tests {
         let mapped = map_payment_data(data).expect("payment mapping should succeed");
         assert_eq!(mapped.payment_hash.0, [7u8; 32]);
         assert_eq!(mapped.preimage, expected_preimage);
+        assert!(matches!(mapped.payment_type, PaymentType::InboundHodl));
     }
 }

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -86,12 +86,18 @@ pub struct Payment {
     pub asset_amount: Option<u64>,
     pub asset_id: Option<ContractId>,
     pub payment_hash: PaymentHash,
-    pub inbound: bool,
+    pub payment_type: PaymentType,
     pub status: HtlcStatus,
     pub created_at: u64,
     pub updated_at: u64,
     pub payee_pubkey: PublicKey,
     pub preimage: Option<String>,
+}
+
+pub enum PaymentType {
+    Outbound,
+    InboundAutoClaim,
+    InboundHodl,
 }
 
 pub enum HtlcStatus {
@@ -387,6 +393,31 @@ pub struct LnInvoiceRequest {
     pub expiry_sec: u32,
     pub asset_id: Option<ContractId>,
     pub asset_amount: Option<u64>,
+    pub payment_hash: Option<PaymentHash>,
+}
+
+pub struct CancelHodlInvoiceRequest {
+    pub payment_hash: PaymentHash,
+}
+
+pub struct ClaimHodlInvoiceRequest {
+    pub payment_hash: PaymentHash,
+    pub payment_preimage: String,
+}
+
+pub struct ClaimHodlInvoiceResponse {
+    pub changed: bool,
+}
+
+pub struct InflateRequest {
+    pub asset_id: ContractId,
+    pub inflation_amounts: Vec<u64>,
+    pub fee_rate: u64,
+    pub min_confirmations: u8,
+}
+
+pub struct InflateResponse {
+    pub txid: Txid,
 }
 
 pub struct SdkUnlockRequest {


### PR DESCRIPTION
Ports recent HODL/inflate core API changes into the UniFFI SDK surface for full parity. It adds UniFFI support for HODL lifecycle methods (`cancelhodlinvoice`, `claimhodlinvoice`), `inflate`, and extends `ln_invoice` with optional `payment_hash` for HODL invoice creation. It also updates the payment model from `inbound: bool` to explicit `payment_type` (`Outbound`, `InboundAutoClaim`, `InboundHodl`) and wires the new mappings through SDK and UniFFI layers. Core compile/test checks and UniFFI smoke tests were run to validate the updated API surface.