### PR TITLE
Vss

### DIFF
--- a/.github/workflows/sdk-e2e.yaml
+++ b/.github/workflows/sdk-e2e.yaml
@@ -96,6 +96,24 @@ jobs:
           PYTHON_E2E_SCENARIO: ${{ matrix.scenario }}
         run: python3 test/python-e2e/PythonUniffiE2e.py
 
+      - name: Dump node logs on failure
+        if: failure()
+        run: |
+          echo "===== LDK logs (logs.txt) ====="
+          find target/uniffi/python-e2e/data -name logs.txt -print -exec tail -n 300 {} \; || true
+          echo "===== rgb-lib logs (log) ====="
+          find target/uniffi/python-e2e/data -path '*/data/*' -name log -print -exec tail -n 300 {} \; || true
+
+      - name: Upload node logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-logs-${{ matrix.scenario }}
+          path: |
+            target/uniffi/python-e2e/data/**/logs.txt
+            target/uniffi/python-e2e/data/**/log
+          if-no-files-found: ignore
+
       - name: Stop regtest services
         if: always()
         run: ./regtest.sh stop

--- a/.github/workflows/sdk-e2e.yaml
+++ b/.github/workflows/sdk-e2e.yaml
@@ -99,19 +99,24 @@ jobs:
       - name: Dump node logs on failure
         if: failure()
         run: |
-          echo "===== LDK logs (logs.txt) ====="
-          find target/uniffi/python-e2e/data -name logs.txt -print -exec tail -n 300 {} \; || true
-          echo "===== rgb-lib logs (log) ====="
-          find target/uniffi/python-e2e/data -path '*/data/*' -name log -print -exec tail -n 300 {} \; || true
+          echo "===== LDK channel/funding events ====="
+          find target/uniffi/python-e2e/data -name logs.txt | while read -r f; do
+            echo "### $f"
+            grep -iE "OpenChannel|AcceptChannel|FundingGeneration|funding_transaction|Channel went away|Funding TXID|disconnect|refus|reject|closed|close_channel|ERROR|WARN|Generated funding|broadcast|chan.*clos|cannot " "$f" || true
+          done
+          echo "===== rgb-lib non-sync lines ====="
+          find target/uniffi/python-e2e/data -path '*/data/*' -name log | while read -r f; do
+            echo "### $f"
+            grep -vE "Syncing\.\.\.|Sync completed" "$f" || true
+          done
 
       - name: Upload node logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: node-logs-${{ matrix.scenario }}
-          path: |
-            target/uniffi/python-e2e/data/**/logs.txt
-            target/uniffi/python-e2e/data/**/log
+          path: target/uniffi/python-e2e/data/**
+          include-hidden-files: true
           if-no-files-found: ignore
 
       - name: Stop regtest services

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,3 +59,23 @@ jobs:
       - name: Stop regtest services
         if: always()
         run: ./regtest.sh stop
+
+  vss-tests:
+    runs-on: warp-ubuntu-latest-x64-16x
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+      - name: Build with vss feature
+        run: cargo build --features vss
+      - name: Start regtest and VSS services
+        run: VSS=1 ./regtest.sh start
+      - name: Run VSS tests (e2e against regtest + VSS server)
+        run: cargo test --features vss "test::vss::tests" -- --test-threads=1
+      - name: Stop regtest and VSS services
+        if: always()
+        run: docker compose --profile vss down -v --remove-orphans

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3845,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.5"
-source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#9aa42d1dbc74a04ea06446ed7f5d093cbf7c44ea"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#b1a14bd88acbc3777cbd45998018e60ff1b3e58a"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.3"
-source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#9aa42d1dbc74a04ea06446ed7f5d093cbf7c44ea"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#b1a14bd88acbc3777cbd45998018e60ff1b3e58a"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -6809,8 +6809,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "rgb-lib"
-version = "0.3.0-beta.5"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#1fdb460176559c097f97dcd989b155a3c45b10c7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_file_store"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446f02da319941ea78454a479fca72707f3355a62db3bb1c2c13b94e7f963ce0"
+checksum = "c7b9a98edb58d02b601239832674a9ca9f1465e08e1dd1fac3a0e34004372406"
 dependencies = [
  "bdk_core",
  "bincode",
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_wallet"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f278518ee6f2a17711fd4662dc34ce6153792a7a21575f05a9c8e2cb9ba36245"
+checksum = "67f3c4f9526d22374fca5b7ff1d6bf8d921ab56db2dac8df66a2c5561b31d4ef"
 dependencies = [
  "bdk_chain",
  "bdk_file_store",
@@ -3764,9 +3764,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-aluvm"
-version = "0.11.1-rc.2"
+version = "0.11.1-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b9e41006564b48551e52e001181898982b11732348100216097033b3e536a2"
+checksum = "b60686e4f1701ca4f73b77660777a49e651f3c611461ab62ef718db47a5a6caa"
 dependencies = [
  "amplify",
  "baid64",
@@ -3798,9 +3798,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-consensus"
-version = "0.11.1-rc.9"
+version = "0.11.1-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6e0da534613ed77953976b9be54c7db66bd5a6c66773bd5866b1bacdbfb41d"
+checksum = "535483ee9143782e33ddebd3eda465de0184061fc3c480e24990e42fefc58bb0"
 dependencies = [
  "amplify",
  "baid64",
@@ -3825,9 +3825,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-invoicing"
-version = "0.11.1-rc.9"
+version = "0.11.1-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22f7125c70fd8e959d85d29c0bdbeecb173d6aed9a72eae71f1e43bade383f"
+checksum = "10400124af86de579b0f13603e014512b6166ad94ea791212b71579ffb91dd8a"
 dependencies = [
  "amplify",
  "baid64",
@@ -3845,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.5"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#5aabef63b8fc004fa51a143f47c687fc6dc9c0e5"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#1fdb460176559c097f97dcd989b155a3c45b10c7"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.3"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#5aabef63b8fc004fa51a143f47c687fc6dc9c0e5"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#1fdb460176559c097f97dcd989b155a3c45b10c7"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -3960,9 +3960,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-ops"
-version = "0.11.1-rc.9"
+version = "0.11.1-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb298dfc6cddd4367c850bf621fca6b2b77a16c2ce472bc4e576811fe5b29be"
+checksum = "3782a5ff1e5408e23c2d14fc556347684f5c8f72d96c4ca357527a3dbffb7378"
 dependencies = [
  "amplify",
  "baid64",
@@ -3981,14 +3981,15 @@ dependencies = [
  "rgb-strict-encoding",
  "rgb-strict-types",
  "serde",
+ "serde_json",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "rgb-psbt-utils"
-version = "0.11.1-rc.9"
+version = "0.11.1-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9faab66bd883c85ffcb35f8dfa9d676184c5924f5076ffd9c72943bdf5b3df3c"
+checksum = "0107634634c424a8b268ec6549df08da676768ec6ddbcda51f12e7882daeeee6"
 dependencies = [
  "amplify",
  "baid64",
@@ -4001,9 +4002,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-schemas"
-version = "0.11.1-rc.9"
+version = "0.11.1-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a80e2f45e850293c97d0e4fcd9b1c066a666b52b66617f4476365346c92111"
+checksum = "1903961c836cc3f6963b06c69cb47491a815309f265439f20c932e0a3aa16a78"
 dependencies = [
  "amplify",
  "rgb-aluvm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3845,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.5"
-source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#36615b1a08b0c3b4a16b9542b75b69b9bcbb7e42"
+source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#981e9265ae47b77063201d08c6d46cbc5d9b6f2b"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.3"
-source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#36615b1a08b0c3b4a16b9542b75b69b9bcbb7e42"
+source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#981e9265ae47b77063201d08c6d46cbc5d9b6f2b"
 dependencies = [
  "sea-orm-migration",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,8 +629,8 @@ dependencies = [
  "nom",
  "p256",
  "pkcs8 0.9.0",
- "prost",
- "prost-types",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "regex",
@@ -739,6 +739,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitreq"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6df90cd78f0510165fd370574676aeb57dbec0ee3bfff68645bb7b0e9a65dbd5"
+dependencies = [
+ "rustls 0.23.39",
+ "rustls-webpki 0.103.13",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -898,6 +911,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
+
+[[package]]
+name = "chacha20-poly1305"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b0fc281743d80256607bd65e8beedc42cb0787ea119c85b81b4c0eab85e5f"
 
 [[package]]
 name = "chacha20poly1305"
@@ -1192,7 +1211,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804169db156b21258a2545757336922d93dfa229892c75911a0ad141aa0ff241"
 dependencies = [
- "petgraph",
+ "petgraph 0.8.3",
  "serde",
 ]
 
@@ -1608,6 +1627,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -2614,6 +2639,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2792,6 +2823,12 @@ dependencies = [
  "spin",
  "version_check",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "musig2"
@@ -3117,11 +3154,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap",
  "serde",
@@ -3230,6 +3277,16 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
@@ -3298,7 +3355,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.10.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph 0.6.5",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+ "regex",
+ "syn 1.0.109",
+ "tempfile",
+ "which",
 ]
 
 [[package]]
@@ -3315,13 +3404,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.10.4",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
+dependencies = [
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -3745,6 +3856,7 @@ dependencies = [
  "file-format",
  "generic-array",
  "hex",
+ "hkdf",
  "rand 0.10.1",
  "reqwest 0.13.2",
  "rgb-invoicing",
@@ -3760,6 +3872,7 @@ dependencies = [
  "sea-query",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "slog",
  "slog-async",
  "slog-term",
@@ -3769,6 +3882,7 @@ dependencies = [
  "tokio",
  "typenum",
  "url",
+ "vss-client-ng",
  "walkdir",
  "zip 8.5.1",
 ]
@@ -3839,6 +3953,7 @@ dependencies = [
  "typenum",
  "uniffi",
  "uuid",
+ "vss-client-ng",
  "walkdir",
  "zip 2.4.2",
 ]
@@ -4021,6 +4136,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4028,7 +4156,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -5096,7 +5224,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5757,6 +5885,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vss-client-ng"
+version = "0.4.1"
+source = "git+https://github.com/lightningdevkit/vss-client?rev=ad63805047561dcf3117cd992ad6d8bc3881adef#ad63805047561dcf3117cd992ad6d8bc3881adef"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bitcoin",
+ "bitcoin_hashes",
+ "bitreq",
+ "chacha20-poly1305",
+ "log",
+ "prost 0.11.9",
+ "prost-build",
+ "rand 0.8.6",
+ "tokio",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5968,6 +6114,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -6413,7 +6571,7 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap",
- "prettyplease",
+ "prettyplease 0.2.37",
  "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
@@ -6427,7 +6585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
 dependencies = [
  "anyhow",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3845,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.5"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#1fdb460176559c097f97dcd989b155a3c45b10c7"
+source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#36615b1a08b0c3b4a16b9542b75b69b9bcbb7e42"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.3"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#1fdb460176559c097f97dcd989b155a3c45b10c7"
+source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#36615b1a08b0c3b4a16b9542b75b69b9bcbb7e42"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -6809,3 +6809,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "rgb-lib"
+version = "0.3.0-beta.5"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#1fdb460176559c097f97dcd989b155a3c45b10c7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3845,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.5"
-source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#981e9265ae47b77063201d08c6d46cbc5d9b6f2b"
+source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#9aa42d1dbc74a04ea06446ed7f5d093cbf7c44ea"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.3"
-source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#981e9265ae47b77063201d08c6d46cbc5d9b6f2b"
+source = "git+https://github.com/dcorral/rgb-lib.git?branch=fix%2Ffunding-tx-final-locktime#9aa42d1dbc74a04ea06446ed7f5d093cbf7c44ea"
 dependencies = [
  "sea-orm-migration",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 [features]
 default = []
 test-utils = []
+vss = ["rgb-lib/vss", "dep:vss-client"]
 
 [dependencies]
 amplify = { version = "=4.8.1", default-features = false }
@@ -70,6 +71,7 @@ typenum = "1.17.0"
 uuid = { version = "1.11.0", default-features = false, features = ["v4"] }
 walkdir = "2.5.0"
 uniffi = { version = "0.28.3", features = ["build"], optional = true }
+vss-client = { package = "vss-client-ng", git = "https://github.com/lightningdevkit/vss-client", rev = "ad63805047561dcf3117cd992ad6d8bc3881adef", default-features = false, features = ["sigs-auth"], optional = true }
 zip = { version = "2.2.0", default-features = false, features = ["time", "zstd"] }
 
 [dev-dependencies]
@@ -87,6 +89,7 @@ uniffi = { version = "0.28.3", features = ["build"], optional = true }
 [patch.crates-io]
 lightning = { path = "./rust-lightning/lightning" }
 lightning-background-processor = { path = "./rust-lightning/lightning-background-processor"}
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib", branch = "dev" }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,12 @@ lightning = { path = "./rust-lightning/lightning" }
 lightning-background-processor = { path = "./rust-lightning/lightning-background-processor"}
 rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib", branch = "dev" }
 
+# Temporary: route rgb-lib (rln + rust-lightning submodule) to the funding-tx
+# locktime fix branch until it merges into UTEXO-Protocol/rgb-lib dev. Revert by
+# deleting this patch block.
+[patch."https://github.com/UTEXO-Protocol/rgb-lib.git"]
+rgb-lib = { git = "https://github.com/dcorral/rgb-lib.git", branch = "fix/funding-tx-final-locktime" }
+
 [lints.rust.unexpected_cfgs]
 level = "allow"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,12 +91,6 @@ lightning = { path = "./rust-lightning/lightning" }
 lightning-background-processor = { path = "./rust-lightning/lightning-background-processor"}
 rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib", branch = "dev" }
 
-# Temporary: route rgb-lib (rln + rust-lightning submodule) to the funding-tx
-# locktime fix branch until it merges into UTEXO-Protocol/rgb-lib dev. Revert by
-# deleting this patch block.
-[patch."https://github.com/UTEXO-Protocol/rgb-lib.git"]
-rgb-lib = { git = "https://github.com/dcorral/rgb-lib.git", branch = "fix/funding-tx-final-locktime" }
-
 [lints.rust.unexpected_cfgs]
 level = "allow"
 

--- a/README.md
+++ b/README.md
@@ -394,6 +394,40 @@ Here is a list of projects using RLN, in alphabetical order:
 - [Tiramisu Wallet]
 
 
+## VSS Cloud Backup (optional)
+
+The node supports cloud backup via [VSS] (Versioned Storage Service).
+When enabled, LDK channel state and RGB wallet data are replicated to a VSS
+server for disaster recovery.
+
+### Setup
+
+Start the VSS server alongside regtest services:
+```sh
+VSS=1 ./regtest.sh start
+```
+
+Or manually:
+```sh
+docker compose --profile vss up -d
+```
+
+### Usage
+
+Pass `--vss-url` when starting the node:
+```sh
+cargo run --features vss -- /tmp/rlndata --vss-url http://localhost:8081/vss
+```
+
+Options:
+- `--vss-url <URL>` — VSS server URL (enables VSS)
+- `--vss-unencrypted` — Disable encryption for VSS backups (default: encrypted)
+
+API endpoints (when VSS is enabled):
+- `POST /vssbackup` — trigger manual RGB wallet backup
+- `GET /vssbackupinfo` — check backup status
+
+[VSS]: https://github.com/lightningdevkit/vss-server
 [Biscuit tokens]: https://www.biscuitsec.org/
 [RGB proxy server]: https://github.com/RGB-Tools/rgb-proxy-server
 [ldk-sample]: https://github.com/lightningdevkit/ldk-sample

--- a/README.md
+++ b/README.md
@@ -396,9 +396,19 @@ Here is a list of projects using RLN, in alphabetical order:
 
 ## VSS Cloud Backup (optional)
 
-The node supports cloud backup via [VSS] (Versioned Storage Service).
-When enabled, LDK channel state and RGB wallet data are replicated to a VSS
-server for disaster recovery.
+The node supports optional cloud backup via [VSS] (Versioned Storage Service).
+When enabled, the node replicates its state to a remote VSS server so it can be
+recovered on a new device. The feature is fully opt-in: it must be compiled in
+with `--features vss` and turned on at runtime with `--vss-url`. Without both,
+the node behaves exactly as before.
+
+Two independent data streams are backed up:
+
+- **Node KV state** — channel manager, channel monitors, payment info, swap
+  data and RGB channel info. Every update is written to both the local SQLite
+  database and the remote VSS server.
+- **RGB wallet data** — the wallet files managed by rgb-lib, backed up
+  automatically after every state-changing wallet operation.
 
 ### Setup
 
@@ -416,16 +426,45 @@ docker compose --profile vss up -d
 
 Pass `--vss-url` when starting the node:
 ```sh
-cargo run --features vss -- /tmp/rlndata --vss-url http://localhost:8081/vss
+cargo run --features vss -- /tmp/rlndata --vss-url https://example.com/vss
 ```
 
 Options:
-- `--vss-url <URL>` — VSS server URL (enables VSS)
-- `--vss-unencrypted` — Disable encryption for VSS backups (default: encrypted)
+- `--vss-url <URL>` — VSS server URL; enables VSS backup. For non-loopback
+  hosts an `https://` URL is required (see `--vss-allow-http`).
+- `--vss-allow-http` — allow an `http://` `--vss-url` for non-loopback hosts.
+  By default only `https://` URLs and loopback HTTP URLs (e.g.
+  `http://localhost:8081/vss`) are accepted. Use only on a network you trust
+  out-of-band.
+- `--vss-allow-empty-restore` — on a fresh device, if a VSS restore fails
+  (server unreachable, wrong key, etc.), start with empty local state instead
+  of aborting unlock. **Use with care:** starting fresh with no channel
+  monitors can lose funds if the node had active channels. The default
+  (abort on restore failure) is the safe choice.
 
-API endpoints (when VSS is enabled):
-- `POST /vssbackup` — trigger manual RGB wallet backup
-- `GET /vssbackupinfo` — check backup status
+### Encryption
+
+The KV stream is always encrypted at rest on VSS using XChaCha20-Poly1305 with
+a key derived from the VSS signing key. There is no option to disable it. The
+VSS signing key is derived from the wallet mnemonic, so backups can only be
+read and restored by a node initialized with the same mnemonic.
+
+### Recovery
+
+On a fresh start, if the local database has no channel-manager state but the
+VSS server has data, the node automatically restores from VSS before
+initializing. Each VSS store is owned by a single running node instance; a
+second node pointed at the same store refuses to start to avoid corrupting
+state.
+
+VSS replication is best-effort: a write that fails to reach the server is
+queued and retried on later successful writes. The number of pending writes is
+reported by `GET /vssbackupinfo` so monitoring can alert on persistent
+staleness.
+
+### API endpoints (when VSS is enabled)
+- `POST /vssbackup` — trigger a manual RGB wallet backup
+- `GET /vssbackupinfo` — check backup status (includes pending write count)
 
 [VSS]: https://github.com/lightningdevkit/vss-server
 [Biscuit tokens]: https://www.biscuitsec.org/

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/ConcurrentBtcPaymentsTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/ConcurrentBtcPaymentsTest.kt
@@ -55,7 +55,7 @@ class ConcurrentBtcPaymentsTest {
     private val invoiceAmtMsat2: ULong = 5_000_000u
     private val utxosNum: UByte = 10u
     private val utxosFeeRate: ULong = 7u
-    private val channelReadyTimeoutSec: Long = 60L
+    private val channelReadyTimeoutSec: Long = 120L
 
     private fun bitcoindRpc(method: String, vararg params: Any): JSONObject {
         val url = URL("http://$bitcoindHost:$bitcoindPort/")
@@ -556,17 +556,17 @@ class ConcurrentBtcPaymentsTest {
 
             log("waiting for sender-side payment success")
             val payment1Sender =
-                waitForPaymentStatus(nodeC, response1.paymentHash!!, PaymentType.OUTBOUND, 60L)
+                waitForPaymentStatus(nodeC, response1.paymentHash!!, PaymentType.OUTBOUND, 120L)
             val payment2Sender =
-                waitForPaymentStatus(nodeD, response2.paymentHash!!, PaymentType.OUTBOUND, 60L)
+                waitForPaymentStatus(nodeD, response2.paymentHash!!, PaymentType.OUTBOUND, 120L)
             dumpNodeState(nodeC, "node C after sender success")
             dumpNodeState(nodeD, "node D after sender success")
             assertEquals(HtlcStatus.SUCCEEDED, payment1Sender.status)
             assertEquals(HtlcStatus.SUCCEEDED, payment2Sender.status)
 
             log("waiting for receiver invoice success")
-            waitForInvoiceStatus(nodeA, invoice1, InvoiceStatus.SUCCEEDED, 60L)
-            waitForInvoiceStatus(nodeA, invoice2, InvoiceStatus.SUCCEEDED, 60L)
+            waitForInvoiceStatus(nodeA, invoice1, InvoiceStatus.SUCCEEDED, 120L)
+            waitForInvoiceStatus(nodeA, invoice2, InvoiceStatus.SUCCEEDED, 120L)
             dumpNodeState(nodeA, "node A after invoice success")
 
             val payments = nodeA.listPayments()
@@ -577,7 +577,7 @@ class ConcurrentBtcPaymentsTest {
             assertEquals(HtlcStatus.SUCCEEDED, payment1.status)
             assertEquals(HtlcStatus.SUCCEEDED, payment2.status)
 
-            waitForChannelLocalBalanceMsat(nodeA, channelA.channelId, invoiceAmtMsat1 + invoiceAmtMsat2, 30L)
+            waitForChannelLocalBalanceMsat(nodeA, channelA.channelId, invoiceAmtMsat1 + invoiceAmtMsat2, 60L)
             val channelsAfter = nodeA.listChannels()
             assertEquals(1, channelsAfter.size)
             assertEquals(invoiceAmtMsat1 + invoiceAmtMsat2, channelsAfter.first().localBalanceSat * 1000u)

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
@@ -341,7 +341,6 @@ class MultiOpenCloseTest {
                 donation = true,
                 feeRate = utxosFeeRate,
                 minConfirmations = 1u,
-                skipSync = false,
                 recipientGroups = listOf(
                     AssetRecipients(
                         assetId = assetId,

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
@@ -59,7 +59,7 @@ class MultiOpenCloseTest {
     private val utxosNum: UByte = 10u
     private val utxosFeeRate: ULong = 7u
     private val assetSupply: ULong = 1000u
-    private val channelReadyTimeoutSec: Long = 60L
+    private val channelReadyTimeoutSec: Long = 120L
 
     private fun bitcoindRpc(method: String, vararg params: Any): JSONObject {
         val url = URL("http://$bitcoindHost:$bitcoindPort/")
@@ -291,7 +291,7 @@ class MultiOpenCloseTest {
             "unexpected keysend status: ${response.status}",
             response.status == HtlcStatus.PENDING || response.status == HtlcStatus.SUCCEEDED
         )
-        waitForPaymentStatus(sender, response.paymentHash, PaymentType.OUTBOUND, 60L)
+        waitForPaymentStatus(sender, response.paymentHash, PaymentType.OUTBOUND, 120L)
         return response.paymentHash
     }
 
@@ -427,7 +427,7 @@ class MultiOpenCloseTest {
                     virtualOpenMode = null,
                 )
             )
-            var fundingTxid = waitForChannelFundingTx(nodeA, nodeBReady, assetId, 120L)
+            var fundingTxid = waitForChannelFundingTx(nodeA, nodeBReady, assetId, 240L)
             log("Mining blocks one by one until funding tx is confirmed...")
             mineUntilTxConfirmed(nodeA, fundingTxid)
             mine(openChannelConfirmBlocks)
@@ -439,8 +439,8 @@ class MultiOpenCloseTest {
 
             val firstChannelId = nodeA.getChannelId(firstOpen.temporaryChannelId)
             closeChannel(nodeA, firstChannelId, nodeBPubkey)
-            waitForBalance(nodeA, assetId, 900uL, 70L)
-            waitForBalance(nodeBReady, assetId, 100uL, 70L)
+            waitForBalance(nodeA, assetId, 900uL, 180L)
+            waitForBalance(nodeBReady, assetId, 100uL, 180L)
 
             val secondOpen = nodeA.openchannel(
                 SdkOpenChannelRequest(
@@ -458,7 +458,7 @@ class MultiOpenCloseTest {
                     virtualOpenMode = null,
                 )
             )
-            fundingTxid = waitForChannelFundingTx(nodeA, nodeBReady, assetId, 120L)
+            fundingTxid = waitForChannelFundingTx(nodeA, nodeBReady, assetId, 240L)
             log("Mining blocks one by one until funding tx is confirmed...")
             mineUntilTxConfirmed(nodeA, fundingTxid)
             mine(openChannelConfirmBlocks)
@@ -470,8 +470,8 @@ class MultiOpenCloseTest {
 
             val secondChannelId = nodeA.getChannelId(secondOpen.temporaryChannelId)
             closeChannel(nodeA, secondChannelId, nodeBPubkey)
-            waitForBalance(nodeA, assetId, 800uL, 70L)
-            waitForBalance(nodeBReady, assetId, 200uL, 70L)
+            waitForBalance(nodeA, assetId, 800uL, 180L)
+            waitForBalance(nodeBReady, assetId, 200uL, 180L)
 
             val recipientIdA = rgbInvoice(nodeCReady)
             sendRgb(nodeA, assetId, recipientIdA, 700u)

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
@@ -66,7 +66,7 @@ class PaymentTest {
     private val utxosFeeRate: ULong = 7u
     private val assetSupply: ULong = 1000u
     private val channelAssetAmount: ULong = 600u
-    private val channelReadyTimeoutSec: Long = 60L
+    private val channelReadyTimeoutSec: Long = 120L
 
     // ── Bitcoin RPC ──────────────────────────────────────────────────────────
 
@@ -523,7 +523,7 @@ class PaymentTest {
             )
             log("openchannel sent")
 
-            val fundingTxid = waitForChannelFundingTx(nodeA, nodeB, assetId, 120L)
+            val fundingTxid = waitForChannelFundingTx(nodeA, nodeB, assetId, 240L)
             log("Mining blocks one by one until funding tx is confirmed..."); mineUntilTxConfirmed(nodeA, fundingTxid)
             mine(6)
             waitForUsableChannel(nodeA, nodeB, assetId, channelReadyTimeoutSec)
@@ -731,8 +731,8 @@ class PaymentTest {
             assertEquals(chan2Before.localBalanceSat, chan2.localBalanceSat)
 
             closeChannel(nodeA, channelId, infoB.pubkey)
-            waitForBalance(nodeA, assetId, 950uL, 70L)
-            waitForBalance(nodeB, assetId, 50uL, 70L)
+            waitForBalance(nodeA, assetId, 950uL, 180L)
+            waitForBalance(nodeB, assetId, 50uL, 180L)
 
             val recipientId1 = rgbInvoice(nodeC)
             sendRgb(nodeA, assetId, recipientId1, 925u)

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
@@ -413,7 +413,6 @@ class PaymentTest {
                 donation = true,
                 feeRate = utxosFeeRate,
                 minConfirmations = 1u,
-                skipSync = false,
                 recipientGroups = listOf(
                     AssetRecipients(
                         assetId = assetId,
@@ -757,7 +756,7 @@ class PaymentTest {
             val txUser = transactions.first { it.received == 100_000_000uL }
             val txUtxos = transactions.first { it.sent == 100_000_000uL }
             val txSend = transactions.first { it.sent == 128_000uL }
-            assertEquals(TransactionType.USER, txUser.transactionType)
+            assertEquals(TransactionType.INCOMING, txUser.transactionType)
             assertEquals(TransactionType.CREATE_UTXOS, txUtxos.transactionType)
             assertEquals(TransactionType.RGB_SEND, txSend.transactionType)
             assertNotNull(txUtxos.confirmationTime)

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
@@ -373,7 +373,6 @@ class RestartTest {
                 donation = true,
                 feeRate = utxosFeeRate,
                 minConfirmations = 1u,
-                skipSync = false,
                 recipientGroups = listOf(
                     AssetRecipients(
                         assetId = assetId,

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
@@ -60,7 +60,7 @@ class RestartTest {
     private val utxosNum: UByte = 10u
     private val utxosFeeRate: ULong = 7u
     private val assetSupply: ULong = 1000u
-    private val channelReadyTimeoutSec: Long = 60L
+    private val channelReadyTimeoutSec: Long = 120L
 
     private fun bitcoindRpc(method: String, vararg params: Any): JSONObject {
         val url = URL("http://$bitcoindHost:$bitcoindPort/")
@@ -472,7 +472,7 @@ class RestartTest {
                     virtualOpenMode = null,
                 )
             )
-            val fundingTxid = waitForChannelFundingTx(requireNotNull(nodeA), requireNotNull(nodeB), assetId, 120L)
+            val fundingTxid = waitForChannelFundingTx(requireNotNull(nodeA), requireNotNull(nodeB), assetId, 240L)
             log("Mining blocks one by one until funding tx is confirmed...")
             mineUntilTxConfirmed(requireNotNull(nodeA), fundingTxid)
             mine(openChannelConfirmBlocks)
@@ -484,7 +484,7 @@ class RestartTest {
             pauseAfterShutdown()
             nodeA = makeNode("restart/node_a", nodeADaemonPort, nodeAPeerPort)
             unlockNode(requireNotNull(nodeA), "nodeApass", "node A")
-            waitForChannelReady(requireNotNull(nodeA), channelId, 10L)
+            waitForChannelReady(requireNotNull(nodeA), channelId, 60L)
 
             safeShutdown(nodeA)
             pauseAfterShutdown()
@@ -492,9 +492,9 @@ class RestartTest {
             nodeB = makeNode("restart/node_b", nodeBDaemonPort, nodeBPeerPort)
             unlockNode(requireNotNull(nodeA), "nodeApass", "node A")
             unlockNode(requireNotNull(nodeB), "nodeBpass", "node B")
-            waitForChannelReady(requireNotNull(nodeA), channelId, 10L)
-            waitForUsableChannels(requireNotNull(nodeA), 1, 60L)
-            waitForUsableChannels(requireNotNull(nodeB), 1, 60L)
+            waitForChannelReady(requireNotNull(nodeA), channelId, 60L)
+            waitForUsableChannels(requireNotNull(nodeA), 1, 120L)
+            waitForUsableChannels(requireNotNull(nodeB), 1, 120L)
             assertEquals(400uL, assetBalanceSpendable(requireNotNull(nodeA), assetId))
 
             val invoice = requireNotNull(nodeB).lnInvoice(
@@ -516,7 +516,7 @@ class RestartTest {
                 )
             )
             val paymentHash = requireNotNull(sendPayment.paymentHash)
-            waitForPaymentStatus(requireNotNull(nodeA), paymentHash, PaymentType.OUTBOUND, 60L)
+            waitForPaymentStatus(requireNotNull(nodeA), paymentHash, PaymentType.OUTBOUND, 120L)
 
             safeShutdown(nodeA); safeShutdown(nodeB)
             pauseAfterShutdown()
@@ -527,9 +527,9 @@ class RestartTest {
             log("restart12_3: node A unlocked")
             unlockNode(requireNotNull(nodeB), "nodeBpass", "node B")
             log("restart12_3: node B unlocked")
-            waitForChannelReady(requireNotNull(nodeA), channelId, 10L)
-            waitForUsableChannels(requireNotNull(nodeA), 1, 60L)
-            waitForUsableChannels(requireNotNull(nodeB), 1, 60L)
+            waitForChannelReady(requireNotNull(nodeA), channelId, 60L)
+            waitForUsableChannels(requireNotNull(nodeA), 1, 120L)
+            waitForUsableChannels(requireNotNull(nodeB), 1, 120L)
             waitForSucceededPaymentInList(
                 requireNotNull(nodeA),
                 paymentHash,
@@ -544,8 +544,8 @@ class RestartTest {
             )
 
             closeChannel(requireNotNull(nodeA), channelId, nodeBPubkey)
-            waitForBalance(requireNotNull(nodeA), assetId, 900uL, 70L)
-            waitForBalance(requireNotNull(nodeB), assetId, 100uL, 70L)
+            waitForBalance(requireNotNull(nodeA), assetId, 900uL, 180L)
+            waitForBalance(requireNotNull(nodeB), assetId, 100uL, 180L)
 
             safeShutdown(nodeA); safeShutdown(nodeB)
             pauseAfterShutdown()

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/SwapRoundtripBuyTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/SwapRoundtripBuyTest.kt
@@ -62,7 +62,7 @@ class SwapRoundtripBuyTest {
     private val utxosNum: UByte = 10u
     private val utxosFeeRate: ULong = 7u
     private val assetSupply: ULong = 1000u
-    private val channelReadyTimeoutSec: Long = 20L
+    private val channelReadyTimeoutSec: Long = 60L
     private var noMineCount: Int = 0
 
     private fun bitcoindRpc(method: String, vararg params: Any): JSONObject {
@@ -616,10 +616,10 @@ class SwapRoundtripBuyTest {
             assertEquals(1, makerPendingLists.maker.size)
             val makerPending = makerPendingLists.maker.first()
             assertEquals(SwapStatus.PENDING, makerPending.status)
-            waitForSwapStatus(requireNotNull(nodeB), makerInit.paymentHash, SwapStatus.SUCCEEDED, 70L)
+            waitForSwapStatus(requireNotNull(nodeB), makerInit.paymentHash, SwapStatus.SUCCEEDED, 150L)
 
-            waitForLnBalance(requireNotNull(nodeA), assetId, 590uL, 60L)
-            waitForLnBalance(requireNotNull(nodeB), assetId, 10uL, 60L)
+            waitForLnBalance(requireNotNull(nodeA), assetId, 590uL, 120L)
+            waitForLnBalance(requireNotNull(nodeB), assetId, 10uL, 120L)
 
             safeShutdown(nodeA); safeShutdown(nodeB)
             pauseAfterShutdown()
@@ -627,11 +627,11 @@ class SwapRoundtripBuyTest {
             nodeB = makeNode("swap_roundtrip_buy/node_b", nodeBDaemonPort, nodeBPeerPort)
             unlockNode(requireNotNull(nodeA), "nodeApass", "node A")
             unlockNode(requireNotNull(nodeB), "nodeBpass", "node B")
-            waitForUsableChannels(requireNotNull(nodeA), 2, 60L)
-            waitForUsableChannels(requireNotNull(nodeB), 2, 60L)
+            waitForUsableChannels(requireNotNull(nodeA), 2, 120L)
+            waitForUsableChannels(requireNotNull(nodeB), 2, 120L)
 
-            waitForAssetOffchainBalances(requireNotNull(nodeA), assetId, 590uL, 10uL, 60L)
-            waitForAssetOffchainBalances(requireNotNull(nodeB), assetId, 10uL, 590uL, 60L)
+            waitForAssetOffchainBalances(requireNotNull(nodeA), assetId, 590uL, 10uL, 120L)
+            waitForAssetOffchainBalances(requireNotNull(nodeB), assetId, 10uL, 590uL, 120L)
 
             val makerSucceededLists = requireNotNull(nodeA).`listSwaps`()
             assertEquals(1, makerSucceededLists.maker.size)
@@ -656,8 +656,8 @@ class SwapRoundtripBuyTest {
             assertEquals(chanB21Before.localBalanceSat - btcLegDiffSat, chanB21.localBalanceSat)
 
             closeChannel(requireNotNull(nodeA), channel12Id, infoB.pubkey)
-            waitForBalance(requireNotNull(nodeA), assetId, 990uL, 70L)
-            waitForBalance(requireNotNull(nodeB), assetId, 10uL, 70L)
+            waitForBalance(requireNotNull(nodeA), assetId, 990uL, 180L)
+            waitForBalance(requireNotNull(nodeB), assetId, 10uL, 180L)
 
             closeChannel(requireNotNull(nodeB), channel21Id, infoA.pubkey)
 

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/SwapRoundtripBuyTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/SwapRoundtripBuyTest.kt
@@ -445,7 +445,6 @@ class SwapRoundtripBuyTest {
                 donation = true,
                 feeRate = utxosFeeRate,
                 minConfirmations = 1u,
-                skipSync = false,
                 recipientGroups = listOf(
                     AssetRecipients(
                         assetId = assetId,

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -271,7 +271,8 @@ enum TransactionType {
     "RgbSend",
     "Drain",
     "CreateUtxos",
-    "User",
+    "SendBtc",
+    "Incoming",
 };
 
 dictionary Transaction {
@@ -724,7 +725,6 @@ dictionary SendRgbRequest {
     boolean donation;
     u64 fee_rate;
     u8 min_confirmations;
-    boolean skip_sync;
     sequence<AssetRecipients> recipient_groups;
 };
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,3 +26,33 @@ services:
     image: ghcr.io/rgb-tools/rgb-proxy-server:0.3.0
     ports:
       - 3000:3000
+  vss-postgres:
+    image: postgres:16-alpine
+    profiles: ['vss']
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+  vss-server:
+    build:
+      context: ./docker/vss-server
+      dockerfile: ./Dockerfile
+    image: vss-server:sigs-auth
+    profiles: ['vss']
+    ports:
+      - 8081:8080
+    environment:
+      VSS_BIND_ADDRESS: "0.0.0.0:8080"
+      VSS_PSQL_USERNAME: postgres
+      VSS_PSQL_PASSWORD: postgres
+      VSS_PSQL_ADDRESS: "vss-postgres:5432"
+      VSS_PSQL_DEFAULT_DB: postgres
+      VSS_PSQL_VSS_DB: vss
+    depends_on:
+      vss-postgres:
+        condition: service_healthy

--- a/docker/vss-server/Dockerfile
+++ b/docker/vss-server/Dockerfile
@@ -1,0 +1,33 @@
+# Multi-stage build for lightningdevkit/vss-server (Rust)
+# Builds with signature-based authentication (SigsAuthProvider)
+
+# Stage 1: Build
+FROM rust:1.85.0-bookworm AS builder
+
+RUN apt-get update && apt-get install -y \
+    libssl-dev \
+    pkg-config \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+RUN git clone https://github.com/lightningdevkit/vss-server.git . && \
+    git checkout e4c835902cdec97676ee8d11b4fa418b23711d9e
+
+WORKDIR /build/rust
+RUN cargo build --release --no-default-features --features sigs
+
+# Stage 2: Runtime
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    libssl3 \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/rust/target/release/vss-server /usr/local/bin/vss-server
+COPY --from=builder /build/rust/server/vss-server-config.toml /etc/vss/vss-server-config.toml
+
+EXPOSE 8080
+
+CMD ["vss-server", "/etc/vss/vss-server-config.toml"]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1066,6 +1066,75 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmptyResponse'
+  /vssbackup:
+    post:
+      tags:
+        - Other
+      summary: Trigger a manual VSS backup of the RGB wallet
+      description: >
+        Builds a zip of the current RGB wallet directory and uploads it to the
+        configured VSS server. Only available when the node was started with
+        --vss-url. The node's KV state is replicated automatically on every
+        persistence event and is not affected by this endpoint.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - version
+                properties:
+                  version:
+                    type: integer
+                    format: int64
+                    description: Server-side version of the just-uploaded RGB wallet backup.
+        '503':
+          description: VSS is not configured or unreachable
+  /vssbackupinfo:
+    get:
+      tags:
+        - Other
+      summary: Inspect VSS backup status
+      description: >
+        Returns whether a backup exists on the server, its server-side version,
+        whether the local wallet has changes since the last backup, and how
+        many KV-stream writes are queued for retry after a replication
+        failure. Read-only; callable by tokens with the read-only role.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - backup_exists
+                  - backup_required
+                  - pending_kv_writes
+                properties:
+                  backup_exists:
+                    type: boolean
+                    description: True if the VSS server has a backup for this wallet.
+                  server_version:
+                    type: integer
+                    format: int64
+                    nullable: true
+                    description: Server-side version of the most recent backup, if any.
+                  backup_required:
+                    type: boolean
+                    description: >
+                      True if the local wallet has changes since the last
+                      successful upload (i.e. a manual backup is needed).
+                  pending_kv_writes:
+                    type: integer
+                    description: >
+                      Number of KV writes that failed to replicate and are
+                      queued for retry. A persistently non-zero value
+                      indicates VSS replication is degraded.
+        '503':
+          description: VSS is not configured or unreachable
 components:
   schemas:
     AddressResponse:
@@ -2947,7 +3016,6 @@ components:
         - fee_rate
         - min_confirmations
         - recipient_map
-        - skip_sync
       properties:
         donation:
           type: boolean
@@ -2987,9 +3055,6 @@ components:
                   Fungible: 100
                 transport_endpoints:
                   - rpc://127.0.0.1:3000/json-rpc
-        skip_sync:
-          type: boolean
-          example: false
     SendRgbResponse:
       type: object
       required:

--- a/regtest.sh
+++ b/regtest.sh
@@ -83,6 +83,13 @@ _start_services() {
     $COMPOSE up -d
     echo "waiting for electrs to have completed startup"
     _wait_for_electrs
+
+    # optionally start VSS server
+    if [ "${VSS:-}" = "1" ]; then
+        echo "starting VSS server..."
+        $COMPOSE --profile vss up -d
+        echo "VSS server available at http://localhost:8081/vss"
+    fi
 }
 
 _stop_services() {

--- a/src/args.rs
+++ b/src/args.rs
@@ -49,13 +49,32 @@ struct Args {
     #[arg(long)]
     lsp_bearer_token: Option<String>,
 
-    /// VSS server URL for cloud backup (e.g., http://localhost:8081/vss)
+    /// VSS server URL for cloud backup (e.g., https://example.com/vss).
+    ///
+    /// HTTPS is required for non-loopback hosts unless `--vss-allow-http` is
+    /// also set; this prevents accidentally shipping channel state plaintext
+    /// over the network.
     #[arg(long)]
     vss_url: Option<String>,
 
-    /// Disable encryption for VSS backups (default: encrypted)
+    /// Allow `--vss-url` to use the `http://` scheme for non-loopback hosts.
+    ///
+    /// Without this flag, only `https://` URLs and loopback HTTP URLs
+    /// (e.g. `http://localhost:8081/vss`) are accepted. Set this only when
+    /// you have an out-of-band reason to trust the link (e.g. a private
+    /// network with link-layer encryption).
     #[arg(long, default_value_t = false)]
-    vss_unencrypted: bool,
+    vss_allow_http: bool,
+
+    /// On a fresh device with no local LDK state, if VSS restore fails
+    /// (server unreachable, wrong signing key, etc.), start with an empty
+    /// local state instead of aborting unlock.
+    ///
+    /// **Use with care.** A node started fresh has no channel monitors and
+    /// can lose funds if it had active channels. The default behavior
+    /// (abort on restore failure) is the safe choice in almost all cases.
+    #[arg(long, default_value_t = false)]
+    vss_allow_empty_restore: bool,
 }
 
 pub(crate) struct UserArgs {
@@ -70,7 +89,7 @@ pub(crate) struct UserArgs {
     pub(crate) lsp_base_url: Option<String>,
     pub(crate) lsp_bearer_token: Option<String>,
     pub(crate) vss_url: Option<String>,
-    pub(crate) vss_unencrypted: bool,
+    pub(crate) vss_allow_empty_restore: bool,
 }
 
 pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
@@ -93,6 +112,11 @@ pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
         virtual_peer_pubkeys.push(parsed_pubkey);
     }
 
+    // Reject http:// URLs unless the host is loopback or --vss-allow-http is set.
+    if let Some(url) = &args.vss_url {
+        crate::utils::validate_vss_url(url, args.vss_allow_http)?;
+    }
+
     Ok(UserArgs {
         storage_dir_path: args.storage_directory_path,
         daemon_listening_port,
@@ -105,6 +129,6 @@ pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
         lsp_base_url: args.lsp_base_url,
         lsp_bearer_token: args.lsp_bearer_token,
         vss_url: args.vss_url,
-        vss_unencrypted: args.vss_unencrypted,
+        vss_allow_empty_restore: args.vss_allow_empty_restore,
     })
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -48,6 +48,14 @@ struct Args {
 
     #[arg(long)]
     lsp_bearer_token: Option<String>,
+
+    /// VSS server URL for cloud backup (e.g., http://localhost:8081/vss)
+    #[arg(long)]
+    vss_url: Option<String>,
+
+    /// Disable encryption for VSS backups (default: encrypted)
+    #[arg(long, default_value_t = false)]
+    vss_unencrypted: bool,
 }
 
 pub(crate) struct UserArgs {
@@ -61,6 +69,8 @@ pub(crate) struct UserArgs {
     pub(crate) virtual_peer_pubkeys: Vec<PublicKey>,
     pub(crate) lsp_base_url: Option<String>,
     pub(crate) lsp_bearer_token: Option<String>,
+    pub(crate) vss_url: Option<String>,
+    pub(crate) vss_unencrypted: bool,
 }
 
 pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
@@ -94,5 +104,7 @@ pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
         virtual_peer_pubkeys,
         lsp_base_url: args.lsp_base_url,
         lsp_bearer_token: args.lsp_bearer_token,
+        vss_url: args.vss_url,
+        vss_unencrypted: args.vss_unencrypted,
     })
 }

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -385,7 +385,7 @@ impl AsyncPaymentsPreimageRoot {
             let message = format!("async_payment_root_derivation_failed: {err}");
             JsonRpcErrorWire::internal_error(message)
         })?;
-        let mut account_xprv = xkey.into_xprv(network).ok_or_else(|| {
+        let mut account_xprv = xkey.into_xprv(network.into()).ok_or_else(|| {
             JsonRpcErrorWire::internal_error("async_payment_xprv_not_available".to_owned())
         })?;
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::{hex_str, hex_str_to_vec, AppState},
 };
 
-const READ_ONLY_OPS: [&str; 23] = [
+const READ_ONLY_OPS: [&str; 24] = [
     "/assetbalance",
     "/assetmetadata",
     "/btcbalance",
@@ -31,6 +31,7 @@ const READ_ONLY_OPS: [&str; 23] = [
     "/listunspents",
     "/networkinfo",
     "/nodeinfo",
+    "/vssbackupinfo",
 ];
 
 pub(crate) fn check_auth_args(

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,6 +80,10 @@ pub enum APIError {
     #[error("Failed to connect to peer")]
     FailedPeerConnection,
 
+    #[cfg(feature = "vss")]
+    #[error("Failed to initialize VSS: {0}")]
+    FailedVssInit(String),
+
     #[error("Failed to disconnect to peer: {0}")]
     FailedPeerDisconnection(String),
 
@@ -577,6 +581,8 @@ impl IntoResponse for APIError {
                 self.to_string(),
                 self.name(),
             ),
+            #[cfg(feature = "vss")]
+            APIError::FailedVssInit(_) => (StatusCode::FORBIDDEN, self.to_string(), self.name()),
         };
 
         let error = error.replace("\n", " ");

--- a/src/error.rs
+++ b/src/error.rs
@@ -582,7 +582,11 @@ impl IntoResponse for APIError {
                 self.name(),
             ),
             #[cfg(feature = "vss")]
-            APIError::FailedVssInit(_) => (StatusCode::FORBIDDEN, self.to_string(), self.name()),
+            APIError::FailedVssInit(_) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                self.to_string(),
+                self.name(),
+            ),
         };
 
         let error = error.replace("\n", " ");
@@ -613,6 +617,9 @@ pub enum AppError {
 
     #[error("Invalid virtual peer pubkey: {0}")]
     InvalidVirtualPeerPubkey(String),
+
+    #[error("Invalid VSS configuration: {0}")]
+    InvalidVssConfig(String),
 
     #[error("IO error: {0}")]
     IO(#[from] std::io::Error),

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1,7 +1,7 @@
 use crate::async_order::{
     AsyncOrderAccessControl, AsyncOrderMessageHandler, AsyncPaymentsPreimageRoot,
 };
-use crate::kv_store::SeaOrmKvStore;
+use crate::synced_kv_store::SyncedKvStore;
 use amplify::{map, s};
 use bitcoin::blockdata::locktime::absolute::LockTime;
 use bitcoin::hashes::{sha256, Hash as BitcoinHash};
@@ -892,7 +892,7 @@ pub(crate) type ChainMonitor = chainmonitor::ChainMonitor<
     Arc<FilesystemLogger>,
     Arc<
         MonitorUpdatingPersister<
-            Arc<SeaOrmKvStore>,
+            Arc<SyncedKvStore>,
             Arc<FilesystemLogger>,
             Arc<KeysManager>,
             Arc<KeysManager>,
@@ -961,7 +961,7 @@ pub(crate) struct RgbOutputSpender {
     static_state: Arc<StaticState>,
     rgb_wallet_wrapper: Arc<RgbLibWalletWrapper>,
     keys_manager: Arc<KeysManager>,
-    kv_store: Arc<SeaOrmKvStore>,
+    kv_store: Arc<SyncedKvStore>,
     txes: Arc<Mutex<OutputSpenderTxes>>,
     proxy_endpoint: String,
 }
@@ -971,7 +971,7 @@ pub(crate) type OutputSweeper = ldk_sweep::OutputSweeper<
     Arc<RgbLibWalletWrapper>,
     Arc<BitcoindClient>,
     Arc<dyn Filter + Send + Sync>,
-    KVStoreSyncWrapper<Arc<SeaOrmKvStore>>,
+    KVStoreSyncWrapper<Arc<SyncedKvStore>>,
     Arc<FilesystemLogger>,
     Arc<RgbOutputSpender>,
 >;
@@ -2674,9 +2674,67 @@ pub(crate) async fn start_ldk(
     let static_state = &app_state.static_state;
 
     // Initialize Persistence using shared database connection
-    let kv_store = Arc::new(SeaOrmKvStore::from_connection(Arc::clone(
+    let local_kv_store = Arc::new(crate::kv_store::SeaOrmKvStore::from_connection(Arc::clone(
         &static_state.database,
     )));
+
+    // Initialize VSS replication if configured
+    #[cfg(feature = "vss")]
+    let kv_store = if let Some(ref vss_url) = static_state.vss_url {
+        let network: Network = static_state.network.into();
+        let xkey: ExtendedKey = mnemonic
+            .clone()
+            .into_extended_key()
+            .expect("valid mnemonic");
+        let master_xprv = &xkey.into_xprv(network).expect("valid xprv");
+        // Derive VSS signing key at m/535'/1' (separate from LDK's m/535')
+        let vss_xprv = master_xprv
+            .derive_priv(
+                &Secp256k1_30::new(),
+                &[
+                    ChildNumber::Hardened { index: 535 },
+                    ChildNumber::Hardened { index: 1 },
+                ],
+            )
+            .unwrap();
+        let vss_signing_key = vss_xprv.private_key;
+
+        // Derive store_id from the VSS key's public key
+        let secp = Secp256k1_30::new();
+        let vss_pubkey = vss_signing_key.public_key(&secp);
+        let store_id = hex_str(&vss_pubkey.serialize());
+
+        tracing::info!(store_id, "Initializing VSS KV store");
+        let vss_kv_store = Arc::new(
+            crate::vss_kv_store::VssKvStore::new(vss_url.clone(), store_id, vss_signing_key)
+                .map_err(|e| APIError::FailedVssInit(e.to_string()))?,
+        );
+        let synced = Arc::new(SyncedKvStore::with_vss(local_kv_store, vss_kv_store));
+
+        // Auto-restore from VSS if local DB has no channel manager data
+        let has_local_data = synced
+            .read(
+                CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+                CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
+                CHANNEL_MANAGER_PERSISTENCE_KEY,
+            )
+            .is_ok();
+        if !has_local_data {
+            match synced.restore_from_vss() {
+                Ok(0) => tracing::info!("No VSS backup data found, starting fresh"),
+                Ok(n) => tracing::info!(keys_restored = n, "Restored LDK state from VSS"),
+                Err(e) => tracing::warn!(error = %e, "VSS restore failed, starting fresh"),
+            }
+        }
+
+        synced
+    } else {
+        Arc::new(SyncedKvStore::local_only(local_kv_store))
+    };
+
+    #[cfg(not(feature = "vss"))]
+    let kv_store = Arc::new(SyncedKvStore::local_only(local_kv_store));
+
     let kv_store_dyn: Arc<dyn KVStoreSync + Send + Sync> =
         Arc::clone(&kv_store) as Arc<dyn KVStoreSync + Send + Sync>;
 
@@ -2979,6 +3037,44 @@ pub(crate) async fn start_ldk(
     .await
     .unwrap();
     let rgb_online = rgb_wallet.go_online(false, indexer_url.to_string())?;
+
+    // Configure VSS backup for the RGB wallet if VSS is enabled
+    #[cfg(feature = "vss")]
+    if let Some(ref vss_url) = static_state.vss_url {
+        let network: Network = static_state.network.into();
+        let xkey: ExtendedKey = mnemonic
+            .clone()
+            .into_extended_key()
+            .expect("valid mnemonic");
+        let master_xprv_vss = &xkey.into_xprv(network).expect("valid xprv");
+        let vss_xprv = master_xprv_vss
+            .derive_priv(
+                &Secp256k1_30::new(),
+                &[
+                    ChildNumber::Hardened { index: 535 },
+                    ChildNumber::Hardened { index: 1 },
+                ],
+            )
+            .unwrap();
+        let vss_signing_key = vss_xprv.private_key;
+        let secp = Secp256k1_30::new();
+        let vss_pubkey = vss_signing_key.public_key(&secp);
+        let rgb_store_id = format!("{}_rgb", hex_str(&vss_pubkey.serialize()));
+
+        let vss_config = rgb_lib::wallet::vss::VssBackupConfig::new(
+            vss_url.clone(),
+            rgb_store_id,
+            vss_signing_key,
+        )
+        .with_encryption(!static_state.vss_unencrypted)
+        .with_auto_backup(true);
+
+        match rgb_wallet.configure_vss_backup(vss_config) {
+            Ok(()) => tracing::info!("VSS auto-backup enabled for RGB wallet"),
+            Err(e) => tracing::warn!("Failed to configure VSS backup for RGB wallet: {e}"),
+        }
+    }
+
     save_config(
         &static_state.database,
         kv_store.as_ref(),
@@ -3004,10 +3100,47 @@ pub(crate) async fn start_ldk(
         &master_fingerprint.to_string(),
     )?;
 
-    let rgb_wallet_wrapper = Arc::new(RgbLibWalletWrapper::new(
-        Arc::new(Mutex::new(rgb_wallet)),
-        rgb_online,
-    ));
+    #[allow(unused_mut)]
+    let mut rgb_wallet_wrapper =
+        RgbLibWalletWrapper::new(Arc::new(Mutex::new(rgb_wallet)), rgb_online);
+
+    // Create and store the VssBackupClient for manual backup/info API routes
+    #[cfg(feature = "vss")]
+    if let Some(ref vss_url) = static_state.vss_url {
+        let network: Network = static_state.network.into();
+        let xkey: ExtendedKey = mnemonic
+            .clone()
+            .into_extended_key()
+            .expect("valid mnemonic");
+        let master_xprv_client = &xkey.into_xprv(network).expect("valid xprv");
+        let vss_xprv = master_xprv_client
+            .derive_priv(
+                &Secp256k1_30::new(),
+                &[
+                    ChildNumber::Hardened { index: 535 },
+                    ChildNumber::Hardened { index: 1 },
+                ],
+            )
+            .unwrap();
+        let vss_signing_key = vss_xprv.private_key;
+        let secp = Secp256k1_30::new();
+        let vss_pubkey = vss_signing_key.public_key(&secp);
+        let rgb_store_id = format!("{}_rgb", hex_str(&vss_pubkey.serialize()));
+
+        let client_config = rgb_lib::wallet::vss::VssBackupConfig::new(
+            vss_url.clone(),
+            rgb_store_id,
+            vss_signing_key,
+        )
+        .with_encryption(!static_state.vss_unencrypted);
+
+        match rgb_lib::wallet::vss::VssBackupClient::new(client_config) {
+            Ok(client) => rgb_wallet_wrapper.set_vss_client(client),
+            Err(e) => tracing::warn!("Failed to create VssBackupClient: {e}"),
+        }
+    }
+
+    let rgb_wallet_wrapper = Arc::new(rgb_wallet_wrapper);
 
     // Initialize the OutputSweeper.
     let txes: OutputSpenderTxes = match kv_store.read("", "", OUTPUT_SPENDER_TXES_KEY) {

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -72,11 +72,12 @@ use rgb_lib::{
         secp256k1::Secp256k1 as Secp256k1_30,
         ScriptBuf,
     },
+    keys::WitnessVersion,
     utils::{get_account_data, recipient_id_from_script_buf, script_buf_from_recipient_id},
     wallet::{
         rust_only::{check_indexer_url, AssetColoringInfo, ColoringInfo},
-        DatabaseType, Recipient, SinglesigKeys, TransportEndpoint, Wallet as RgbLibWallet,
-        WalletData, WitnessData,
+        DatabaseType, OnlineOptions, Recipient, SinglesigKeys, TransportEndpoint,
+        Wallet as RgbLibWallet, WalletData, WitnessData,
     },
     AssetSchema, Assignment, BitcoinNetwork, ConsignmentExt, ContractId, Fascia, FileContent,
     RgbTransfer, RgbTxid, WitnessOrd,
@@ -2666,6 +2667,50 @@ impl OutputSpender for RgbOutputSpender {
     }
 }
 
+/// VSS identity derived from the wallet mnemonic.
+///
+/// `signing_key` is used both for sigs-auth against the VSS server and for
+/// deriving per-value encryption keys via HKDF-SHA256. `pubkey_hex` is its
+/// serialized compressed public key in lower-hex; it serves as the LDK
+/// stream's `store_id` directly, and the RGB-wallet stream uses
+/// `{pubkey_hex}_rgb` to avoid key collisions within the same VSS server.
+#[cfg(feature = "vss")]
+struct VssIdentity {
+    signing_key: rgb_lib::bitcoin::secp256k1::SecretKey,
+    pubkey_hex: String,
+}
+
+/// Derive the VSS identity from the wallet mnemonic at `m/535'/1'` — a
+/// hardened child of the node's seed at `m/535'`. Hardened derivation
+/// prevents recovering the node seed from the VSS key, but the mnemonic
+/// compromises both.
+#[cfg(feature = "vss")]
+fn derive_vss_identity(mnemonic: &Mnemonic, network: Network) -> Result<VssIdentity, APIError> {
+    let xkey: ExtendedKey = mnemonic
+        .clone()
+        .into_extended_key()
+        .map_err(|e| APIError::FailedVssInit(format!("VSS identity: invalid mnemonic: {e}")))?;
+    let master_xprv = xkey.into_xprv(network.into()).ok_or_else(|| {
+        APIError::FailedVssInit("VSS identity: failed to derive master xprv for network".into())
+    })?;
+    let secp = Secp256k1_30::new();
+    let vss_xprv = master_xprv
+        .derive_priv(
+            &secp,
+            &[
+                ChildNumber::Hardened { index: 535 },
+                ChildNumber::Hardened { index: 1 },
+            ],
+        )
+        .map_err(|e| APIError::FailedVssInit(format!("VSS identity: derive_priv failed: {e}")))?;
+    let signing_key = vss_xprv.private_key;
+    let pubkey_hex = hex_str(&signing_key.public_key(&secp).serialize());
+    Ok(VssIdentity {
+        signing_key,
+        pubkey_hex,
+    })
+}
+
 pub(crate) async fn start_ldk(
     app_state: Arc<AppState>,
     mnemonic: Mnemonic,
@@ -2678,40 +2723,46 @@ pub(crate) async fn start_ldk(
         &static_state.database,
     )));
 
-    // Initialize VSS replication if configured
+    // Initialize VSS replication if configured.
+    //
+    // The same VSS identity is reused across three call sites further down
+    // (RGB-wallet auto-backup config and the rgb-lib VssBackupClient handle),
+    // so derive it once here and pass it around instead of repeating the
+    // derivation. [[derive_vss_identity]]
     #[cfg(feature = "vss")]
-    let kv_store = if let Some(ref vss_url) = static_state.vss_url {
-        let network: Network = static_state.network.into();
-        let xkey: ExtendedKey = mnemonic
-            .clone()
-            .into_extended_key()
-            .expect("valid mnemonic");
-        let master_xprv = &xkey.into_xprv(network).expect("valid xprv");
-        // Derive VSS signing key at m/535'/1' (separate from LDK's m/535')
-        let vss_xprv = master_xprv
-            .derive_priv(
-                &Secp256k1_30::new(),
-                &[
-                    ChildNumber::Hardened { index: 535 },
-                    ChildNumber::Hardened { index: 1 },
-                ],
-            )
-            .unwrap();
-        let vss_signing_key = vss_xprv.private_key;
+    let vss_identity: Option<VssIdentity> = if static_state.vss_url.is_some() {
+        Some(derive_vss_identity(&mnemonic, static_state.network.into())?)
+    } else {
+        None
+    };
 
-        // Derive store_id from the VSS key's public key
-        let secp = Secp256k1_30::new();
-        let vss_pubkey = vss_signing_key.public_key(&secp);
-        let store_id = hex_str(&vss_pubkey.serialize());
-
-        tracing::info!(store_id, "Initializing VSS KV store");
+    #[cfg(feature = "vss")]
+    let kv_store = if let (Some(ref vss_url), Some(ref identity)) =
+        (&static_state.vss_url, &vss_identity)
+    {
+        tracing::info!(store_id = %identity.pubkey_hex, "Initializing VSS KV store");
         let vss_kv_store = Arc::new(
-            crate::vss_kv_store::VssKvStore::new(vss_url.clone(), store_id, vss_signing_key)
-                .map_err(|e| APIError::FailedVssInit(e.to_string()))?,
+            crate::vss_kv_store::VssKvStore::new(
+                vss_url.clone(),
+                identity.pubkey_hex.clone(),
+                identity.signing_key,
+            )
+            .map_err(|e| APIError::FailedVssInit(e.to_string()))?,
         );
+
+        // Acquire the single-writer fence before any reads/writes go out.
+        // This refuses to start if another instance owns this store_id —
+        // see [[single_writer_invariant]] in CLAUDE.md.
+        vss_kv_store
+            .acquire_fence()
+            .map_err(|e| APIError::FailedVssInit(e.to_string()))?;
+
         let synced = Arc::new(SyncedKvStore::with_vss(local_kv_store, vss_kv_store));
 
-        // Auto-restore from VSS if local DB has no channel manager data
+        // Auto-restore from VSS if local DB has no channel manager data.
+        // On failure: abort unlock unless --vss-allow-empty-restore was set.
+        // Starting a recovering node with empty local state can lose funds
+        // (no channel monitors → can't watch chain), so we refuse by default.
         let has_local_data = synced
             .read(
                 CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
@@ -2720,10 +2771,23 @@ pub(crate) async fn start_ldk(
             )
             .is_ok();
         if !has_local_data {
-            match synced.restore_from_vss() {
+            match synced.restore_from_vss(false) {
                 Ok(0) => tracing::info!("No VSS backup data found, starting fresh"),
-                Ok(n) => tracing::info!(keys_restored = n, "Restored LDK state from VSS"),
-                Err(e) => tracing::warn!(error = %e, "VSS restore failed, starting fresh"),
+                Ok(n) => tracing::info!(keys_restored = n, "Restored node KV state from VSS"),
+                Err(e) => {
+                    if static_state.vss_allow_empty_restore {
+                        tracing::warn!(
+                            error = %e,
+                            "VSS restore failed; starting fresh due to --vss-allow-empty-restore"
+                        );
+                    } else {
+                        return Err(APIError::FailedVssInit(format!(
+                            "VSS restore failed: {e}. Pass --vss-allow-empty-restore \
+                             to start with an empty local state instead (UNSAFE if \
+                             you previously had active channels)."
+                        )));
+                    }
+                }
             }
         }
 
@@ -2847,7 +2911,7 @@ pub(crate) async fn start_ldk(
         .into_extended_key()
         .expect("a valid key should have been provided");
     let master_xprv = &xkey
-        .into_xprv(network)
+        .into_xprv(network.into())
         .expect("should be possible to get an extended private key");
     let xprv: Xpriv = master_xprv
         .derive_priv(&Secp256k1_30::new(), &ChildNumber::Hardened { index: 535 })
@@ -2999,10 +3063,20 @@ pub(crate) async fn start_ldk(
 
     // Prepare the RGB wallet
     let mnemonic_str = mnemonic.to_string();
-    let (_, account_xpub_vanilla, _) =
-        get_account_data(&bitcoin_network, &mnemonic_str, false).unwrap();
-    let (_, account_xpub_colored, master_fingerprint) =
-        get_account_data(&bitcoin_network, &mnemonic_str, true).unwrap();
+    let (_, account_xpub_vanilla, _) = get_account_data(
+        &bitcoin_network,
+        &mnemonic_str,
+        false,
+        WitnessVersion::Taproot,
+    )
+    .unwrap();
+    let (_, account_xpub_colored, master_fingerprint) = get_account_data(
+        &bitcoin_network,
+        &mnemonic_str,
+        true,
+        WitnessVersion::Taproot,
+    )
+    .unwrap();
     let data_dir = static_state
         .storage_dir_path
         .clone()
@@ -3014,6 +3088,7 @@ pub(crate) async fn start_ldk(
         vanilla_keychain: None,
         master_fingerprint: master_fingerprint.to_string(),
         mnemonic: Some(mnemonic.to_string()),
+        witness_version: WitnessVersion::Taproot,
     };
     let mut rgb_wallet = tokio::task::spawn_blocking(move || {
         RgbLibWallet::new(
@@ -3036,37 +3111,24 @@ pub(crate) async fn start_ldk(
     })
     .await
     .unwrap();
-    let rgb_online = rgb_wallet.go_online(false, indexer_url.to_string())?;
+    let rgb_online = rgb_wallet.go_online(OnlineOptions {
+        indexer_url: indexer_url.to_string(),
+        skip_consistency_check: false,
+        vanilla_sync_lookback: 20,
+    })?;
 
-    // Configure VSS backup for the RGB wallet if VSS is enabled
+    // Configure VSS backup for the RGB wallet if VSS is enabled. Reuses the
+    // identity derived once at the top of this function — see N3.1 / the
+    // `derive_vss_identity` helper.
     #[cfg(feature = "vss")]
-    if let Some(ref vss_url) = static_state.vss_url {
-        let network: Network = static_state.network.into();
-        let xkey: ExtendedKey = mnemonic
-            .clone()
-            .into_extended_key()
-            .expect("valid mnemonic");
-        let master_xprv_vss = &xkey.into_xprv(network).expect("valid xprv");
-        let vss_xprv = master_xprv_vss
-            .derive_priv(
-                &Secp256k1_30::new(),
-                &[
-                    ChildNumber::Hardened { index: 535 },
-                    ChildNumber::Hardened { index: 1 },
-                ],
-            )
-            .unwrap();
-        let vss_signing_key = vss_xprv.private_key;
-        let secp = Secp256k1_30::new();
-        let vss_pubkey = vss_signing_key.public_key(&secp);
-        let rgb_store_id = format!("{}_rgb", hex_str(&vss_pubkey.serialize()));
-
+    if let (Some(ref vss_url), Some(ref identity)) = (&static_state.vss_url, &vss_identity) {
+        let rgb_store_id = format!("{}_rgb", identity.pubkey_hex);
         let vss_config = rgb_lib::wallet::vss::VssBackupConfig::new(
             vss_url.clone(),
             rgb_store_id,
-            vss_signing_key,
+            identity.signing_key,
         )
-        .with_encryption(!static_state.vss_unencrypted)
+        .with_encryption(true)
         .with_auto_backup(true);
 
         match rgb_wallet.configure_vss_backup(vss_config) {
@@ -3100,47 +3162,16 @@ pub(crate) async fn start_ldk(
         &master_fingerprint.to_string(),
     )?;
 
-    #[allow(unused_mut)]
-    let mut rgb_wallet_wrapper =
-        RgbLibWalletWrapper::new(Arc::new(Mutex::new(rgb_wallet)), rgb_online);
-
-    // Create and store the VssBackupClient for manual backup/info API routes
-    #[cfg(feature = "vss")]
-    if let Some(ref vss_url) = static_state.vss_url {
-        let network: Network = static_state.network.into();
-        let xkey: ExtendedKey = mnemonic
-            .clone()
-            .into_extended_key()
-            .expect("valid mnemonic");
-        let master_xprv_client = &xkey.into_xprv(network).expect("valid xprv");
-        let vss_xprv = master_xprv_client
-            .derive_priv(
-                &Secp256k1_30::new(),
-                &[
-                    ChildNumber::Hardened { index: 535 },
-                    ChildNumber::Hardened { index: 1 },
-                ],
-            )
-            .unwrap();
-        let vss_signing_key = vss_xprv.private_key;
-        let secp = Secp256k1_30::new();
-        let vss_pubkey = vss_signing_key.public_key(&secp);
-        let rgb_store_id = format!("{}_rgb", hex_str(&vss_pubkey.serialize()));
-
-        let client_config = rgb_lib::wallet::vss::VssBackupConfig::new(
-            vss_url.clone(),
-            rgb_store_id,
-            vss_signing_key,
-        )
-        .with_encryption(!static_state.vss_unencrypted);
-
-        match rgb_lib::wallet::vss::VssBackupClient::new(client_config) {
-            Ok(client) => rgb_wallet_wrapper.set_vss_client(client),
-            Err(e) => tracing::warn!("Failed to create VssBackupClient: {e}"),
-        }
-    }
-
-    let rgb_wallet_wrapper = Arc::new(rgb_wallet_wrapper);
+    // No second VssBackupClient is constructed here: the manual /vssbackup
+    // and /vssbackupinfo routes use the wallet's own client, retrievable via
+    // `wallet.vss_client()` (R-lib.1 in rgb-lib's PR #31). Keeping a single
+    // client per stream avoids running two tokio runtimes for the same
+    // backups and removes the race between the two clients writing
+    // overlapping state.
+    let rgb_wallet_wrapper = Arc::new(RgbLibWalletWrapper::new(
+        Arc::new(Mutex::new(rgb_wallet)),
+        rgb_online,
+    ));
 
     // Initialize the OutputSweeper.
     let txes: OutputSpenderTxes = match kv_store.read("", "", OUTPUT_SPENDER_TXES_KEY) {

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1243,7 +1243,7 @@ async fn handle_ldk_events(
                     let unlocked_state_copy = unlocked_state.clone();
                     let res = tokio::task::spawn_blocking(move || -> Result<String, String> {
                         let res = unlocked_state_copy
-                            .rgb_send_begin(recipient_map, true, FEE_RATE, 0, None, false)
+                            .rgb_send_begin(recipient_map, true, FEE_RATE, 0, None, false, Some(0))
                             .map_err(|e| e.to_string())?;
                         let fascia_str = fs::read_to_string(&res.details.fascia_path)
                             .map_err(|e| e.to_string())?;
@@ -1458,6 +1458,8 @@ async fn handle_ldk_events(
                             MIN_CHANNEL_CONFIRMATIONS,
                             None,
                             false,
+                            // Final locktime: this colored tx funds an LN channel.
+                            Some(0),
                         )
                         .map_err(|e| e.to_string())?;
                     let fascia_str =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,14 @@ mod routes;
 mod runtime;
 mod sdk;
 mod swap;
+mod synced_kv_store;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 #[cfg(feature = "uniffi")]
 mod uniffi_api;
 mod utils;
+#[cfg(feature = "vss")]
+mod vss_kv_store;
 
 pub use node::{NodeConfig, NodeHandle};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,10 @@ mod rgb;
 mod routes;
 mod runtime;
 mod swap;
+mod synced_kv_store;
 mod utils;
+#[cfg(feature = "vss")]
+mod vss_kv_store;
 
 #[cfg(test)]
 mod test;
@@ -61,6 +64,8 @@ use crate::routes::{
     post_asset_media, refresh_transfers, restore, revoke_token, rgb_invoice, send_btc,
     send_onion_message, send_payment, send_rgb, shutdown, sign_message, sync, taker, unlock,
 };
+#[cfg(feature = "vss")]
+use crate::routes::{vss_backup, vss_backup_info};
 use crate::utils::{start_daemon, AppState, LOGS_DIR};
 
 #[tokio::main]
@@ -171,7 +176,14 @@ pub(crate) async fn app(args: UserArgs) -> Result<(Router, Arc<AppState>), AppEr
         .route("/signmessage", post(sign_message))
         .route("/sync", post(sync))
         .route("/taker", post(taker))
-        .route("/unlock", post(unlock))
+        .route("/unlock", post(unlock));
+
+    #[cfg(feature = "vss")]
+    let router = router
+        .route("/vssbackup", post(vss_backup))
+        .route("/vssbackupinfo", get(vss_backup_info));
+
+    let router = router
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(|request: &Request<_>| {

--- a/src/node.rs
+++ b/src/node.rs
@@ -18,6 +18,8 @@ pub struct NodeConfig {
     pub virtual_peer_pubkeys: Vec<bitcoin::secp256k1::PublicKey>,
     pub lsp_base_url: Option<String>,
     pub lsp_bearer_token: Option<String>,
+    pub vss_url: Option<String>,
+    pub vss_unencrypted: bool,
 }
 
 #[derive(Clone)]
@@ -48,6 +50,8 @@ impl NodeHandle {
             virtual_peer_pubkeys: config.virtual_peer_pubkeys,
             lsp_base_url: config.lsp_base_url,
             lsp_bearer_token: config.lsp_bearer_token,
+            vss_url: config.vss_url,
+            vss_unencrypted: config.vss_unencrypted,
         };
         let state = start_daemon(&args).await?;
         Ok(Self { state })

--- a/src/node.rs
+++ b/src/node.rs
@@ -19,7 +19,7 @@ pub struct NodeConfig {
     pub lsp_base_url: Option<String>,
     pub lsp_bearer_token: Option<String>,
     pub vss_url: Option<String>,
-    pub vss_unencrypted: bool,
+    pub vss_allow_empty_restore: bool,
 }
 
 #[derive(Clone)]
@@ -51,7 +51,7 @@ impl NodeHandle {
             lsp_base_url: config.lsp_base_url,
             lsp_bearer_token: config.lsp_bearer_token,
             vss_url: config.vss_url,
-            vss_unencrypted: config.vss_unencrypted,
+            vss_allow_empty_restore: config.vss_allow_empty_restore,
         };
         let state = start_daemon(&args).await?;
         Ok(Self { state })

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -359,11 +359,23 @@ impl UnlockedAppState {
 pub(crate) struct RgbLibWalletWrapper {
     pub(crate) wallet: Arc<Mutex<RgbLibWallet>>,
     pub(crate) online: Online,
+    #[cfg(feature = "vss")]
+    pub(crate) vss_client: Option<Arc<rgb_lib::wallet::vss::VssBackupClient>>,
 }
 
 impl RgbLibWalletWrapper {
     pub(crate) fn new(wallet: Arc<Mutex<RgbLibWallet>>, online: Online) -> Self {
-        RgbLibWalletWrapper { wallet, online }
+        RgbLibWalletWrapper {
+            wallet,
+            online,
+            #[cfg(feature = "vss")]
+            vss_client: None,
+        }
+    }
+
+    #[cfg(feature = "vss")]
+    pub(crate) fn set_vss_client(&mut self, client: rgb_lib::wallet::vss::VssBackupClient) {
+        self.vss_client = Some(Arc::new(client));
     }
 
     pub(crate) fn get_rgb_wallet(&self) -> MutexGuard<'_, RgbLibWallet> {

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -271,6 +271,7 @@ impl UnlockedAppState {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn rgb_send_begin(
         &self,
         recipient_map: HashMap<String, Vec<Recipient>>,
@@ -279,6 +280,7 @@ impl UnlockedAppState {
         min_confirmations: u8,
         expiration_timestamp: Option<u64>,
         dry_run: bool,
+        lock_time: Option<u32>,
     ) -> Result<SendBeginResult, RgbLibError> {
         self.rgb_wallet_wrapper.send_begin(
             recipient_map,
@@ -287,6 +289,7 @@ impl UnlockedAppState {
             min_confirmations,
             expiration_timestamp,
             dry_run,
+            lock_time,
         )
     }
 
@@ -647,9 +650,11 @@ impl RgbLibWalletWrapper {
             fee_rate,
             min_confirmations,
             expiration_timestamp,
+            None,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn send_begin(
         &self,
         recipient_map: HashMap<String, Vec<Recipient>>,
@@ -658,6 +663,7 @@ impl RgbLibWalletWrapper {
         min_confirmations: u8,
         expiration_timestamp: Option<u64>,
         dry_run: bool,
+        lock_time: Option<u32>,
     ) -> Result<SendBeginResult, RgbLibError> {
         self.get_rgb_wallet().send_begin(
             self.online,
@@ -667,6 +673,7 @@ impl RgbLibWalletWrapper {
             min_confirmations,
             expiration_timestamp,
             dry_run,
+            lock_time,
         )
     }
 
@@ -678,7 +685,7 @@ impl RgbLibWalletWrapper {
         skip_sync: bool,
     ) -> Result<String, RgbLibError> {
         self.get_rgb_wallet()
-            .send_btc(self.online, address, amount, fee_rate, skip_sync)
+            .send_btc(self.online, address, amount, fee_rate, skip_sync, None)
     }
 
     pub(crate) fn send_btc_begin(
@@ -687,8 +694,17 @@ impl RgbLibWalletWrapper {
         amount: u64,
         fee_rate: u64,
     ) -> Result<String, RgbLibError> {
-        self.get_rgb_wallet()
-            .send_btc_begin(self.online, address, amount, fee_rate, false, false)
+        // Funding-only path: pin a final (zero) locktime so LDK accepts the
+        // vanilla channel funding tx regardless of the node's chain-tip lag.
+        self.get_rgb_wallet().send_btc_begin(
+            self.online,
+            address,
+            amount,
+            fee_rate,
+            false,
+            false,
+            Some(0),
+        )
     }
 
     pub(crate) fn send_btc_end(&self, signed_psbt: String) -> Result<String, RgbLibError> {

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -261,7 +261,6 @@ impl UnlockedAppState {
         fee_rate: u64,
         min_confirmations: u8,
         expiration_timestamp: Option<u64>,
-        skip_sync: bool,
     ) -> Result<OperationResult, RgbLibError> {
         self.rgb_wallet_wrapper.send(
             recipient_map,
@@ -269,7 +268,6 @@ impl UnlockedAppState {
             fee_rate,
             min_confirmations,
             expiration_timestamp,
-            skip_sync,
         )
     }
 
@@ -359,27 +357,24 @@ impl UnlockedAppState {
 pub(crate) struct RgbLibWalletWrapper {
     pub(crate) wallet: Arc<Mutex<RgbLibWallet>>,
     pub(crate) online: Online,
-    #[cfg(feature = "vss")]
-    pub(crate) vss_client: Option<Arc<rgb_lib::wallet::vss::VssBackupClient>>,
 }
 
 impl RgbLibWalletWrapper {
     pub(crate) fn new(wallet: Arc<Mutex<RgbLibWallet>>, online: Online) -> Self {
-        RgbLibWalletWrapper {
-            wallet,
-            online,
-            #[cfg(feature = "vss")]
-            vss_client: None,
-        }
-    }
-
-    #[cfg(feature = "vss")]
-    pub(crate) fn set_vss_client(&mut self, client: rgb_lib::wallet::vss::VssBackupClient) {
-        self.vss_client = Some(Arc::new(client));
+        RgbLibWalletWrapper { wallet, online }
     }
 
     pub(crate) fn get_rgb_wallet(&self) -> MutexGuard<'_, RgbLibWallet> {
         self.wallet.lock().unwrap()
+    }
+
+    /// Returns the wallet's configured `VssBackupClient`, if any. This is the
+    /// client constructed by `configure_vss_backup` in `start_ldk`; callers
+    /// (e.g. the manual `/vssbackup` route) reuse it instead of building a
+    /// duplicate with the same configuration.
+    #[cfg(feature = "vss")]
+    pub(crate) fn vss_client(&self) -> Option<Arc<rgb_lib::wallet::vss::VssBackupClient>> {
+        self.get_rgb_wallet().vss_client()
     }
 
     pub(crate) fn bitcoin_network(&self) -> BitcoinNetwork {
@@ -644,7 +639,6 @@ impl RgbLibWalletWrapper {
         fee_rate: u64,
         min_confirmations: u8,
         expiration_timestamp: Option<u64>,
-        skip_sync: bool,
     ) -> Result<OperationResult, RgbLibError> {
         self.get_rgb_wallet().send(
             self.online,
@@ -653,7 +647,6 @@ impl RgbLibWalletWrapper {
             fee_rate,
             min_confirmations,
             expiration_timestamp,
-            skip_sync,
         )
     }
 
@@ -695,17 +688,15 @@ impl RgbLibWalletWrapper {
         fee_rate: u64,
     ) -> Result<String, RgbLibError> {
         self.get_rgb_wallet()
-            .send_btc_begin(self.online, address, amount, fee_rate, false)
+            .send_btc_begin(self.online, address, amount, fee_rate, false, false)
     }
 
     pub(crate) fn send_btc_end(&self, signed_psbt: String) -> Result<String, RgbLibError> {
-        self.get_rgb_wallet()
-            .send_btc_end(self.online, signed_psbt, false)
+        self.get_rgb_wallet().send_btc_end(self.online, signed_psbt)
     }
 
     pub(crate) fn send_end(&self, signed_psbt: String) -> Result<OperationResult, RgbLibError> {
-        self.get_rgb_wallet()
-            .send_end(self.online, signed_psbt, false)
+        self.get_rgb_wallet().send_end(self.online, signed_psbt)
     }
 
     pub(crate) fn sign_psbt(&self, unsigned_psbt: String) -> Result<String, RgbLibError> {
@@ -713,7 +704,13 @@ impl RgbLibWalletWrapper {
     }
 
     pub(crate) fn sync(&self) -> Result<(), RgbLibError> {
-        self.get_rgb_wallet().sync(self.online)
+        self.get_rgb_wallet().sync(
+            self.online,
+            rgb_lib::wallet::SyncOptions {
+                keychain: rgb_lib::wallet::SyncKeychain::Colored,
+                strategy: rgb_lib::wallet::SyncStrategy::FastSync,
+            },
+        )
     }
 
     pub(crate) fn update_witnesses(

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -3786,6 +3786,8 @@ pub(crate) async fn open_channel(
                         MIN_CHANNEL_CONFIRMATIONS,
                         None,
                         true,
+                        // Channel-funding dry run: mirror the real funding tx's final locktime.
+                        Some(0),
                     )
                 })
                 .await

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -4489,3 +4489,63 @@ pub(crate) async fn unlock(
     })
     .await
 }
+
+#[cfg(feature = "vss")]
+pub(crate) async fn vss_backup(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<serde_json::Value>, APIError> {
+    let guard = state.check_unlocked().await?;
+    let unlocked_state = guard.as_ref().unwrap().clone();
+    drop(guard);
+
+    let vss_client = unlocked_state
+        .rgb_wallet_wrapper
+        .vss_client
+        .as_ref()
+        .ok_or_else(|| APIError::Unexpected("VSS is not configured".to_string()))?
+        .clone();
+
+    let wrapper = unlocked_state.rgb_wallet_wrapper.clone();
+    let version = tokio::task::spawn_blocking(move || {
+        let wallet = wrapper.get_rgb_wallet();
+        let rt = vss_client.handle().clone();
+        rt.block_on(wallet.vss_backup(&vss_client))
+    })
+    .await
+    .map_err(|e| APIError::Unexpected(format!("VSS backup task failed: {e}")))?
+    .map_err(|e| APIError::Unexpected(format!("VSS backup failed: {e}")))?;
+
+    Ok(Json(serde_json::json!({ "version": version })))
+}
+
+#[cfg(feature = "vss")]
+pub(crate) async fn vss_backup_info(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<serde_json::Value>, APIError> {
+    let guard = state.check_unlocked().await?;
+    let unlocked_state = guard.as_ref().unwrap().clone();
+    drop(guard);
+
+    let vss_client = unlocked_state
+        .rgb_wallet_wrapper
+        .vss_client
+        .as_ref()
+        .ok_or_else(|| APIError::Unexpected("VSS is not configured".to_string()))?
+        .clone();
+
+    let wrapper = unlocked_state.rgb_wallet_wrapper.clone();
+    let info = tokio::task::spawn_blocking(move || {
+        let wallet = wrapper.get_rgb_wallet();
+        let rt = vss_client.handle().clone();
+        rt.block_on(wallet.vss_backup_info(&vss_client))
+    })
+    .await
+    .map_err(|e| APIError::Unexpected(format!("VSS backup info task failed: {e}")))?
+    .map_err(|e| APIError::Unexpected(format!("VSS backup info failed: {e}")))?;
+
+    Ok(Json(serde_json::json!({
+        "backup_exists": info.backup_exists,
+        "server_version": info.server_version,
+        "backup_required": info.backup_required,
+    })))
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1121,7 +1121,6 @@ pub(crate) struct SendRgbRequest {
     pub(crate) min_confirmations: u8,
     pub(crate) expiration_timestamp: Option<u64>,
     pub(crate) recipient_map: HashMap<String, Vec<Recipient>>,
-    pub(crate) skip_sync: bool,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1235,7 +1234,8 @@ pub(crate) enum TransactionType {
     RgbSend,
     Drain,
     CreateUtxos,
-    User,
+    SendBtc,
+    Incoming,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1262,12 +1262,14 @@ pub(crate) enum TransferKind {
     ReceiveWitness,
     Send,
     Inflation,
+    Burn,
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 pub(crate) enum TransferStatus {
     Initiated,
     WaitingCounterparty,
+    WaitingSafeHeight,
     WaitingConfirmations,
     Settled,
     Failed,
@@ -2327,7 +2329,13 @@ pub(crate) async fn init(
             Some(mnemonic) => Mnemonic::from_str(&mnemonic)
                 .map_err(|e| APIError::InvalidMnemonic(e.to_string()))?
                 .to_string(),
-            None => generate_keys(state.static_state.network).mnemonic,
+            None => {
+                generate_keys(
+                    state.static_state.network,
+                    rgb_lib::keys::WitnessVersion::Taproot,
+                )
+                .mnemonic
+            }
         };
 
         encrypt_and_save_mnemonic(
@@ -2922,7 +2930,8 @@ pub(crate) async fn list_transactions(
                 rgb_lib::wallet::TransactionType::RgbSend => TransactionType::RgbSend,
                 rgb_lib::wallet::TransactionType::Drain => TransactionType::Drain,
                 rgb_lib::wallet::TransactionType::CreateUtxos => TransactionType::CreateUtxos,
-                rgb_lib::wallet::TransactionType::User => TransactionType::User,
+                rgb_lib::wallet::TransactionType::SendBtc => TransactionType::SendBtc,
+                rgb_lib::wallet::TransactionType::Incoming => TransactionType::Incoming,
             },
             txid: tx.txid,
             received: tx.received,
@@ -2954,6 +2963,7 @@ pub(crate) async fn list_transfers(
             status: match transfer.status {
                 rgb_lib::TransferStatus::Initiated => TransferStatus::Initiated,
                 rgb_lib::TransferStatus::WaitingCounterparty => TransferStatus::WaitingCounterparty,
+                rgb_lib::TransferStatus::WaitingSafeHeight => TransferStatus::WaitingSafeHeight,
                 rgb_lib::TransferStatus::WaitingConfirmations => {
                     TransferStatus::WaitingConfirmations
                 }
@@ -2968,6 +2978,7 @@ pub(crate) async fn list_transfers(
                 rgb_lib::wallet::TransferKind::ReceiveWitness => TransferKind::ReceiveWitness,
                 rgb_lib::wallet::TransferKind::Send => TransferKind::Send,
                 rgb_lib::wallet::TransferKind::Inflation => TransferKind::Inflation,
+                rgb_lib::wallet::TransferKind::Burn => TransferKind::Burn,
             },
             txid: transfer.txid,
             recipient_id: transfer.recipient_id,
@@ -4347,7 +4358,6 @@ pub(crate) async fn send_rgb(
                 payload.fee_rate,
                 payload.min_confirmations,
                 payload.expiration_timestamp,
-                payload.skip_sync,
             )
         })
         .await
@@ -4500,10 +4510,8 @@ pub(crate) async fn vss_backup(
 
     let vss_client = unlocked_state
         .rgb_wallet_wrapper
-        .vss_client
-        .as_ref()
-        .ok_or_else(|| APIError::Unexpected("VSS is not configured".to_string()))?
-        .clone();
+        .vss_client()
+        .ok_or_else(|| APIError::Unexpected("VSS is not configured".to_string()))?;
 
     let wrapper = unlocked_state.rgb_wallet_wrapper.clone();
     let version = tokio::task::spawn_blocking(move || {
@@ -4528,10 +4536,8 @@ pub(crate) async fn vss_backup_info(
 
     let vss_client = unlocked_state
         .rgb_wallet_wrapper
-        .vss_client
-        .as_ref()
-        .ok_or_else(|| APIError::Unexpected("VSS is not configured".to_string()))?
-        .clone();
+        .vss_client()
+        .ok_or_else(|| APIError::Unexpected("VSS is not configured".to_string()))?;
 
     let wrapper = unlocked_state.rgb_wallet_wrapper.clone();
     let info = tokio::task::spawn_blocking(move || {
@@ -4543,9 +4549,12 @@ pub(crate) async fn vss_backup_info(
     .map_err(|e| APIError::Unexpected(format!("VSS backup info task failed: {e}")))?
     .map_err(|e| APIError::Unexpected(format!("VSS backup info failed: {e}")))?;
 
+    let pending_kv_writes = unlocked_state.kv_store.pending_remote_writes();
+
     Ok(Json(serde_json::json!({
         "backup_exists": info.backup_exists,
         "server_version": info.server_version,
         "backup_required": info.backup_required,
+        "pending_kv_writes": pending_kv_writes,
     })))
 }

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -2503,6 +2503,8 @@ pub(crate) async fn open_channel(
                 MIN_CHANNEL_CONFIRMATIONS,
                 None,
                 true,
+                // Channel-funding dry run: mirror the real funding tx's final locktime.
+                Some(0),
             )
         })
         .await

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -355,7 +355,6 @@ pub(crate) struct SendRgbRequestData {
     pub(crate) donation: bool,
     pub(crate) fee_rate: u64,
     pub(crate) min_confirmations: u8,
-    pub(crate) skip_sync: bool,
     pub(crate) recipient_groups: Vec<AssetRecipientsInput>,
 }
 
@@ -728,7 +727,8 @@ pub(crate) enum TransactionType {
     RgbSend,
     Drain,
     CreateUtxos,
-    User,
+    SendBtc,
+    Incoming,
 }
 
 #[derive(Debug, PartialEq)]
@@ -738,12 +738,14 @@ pub(crate) enum TransferKind {
     ReceiveWitness,
     Send,
     Inflation,
+    Burn,
 }
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum TransferStatus {
     Initiated,
     WaitingCounterparty,
+    WaitingSafeHeight,
     WaitingConfirmations,
     Settled,
     Failed,
@@ -1549,7 +1551,6 @@ pub(crate) async fn send_rgb(
     donation: bool,
     fee_rate: u64,
     min_confirmations: u8,
-    skip_sync: bool,
 ) -> Result<SendRgbData, APIError> {
     let guard = check_unlocked(&state).await?;
     let unlocked_state = guard.as_ref().unwrap();
@@ -1560,14 +1561,7 @@ pub(crate) async fn send_rgb(
 
     let unlocked_state_copy = unlocked_state.clone();
     let send_result = tokio::task::spawn_blocking(move || {
-        unlocked_state_copy.rgb_send(
-            recipient_map,
-            donation,
-            fee_rate,
-            min_confirmations,
-            None,
-            skip_sync,
-        )
+        unlocked_state_copy.rgb_send(recipient_map, donation, fee_rate, min_confirmations, None)
     })
     .await
     .unwrap()?;
@@ -1620,7 +1614,6 @@ pub(crate) async fn send_rgb_from_groups(
         request.donation,
         request.fee_rate,
         request.min_confirmations,
-        request.skip_sync,
     )
     .await
 }
@@ -1639,7 +1632,13 @@ pub(crate) async fn init(
         Some(mnemonic) => Mnemonic::from_str(&mnemonic)
             .map_err(|e| APIError::InvalidMnemonic(e.to_string()))?
             .to_string(),
-        None => generate_keys(state.static_state.network).mnemonic,
+        None => {
+            generate_keys(
+                state.static_state.network,
+                rgb_lib::keys::WitnessVersion::Taproot,
+            )
+            .mnemonic
+        }
     };
 
     encrypt_and_save_mnemonic(password, mnemonic.clone(), &state.static_state.database)?;
@@ -3697,7 +3696,8 @@ pub(crate) async fn list_transactions(
                 rgb_lib::wallet::TransactionType::RgbSend => TransactionType::RgbSend,
                 rgb_lib::wallet::TransactionType::Drain => TransactionType::Drain,
                 rgb_lib::wallet::TransactionType::CreateUtxos => TransactionType::CreateUtxos,
-                rgb_lib::wallet::TransactionType::User => TransactionType::User,
+                rgb_lib::wallet::TransactionType::SendBtc => TransactionType::SendBtc,
+                rgb_lib::wallet::TransactionType::Incoming => TransactionType::Incoming,
             },
             txid: tx.txid,
             received: tx.received,
@@ -3729,6 +3729,7 @@ pub(crate) async fn list_transfers(
             status: match transfer.status {
                 rgb_lib::TransferStatus::Initiated => TransferStatus::Initiated,
                 rgb_lib::TransferStatus::WaitingCounterparty => TransferStatus::WaitingCounterparty,
+                rgb_lib::TransferStatus::WaitingSafeHeight => TransferStatus::WaitingSafeHeight,
                 rgb_lib::TransferStatus::WaitingConfirmations => {
                     TransferStatus::WaitingConfirmations
                 }
@@ -3743,6 +3744,7 @@ pub(crate) async fn list_transfers(
                 rgb_lib::wallet::TransferKind::ReceiveWitness => TransferKind::ReceiveWitness,
                 rgb_lib::wallet::TransferKind::Send => TransferKind::Send,
                 rgb_lib::wallet::TransferKind::Inflation => TransferKind::Inflation,
+                rgb_lib::wallet::TransferKind::Burn => TransferKind::Burn,
             },
             txid: transfer.txid,
             recipient_id: transfer.recipient_id,

--- a/src/synced_kv_store.rs
+++ b/src/synced_kv_store.rs
@@ -1,0 +1,158 @@
+use std::sync::Arc;
+
+use bitcoin::io;
+use lightning::util::persist::KVStoreSync;
+
+use crate::kv_store::SeaOrmKvStore;
+
+/// KVStore implementation that writes to local SQLite and optionally replicates
+/// to a remote VSS server. Reads always go to the local store for speed.
+///
+/// When `remote` is `None`, this behaves identically to a plain `SeaOrmKvStore`.
+pub struct SyncedKvStore {
+    local: Arc<SeaOrmKvStore>,
+    #[cfg(feature = "vss")]
+    remote: Option<Arc<crate::vss_kv_store::VssKvStore>>,
+}
+
+impl SyncedKvStore {
+    /// Creates a SyncedKvStore with local-only storage (no VSS replication).
+    pub fn local_only(local: Arc<SeaOrmKvStore>) -> Self {
+        Self {
+            local,
+            #[cfg(feature = "vss")]
+            remote: None,
+        }
+    }
+
+    /// Creates a SyncedKvStore with local storage and VSS replication.
+    #[cfg(feature = "vss")]
+    pub fn with_vss(
+        local: Arc<SeaOrmKvStore>,
+        remote: Arc<crate::vss_kv_store::VssKvStore>,
+    ) -> Self {
+        Self {
+            local,
+            remote: Some(remote),
+        }
+    }
+
+    /// Restores all key-value pairs from VSS into the local store.
+    ///
+    /// Downloads all data from the remote VSS server and writes each entry
+    /// into the local SQLite database. Used for disaster recovery on a fresh device.
+    ///
+    /// Returns the number of keys restored, or 0 if VSS is not configured.
+    #[cfg(feature = "vss")]
+    pub fn restore_from_vss(&self) -> Result<usize, io::Error> {
+        let Some(ref remote) = self.remote else {
+            return Ok(0);
+        };
+
+        tracing::info!("Starting restore from VSS...");
+        let items = remote.download_all()?;
+        let total = items.len();
+        let mut restored = 0usize;
+
+        for (vss_key_str, value) in items {
+            if let Some((primary_ns, secondary_ns, key)) =
+                crate::vss_kv_store::parse_vss_key(&vss_key_str)
+            {
+                if let Err(e) = self.local.write(&primary_ns, &secondary_ns, &key, value) {
+                    tracing::warn!(
+                        vss_key = vss_key_str,
+                        error = %e,
+                        "Failed to restore key to local store"
+                    );
+                } else {
+                    restored += 1;
+                }
+            } else {
+                tracing::warn!(
+                    vss_key = vss_key_str,
+                    "Skipping unrecognized VSS key format"
+                );
+            }
+        }
+
+        tracing::info!(restored, total, "VSS restore complete");
+        Ok(restored)
+    }
+}
+
+impl KVStoreSync for SyncedKvStore {
+    fn read(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+    ) -> Result<Vec<u8>, io::Error> {
+        // Always read from local store
+        self.local.read(primary_namespace, secondary_namespace, key)
+    }
+
+    fn write(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        buf: Vec<u8>,
+    ) -> Result<(), io::Error> {
+        // Write to local first (must succeed)
+        self.local
+            .write(primary_namespace, secondary_namespace, key, buf.clone())?;
+
+        // Replicate to VSS (best-effort, log errors but don't fail)
+        #[cfg(feature = "vss")]
+        if let Some(ref remote) = self.remote {
+            if let Err(e) = remote.write(primary_namespace, secondary_namespace, key, buf) {
+                tracing::warn!(
+                    primary_namespace,
+                    secondary_namespace,
+                    key,
+                    error = %e,
+                    "VSS replication write failed"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn remove(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        lazy: bool,
+    ) -> Result<(), io::Error> {
+        // Remove from local first (must succeed)
+        self.local
+            .remove(primary_namespace, secondary_namespace, key, lazy)?;
+
+        // Replicate removal to VSS (best-effort)
+        #[cfg(feature = "vss")]
+        if let Some(ref remote) = self.remote {
+            if let Err(e) = remote.remove(primary_namespace, secondary_namespace, key, lazy) {
+                tracing::warn!(
+                    primary_namespace,
+                    secondary_namespace,
+                    key,
+                    error = %e,
+                    "VSS replication remove failed"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn list(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+    ) -> Result<Vec<String>, io::Error> {
+        // Always list from local store
+        self.local.list(primary_namespace, secondary_namespace)
+    }
+}

--- a/src/synced_kv_store.rs
+++ b/src/synced_kv_store.rs
@@ -5,14 +5,38 @@ use lightning::util::persist::KVStoreSync;
 
 use crate::kv_store::SeaOrmKvStore;
 
-/// KVStore implementation that writes to local SQLite and optionally replicates
-/// to a remote VSS server. Reads always go to the local store for speed.
+/// Maximum number of writes the pending-retry queue is allowed to hold.
 ///
-/// When `remote` is `None`, this behaves identically to a plain `SeaOrmKvStore`.
+/// When this cap is reached we drop the oldest entry per key (newest write
+/// wins for any given key — channel-monitor persistence is last-write-wins
+/// anyway). Bounds memory under prolonged VSS outage while still preserving
+/// the latest state for each touched key.
+#[cfg(feature = "vss")]
+const PENDING_QUEUE_CAP: usize = 1000;
+
+/// How many pending entries to attempt to drain on each successful VSS write.
+#[cfg(feature = "vss")]
+const PENDING_DRAIN_BATCH: usize = 16;
+
+/// KVStore wrapper that writes to the local SeaORM store and (optionally)
+/// replicates to a remote VSS server. Reads always go to the local store for
+/// latency. When `remote` is `None`, this behaves identically to a plain
+/// `SeaOrmKvStore`.
 pub struct SyncedKvStore {
     local: Arc<SeaOrmKvStore>,
     #[cfg(feature = "vss")]
     remote: Option<Arc<crate::vss_kv_store::VssKvStore>>,
+    /// VSS-replication failures park here so a transient outage doesn't lose
+    /// state from the remote backup. Each successful VSS write drains up to
+    /// [`PENDING_DRAIN_BATCH`] entries; the map is capped at
+    /// [`PENDING_QUEUE_CAP`].
+    ///
+    /// Key: encoded VSS key string (same format as `vss_key()`).
+    /// Value: bytes that should be re-written to VSS. `None` represents a
+    /// pending removal (so a later write to the same key supersedes the
+    /// removal correctly).
+    #[cfg(feature = "vss")]
+    pending: Arc<std::sync::Mutex<std::collections::HashMap<String, Option<Vec<u8>>>>>,
 }
 
 impl SyncedKvStore {
@@ -22,6 +46,8 @@ impl SyncedKvStore {
             local,
             #[cfg(feature = "vss")]
             remote: None,
+            #[cfg(feature = "vss")]
+            pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
     }
 
@@ -34,20 +60,49 @@ impl SyncedKvStore {
         Self {
             local,
             remote: Some(remote),
+            pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
     }
 
     /// Restores all key-value pairs from VSS into the local store.
     ///
-    /// Downloads all data from the remote VSS server and writes each entry
-    /// into the local SQLite database. Used for disaster recovery on a fresh device.
+    /// `force = false` is the safe default and returns `Ok(0)` if the local
+    /// store already has a channel-manager key (i.e. it's not a fresh
+    /// device). `force = true` overwrites local state with whatever VSS holds
+    /// and is intended only for explicit operator use.
     ///
-    /// Returns the number of keys restored, or 0 if VSS is not configured.
+    /// Returns the number of keys restored, or 0 if VSS is not configured or
+    /// the local store is already populated.
     #[cfg(feature = "vss")]
-    pub fn restore_from_vss(&self) -> Result<usize, io::Error> {
+    pub(crate) fn restore_from_vss(&self, force: bool) -> Result<usize, io::Error> {
         let Some(ref remote) = self.remote else {
             return Ok(0);
         };
+
+        if !force {
+            // Guard: refuse to clobber an already-populated local store.
+            // The caller in `start_ldk` also performs this check, but a
+            // belt-and-suspenders guard makes this API hard to misuse.
+            use lightning::util::persist::{
+                CHANNEL_MANAGER_PERSISTENCE_KEY, CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+                CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
+            };
+            if self
+                .local
+                .read(
+                    CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+                    CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
+                    CHANNEL_MANAGER_PERSISTENCE_KEY,
+                )
+                .is_ok()
+            {
+                tracing::info!(
+                    "VSS restore skipped: local store already has channel manager data \
+                     (pass force=true to override)"
+                );
+                return Ok(0);
+            }
+        }
 
         tracing::info!("Starting restore from VSS...");
         let items = remote.download_all()?;
@@ -78,6 +133,77 @@ impl SyncedKvStore {
         tracing::info!(restored, total, "VSS restore complete");
         Ok(restored)
     }
+
+    /// Returns the number of pending VSS-replication entries that failed and
+    /// are awaiting retry. Surfaced via `/vssbackupinfo` so operators can
+    /// alert on persistent backup-staleness.
+    #[cfg(feature = "vss")]
+    pub fn pending_remote_writes(&self) -> usize {
+        self.pending.lock().unwrap().len()
+    }
+
+    /// Enqueue a failed VSS replication for later retry.
+    #[cfg(feature = "vss")]
+    fn enqueue_pending(&self, vss_key: String, value: Option<Vec<u8>>) {
+        let mut pending = self.pending.lock().unwrap();
+        if pending.len() >= PENDING_QUEUE_CAP && !pending.contains_key(&vss_key) {
+            // Drop one entry to make room. HashMap iteration order is
+            // arbitrary; for "drop newest of the same key" we still want the
+            // newer value for that key, so we just evict an arbitrary other
+            // key. Logged as a metric so the operator can alert on it.
+            if let Some(evict) = pending.keys().next().cloned() {
+                pending.remove(&evict);
+                tracing::warn!(
+                    evicted_key = evict,
+                    cap = PENDING_QUEUE_CAP,
+                    "VSS pending-writes queue at cap; evicted an entry to make room"
+                );
+            }
+        }
+        pending.insert(vss_key, value);
+    }
+
+    /// Attempt to drain up to [`PENDING_DRAIN_BATCH`] entries from the
+    /// pending queue. Called opportunistically after each successful VSS
+    /// write. Entries that re-fail are re-queued.
+    #[cfg(feature = "vss")]
+    fn drain_pending(&self) {
+        let Some(ref remote) = self.remote else {
+            return;
+        };
+        let to_retry: Vec<(String, Option<Vec<u8>>)> = {
+            let mut pending = self.pending.lock().unwrap();
+            let take_n = pending.len().min(PENDING_DRAIN_BATCH);
+            let keys: Vec<String> = pending.keys().take(take_n).cloned().collect();
+            keys.into_iter()
+                .filter_map(|k| pending.remove(&k).map(|v| (k, v)))
+                .collect()
+        };
+        if to_retry.is_empty() {
+            return;
+        }
+        let drained = to_retry.len();
+        for (vss_key, value) in to_retry {
+            let parsed = crate::vss_kv_store::parse_vss_key(&vss_key);
+            let Some((primary, secondary, key)) = parsed else {
+                tracing::warn!(vss_key, "Dropping unparseable key from pending queue");
+                continue;
+            };
+            let result = match &value {
+                Some(buf) => remote.write(&primary, &secondary, &key, buf.clone()),
+                None => remote.remove(&primary, &secondary, &key, false),
+            };
+            if let Err(e) = result {
+                tracing::debug!(
+                    vss_key,
+                    error = %e,
+                    "Pending VSS replication still failing; re-queued"
+                );
+                self.enqueue_pending(vss_key, value);
+            }
+        }
+        tracing::debug!(drained, "Drained pending VSS writes");
+    }
 }
 
 impl KVStoreSync for SyncedKvStore {
@@ -102,17 +228,25 @@ impl KVStoreSync for SyncedKvStore {
         self.local
             .write(primary_namespace, secondary_namespace, key, buf.clone())?;
 
-        // Replicate to VSS (best-effort, log errors but don't fail)
+        // Replicate to VSS (best-effort, queue for retry on failure).
         #[cfg(feature = "vss")]
         if let Some(ref remote) = self.remote {
-            if let Err(e) = remote.write(primary_namespace, secondary_namespace, key, buf) {
-                tracing::warn!(
-                    primary_namespace,
-                    secondary_namespace,
-                    key,
-                    error = %e,
-                    "VSS replication write failed"
-                );
+            match remote.write(primary_namespace, secondary_namespace, key, buf.clone()) {
+                Ok(()) => {
+                    self.drain_pending();
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        primary_namespace,
+                        secondary_namespace,
+                        key,
+                        error = %e,
+                        "VSS replication write failed; queued for retry"
+                    );
+                    let vss_key =
+                        crate::vss_kv_store::vss_key(primary_namespace, secondary_namespace, key);
+                    self.enqueue_pending(vss_key, Some(buf));
+                }
             }
         }
 
@@ -130,17 +264,25 @@ impl KVStoreSync for SyncedKvStore {
         self.local
             .remove(primary_namespace, secondary_namespace, key, lazy)?;
 
-        // Replicate removal to VSS (best-effort)
+        // Replicate removal to VSS (best-effort, queue for retry on failure).
         #[cfg(feature = "vss")]
         if let Some(ref remote) = self.remote {
-            if let Err(e) = remote.remove(primary_namespace, secondary_namespace, key, lazy) {
-                tracing::warn!(
-                    primary_namespace,
-                    secondary_namespace,
-                    key,
-                    error = %e,
-                    "VSS replication remove failed"
-                );
+            match remote.remove(primary_namespace, secondary_namespace, key, lazy) {
+                Ok(()) => {
+                    self.drain_pending();
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        primary_namespace,
+                        secondary_namespace,
+                        key,
+                        error = %e,
+                        "VSS replication remove failed; queued for retry"
+                    );
+                    let vss_key =
+                        crate::vss_kv_store::vss_key(primary_namespace, secondary_namespace, key);
+                    self.enqueue_pending(vss_key, None);
+                }
             }
         }
 

--- a/src/test/auth_db_persistence.rs
+++ b/src/test/auth_db_persistence.rs
@@ -30,7 +30,7 @@ fn build_state(storage_dir_path: PathBuf, database: DatabaseConnection) -> AppSt
             lsp_base_url: None,
             lsp_bearer_token: None,
             vss_url: None,
-            vss_unencrypted: false,
+            vss_allow_empty_restore: false,
         }),
         cancel_token: CancellationToken::new(),
         unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/test/auth_db_persistence.rs
+++ b/src/test/auth_db_persistence.rs
@@ -29,6 +29,8 @@ fn build_state(storage_dir_path: PathBuf, database: DatabaseConnection) -> AppSt
             database: Arc::new(database),
             lsp_base_url: None,
             lsp_bearer_token: None,
+            vss_url: None,
+            vss_unencrypted: false,
         }),
         cancel_token: CancellationToken::new(),
         unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/test/lib_core.rs
+++ b/src/test/lib_core.rs
@@ -69,7 +69,6 @@ fn locked_state_does_not_bypass_unlock_guards() {
         donation: false,
         fee_rate: 1,
         min_confirmations: 1,
-        skip_sync: true,
         recipient_groups: vec![],
     });
     assert!(matches!(send_rgb, Err(RlnError::InvalidRequest)));

--- a/src/test/lib_sdk/close_coop_other_side.rs
+++ b/src/test/lib_sdk/close_coop_other_side.rs
@@ -113,7 +113,6 @@ fn close_coop_other_side() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -149,7 +148,6 @@ fn close_coop_other_side() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {

--- a/src/test/lib_sdk/close_coop_standard.rs
+++ b/src/test/lib_sdk/close_coop_standard.rs
@@ -159,7 +159,6 @@ fn close_coop_standard() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -215,7 +214,6 @@ fn close_coop_standard() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -251,7 +249,6 @@ fn close_coop_standard() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {

--- a/src/test/lib_sdk/close_force_standard.rs
+++ b/src/test/lib_sdk/close_force_standard.rs
@@ -115,7 +115,6 @@ fn close_force_standard() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -151,7 +150,6 @@ fn close_force_standard() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {

--- a/src/test/lib_sdk/multi_hop.rs
+++ b/src/test/lib_sdk/multi_hop.rs
@@ -95,7 +95,6 @@ fn multi_hop() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -438,7 +437,6 @@ fn multi_hop() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -474,7 +472,6 @@ fn multi_hop() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -510,7 +507,6 @@ fn multi_hop() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {

--- a/src/test/lib_sdk/openchannel_push_asset_amount.rs
+++ b/src/test/lib_sdk/openchannel_push_asset_amount.rs
@@ -328,7 +328,6 @@ fn openchannel_push_asset_amount() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {

--- a/src/test/lib_sdk/payment.rs
+++ b/src/test/lib_sdk/payment.rs
@@ -384,7 +384,6 @@ fn success() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -420,7 +419,6 @@ fn success() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -459,7 +457,10 @@ fn success() {
             .iter()
             .find(|tx| tx.sent == 128_000)
             .expect("rgb send transaction");
-        assert!(matches!(tx_user.transaction_type, TransactionType::User));
+        assert!(matches!(
+            tx_user.transaction_type,
+            TransactionType::Incoming
+        ));
         assert!(matches!(
             tx_utxos.transaction_type,
             TransactionType::CreateUtxos

--- a/src/test/lib_sdk/restart.rs
+++ b/src/test/lib_sdk/restart.rs
@@ -230,7 +230,6 @@ fn restart() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -266,7 +265,6 @@ fn restart() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {

--- a/src/test/lib_sdk/send_receive.rs
+++ b/src/test/lib_sdk/send_receive.rs
@@ -77,7 +77,6 @@ fn send_receive() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -124,7 +123,6 @@ fn send_receive() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id_2.clone(),
                     recipients: vec![RgbRecipient {
@@ -186,7 +184,6 @@ fn send_receive() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![
                     AssetRecipients {
                         asset_id: asset_id.clone(),
@@ -285,7 +282,6 @@ fn send_receive() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![

--- a/src/test/lib_sdk/swap_roundtrip_buy.rs
+++ b/src/test/lib_sdk/swap_roundtrip_buy.rs
@@ -383,7 +383,6 @@ fn swap_roundtrip_buy() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {
@@ -419,7 +418,6 @@ fn swap_roundtrip_buy() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {

--- a/src/test/lib_sdk/vanilla_payment_on_rgb_channel.rs
+++ b/src/test/lib_sdk/vanilla_payment_on_rgb_channel.rs
@@ -173,7 +173,6 @@ fn vanilla_payment_on_rgb_channel() {
                 donation: true,
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 min_confirmations: 1,
-                skip_sync: false,
                 recipient_groups: vec![AssetRecipients {
                     asset_id: asset_id.clone(),
                     recipients: vec![RgbRecipient {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -97,7 +97,7 @@ impl Default for UserArgs {
             lsp_base_url: None,
             lsp_bearer_token: None,
             vss_url: None,
-            vss_unencrypted: false,
+            vss_allow_empty_restore: false,
         }
     }
 }
@@ -1737,7 +1737,6 @@ async fn send_assets(
             OffsetDateTime::now_utc().unix_timestamp() as u64 + DURATION_SECONDS,
         ),
         recipient_map,
-        skip_sync: false,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node_address}/sendrgb"))

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -96,6 +96,8 @@ impl Default for UserArgs {
             virtual_peer_pubkeys: vec![],
             lsp_base_url: None,
             lsp_bearer_token: None,
+            vss_url: None,
+            vss_unencrypted: false,
         }
     }
 }
@@ -2282,3 +2284,5 @@ mod swap_roundtrip_sell;
 mod upload_asset_media;
 mod vanilla_payment_on_rgb_channel;
 mod virtual_channels;
+#[cfg(feature = "vss")]
+mod vss;

--- a/src/test/payment.rs
+++ b/src/test/payment.rs
@@ -211,7 +211,7 @@ async fn success() {
         .unwrap();
     let tx_utxos = transactions.iter().find(|t| t.sent == 100000000).unwrap();
     let tx_send = transactions.iter().find(|t| t.sent == 128000).unwrap();
-    assert_eq!(tx_user.transaction_type, TransactionType::User);
+    assert_eq!(tx_user.transaction_type, TransactionType::Incoming);
     assert_eq!(tx_utxos.transaction_type, TransactionType::CreateUtxos);
     assert_eq!(tx_send.transaction_type, TransactionType::RgbSend);
     assert!(tx_utxos.confirmation_time.is_some());

--- a/src/test/vss.rs
+++ b/src/test/vss.rs
@@ -1,0 +1,395 @@
+//! VSS integration tests
+//!
+//! Requires a running VSS server: `docker compose --profile vss up -d`
+//! Run with: `cargo test --features vss vss_ -- --nocapture`
+
+#[cfg(feature = "vss")]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use bitcoin::secp256k1::{rand::rngs::OsRng, Secp256k1, SecretKey};
+    use hex::DisplayHex;
+    use lightning::util::persist::KVStoreSync;
+    use sea_orm::{ConnectOptions, Database};
+
+    use crate::kv_store::SeaOrmKvStore;
+    use crate::synced_kv_store::SyncedKvStore;
+    use crate::vss_kv_store::{parse_vss_key, vss_key, VssKvStore};
+
+    const VSS_URL: &str = "http://localhost:8081/vss";
+
+    fn generate_test_keys() -> (SecretKey, String) {
+        let secp = Secp256k1::new();
+        let (secret_key, public_key) = secp.generate_keypair(&mut OsRng);
+        let store_id = format!("rln_test_{}", public_key.serialize()[0..8].as_hex());
+        (secret_key, store_id)
+    }
+
+    fn vss_server_available() -> bool {
+        std::net::TcpStream::connect_timeout(
+            &"127.0.0.1:8081".parse().unwrap(),
+            Duration::from_secs(2),
+        )
+        .is_ok()
+    }
+
+    fn create_test_sqlite() -> Arc<sea_orm::DatabaseConnection> {
+        use rln_migration::MigratorTrait;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.into_path();
+        let db_path = path.join("test_rln_db");
+        let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+        let mut opt = ConnectOptions::new(conn_str);
+        opt.max_connections(1)
+            .connect_timeout(Duration::from_secs(5));
+        let db = crate::runtime::block_on(Database::connect(opt)).expect("test db");
+        crate::runtime::block_on(rln_migration::Migrator::up(&db, None)).expect("migration");
+        Arc::new(db)
+    }
+
+    // --- Unit tests ---
+
+    #[test]
+    fn vss_key_roundtrip() {
+        let cases = vec![
+            ("channel_manager", "", "manager"),
+            ("", "", "inbound_payments"),
+            ("monitors", "funding_txo", "abc123"),
+            ("rgb", "inbound", "hash_pending"),
+        ];
+        for (primary, secondary, key) in cases {
+            let encoded = vss_key(primary, secondary, key);
+            let (p, s, k) = parse_vss_key(&encoded).expect("parse should succeed");
+            assert_eq!(p, primary, "primary mismatch for key={encoded}");
+            assert_eq!(s, secondary, "secondary mismatch for key={encoded}");
+            assert_eq!(k, key, "key mismatch for key={encoded}");
+        }
+    }
+
+    #[test]
+    fn parse_vss_key_rejects_invalid() {
+        assert!(parse_vss_key("no_slashes").is_none());
+        assert!(parse_vss_key("one/slash").is_none());
+        assert!(parse_vss_key("a/b/").is_none()); // empty key
+    }
+
+    // --- Integration tests (require VSS server) ---
+
+    #[test]
+    fn vss_kv_store_crud() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let (signing_key, store_id) = generate_test_keys();
+        let store = VssKvStore::new(VSS_URL.to_string(), store_id, signing_key).expect("vss store");
+
+        let ns = "test_ns";
+        let sub_ns = "sub";
+        let key = "mykey";
+        let data = b"hello vss world".to_vec();
+
+        // Write
+        store
+            .write(ns, sub_ns, key, data.clone())
+            .expect("write should succeed");
+
+        // Read back
+        let read_data = store.read(ns, sub_ns, key).expect("read should succeed");
+        assert_eq!(read_data, data);
+
+        // List
+        let keys = store.list(ns, sub_ns).expect("list should succeed");
+        assert!(keys.contains(&key.to_string()), "list should contain key");
+
+        // Overwrite
+        let data2 = b"updated value".to_vec();
+        store
+            .write(ns, sub_ns, key, data2.clone())
+            .expect("overwrite should succeed");
+        let read_data2 = store.read(ns, sub_ns, key).expect("re-read");
+        assert_eq!(read_data2, data2);
+
+        // Remove
+        store
+            .remove(ns, sub_ns, key, false)
+            .expect("remove should succeed");
+        let err = store.read(ns, sub_ns, key).unwrap_err();
+        assert_eq!(err.kind(), bitcoin::io::ErrorKind::NotFound);
+
+        // List after remove should be empty
+        let keys = store.list(ns, sub_ns).expect("list after remove");
+        assert!(!keys.contains(&key.to_string()));
+    }
+
+    #[test]
+    fn vss_kv_store_multiple_namespaces() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let (signing_key, store_id) = generate_test_keys();
+        let store = VssKvStore::new(VSS_URL.to_string(), store_id, signing_key).expect("vss store");
+
+        // Write to different namespaces (simulating LDK's real usage)
+        store
+            .write("channel_manager", "", "manager", b"cm_data".to_vec())
+            .expect("write cm");
+        store
+            .write(
+                "channel_monitors",
+                "funding_abc",
+                "monitor",
+                b"mon_data".to_vec(),
+            )
+            .expect("write monitor");
+        store
+            .write("", "", "inbound_payments", b"payments".to_vec())
+            .expect("write payments");
+
+        // Read each back
+        assert_eq!(
+            store.read("channel_manager", "", "manager").unwrap(),
+            b"cm_data"
+        );
+        assert_eq!(
+            store
+                .read("channel_monitors", "funding_abc", "monitor")
+                .unwrap(),
+            b"mon_data"
+        );
+        assert_eq!(store.read("", "", "inbound_payments").unwrap(), b"payments");
+
+        // List in specific namespace
+        let cm_keys = store.list("channel_manager", "").unwrap();
+        assert_eq!(cm_keys, vec!["manager"]);
+    }
+
+    #[test]
+    fn vss_kv_store_download_all() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let (signing_key, store_id) = generate_test_keys();
+        let store = VssKvStore::new(VSS_URL.to_string(), store_id, signing_key).expect("vss store");
+
+        // Write several entries
+        let entries = vec![
+            ("ns1", "sub1", "key1", b"value1".to_vec()),
+            ("ns1", "sub2", "key2", b"value2".to_vec()),
+            ("ns2", "", "key3", b"value3".to_vec()),
+            ("", "", "key4", b"value4".to_vec()),
+        ];
+        for (ns, sub, key, val) in &entries {
+            store.write(ns, sub, key, val.clone()).expect("write");
+        }
+
+        // Download all
+        let all = store.download_all().expect("download_all");
+        assert_eq!(all.len(), entries.len());
+
+        // Verify all entries are present (order may differ)
+        for (ns, sub, key, val) in &entries {
+            let vss_k = vss_key(ns, sub, key);
+            let found = all.iter().find(|(k, _)| k == &vss_k);
+            assert!(found.is_some(), "missing key: {vss_k}");
+            assert_eq!(&found.unwrap().1, val, "value mismatch for {vss_k}");
+        }
+    }
+
+    #[test]
+    fn synced_kv_store_backup_restore_cycle() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let (signing_key, store_id) = generate_test_keys();
+
+        // --- Phase 1: Write data through SyncedKvStore (local + VSS) ---
+        let db1 = create_test_sqlite();
+        let local1 = Arc::new(SeaOrmKvStore::from_connection(db1));
+        let vss1 = Arc::new(
+            VssKvStore::new(VSS_URL.to_string(), store_id.clone(), signing_key).expect("vss store"),
+        );
+        let synced1 = SyncedKvStore::with_vss(local1.clone(), vss1);
+
+        // Simulate real LDK data patterns
+        let test_data = vec![
+            ("channel_manager", "", "manager", vec![0xCA; 256]),
+            (
+                "channel_monitors",
+                "funding_tx_001",
+                "monitor",
+                vec![0xBE; 512],
+            ),
+            ("", "", "inbound_payments", vec![0xEF; 128]),
+            ("", "", "outbound_payments", vec![0xAB; 64]),
+            ("scorer", "", "scorer_data", vec![0xCD; 32]),
+        ];
+
+        for (ns, sub, key, val) in &test_data {
+            synced1
+                .write(ns, sub, key, val.clone())
+                .expect("synced write");
+        }
+
+        // Verify local reads work
+        for (ns, sub, key, val) in &test_data {
+            let read = synced1.read(ns, sub, key).expect("local read");
+            assert_eq!(&read, val);
+        }
+
+        // --- Phase 2: Create a FRESH local store + same VSS = simulate new device ---
+        let db2 = create_test_sqlite();
+        let local2 = Arc::new(SeaOrmKvStore::from_connection(db2));
+        let vss2 = Arc::new(
+            VssKvStore::new(VSS_URL.to_string(), store_id, signing_key).expect("vss store 2"),
+        );
+        let synced2 = SyncedKvStore::with_vss(local2.clone(), vss2);
+
+        // Fresh local store should have nothing
+        let err = synced2.read("channel_manager", "", "manager").unwrap_err();
+        assert_eq!(err.kind(), bitcoin::io::ErrorKind::NotFound);
+
+        // --- Phase 3: Restore from VSS ---
+        let restored_count = synced2.restore_from_vss().expect("restore");
+        assert_eq!(restored_count, test_data.len());
+
+        // --- Phase 4: Verify all data matches after restore ---
+        for (ns, sub, key, val) in &test_data {
+            let read = synced2.read(ns, sub, key).expect("post-restore read");
+            assert_eq!(&read, val, "mismatch after restore: {ns}/{sub}/{key}");
+        }
+
+        // List should also work
+        let cm_keys = synced2.list("channel_manager", "").expect("list");
+        assert_eq!(cm_keys, vec!["manager"]);
+    }
+
+    /// Helper to create a minimal wallet zip (required format for VssBackupClient)
+    fn create_test_wallet_zip(fingerprint: &str, payload: &[u8]) -> Vec<u8> {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+
+        let mut buffer = std::io::Cursor::new(Vec::new());
+        {
+            let mut zip = zip::ZipWriter::new(&mut buffer);
+            let opts =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            zip.add_directory(format!("{fingerprint}/"), opts).unwrap();
+            zip.start_file(format!("{fingerprint}/test_data.bin"), opts)
+                .unwrap();
+            zip.write_all(payload).unwrap();
+            zip.finish().unwrap();
+        }
+        buffer.into_inner()
+    }
+
+    #[test]
+    fn vss_backup_client_encrypted_roundtrip() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let (signing_key, store_id) = generate_test_keys();
+        let config =
+            rgb_lib::wallet::vss::VssBackupConfig::new(VSS_URL.to_string(), store_id, signing_key)
+                .with_encryption(true);
+
+        let client = rgb_lib::wallet::vss::VssBackupClient::new(config).expect("encrypted client");
+        assert!(client.encryption_enabled());
+
+        let fingerprint = "a1b2c3d4";
+        let original_payload = b"encrypted secret channel data for testing";
+        let zip_data = create_test_wallet_zip(fingerprint, original_payload);
+
+        let rt = client.handle().clone();
+
+        // Upload encrypted
+        let version = rt
+            .block_on(client.upload_backup(zip_data.clone()))
+            .expect("upload encrypted backup");
+        assert!(version > 0);
+
+        // Download and decrypt
+        let downloaded = rt
+            .block_on(client.download_backup())
+            .expect("download encrypted backup");
+
+        // Verify content matches original zip
+        assert_eq!(downloaded, zip_data);
+
+        // Cleanup
+        rt.block_on(client.delete_backup()).expect("cleanup");
+    }
+
+    #[test]
+    fn vss_backup_client_unencrypted_roundtrip() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let (signing_key, store_id) = generate_test_keys();
+        let config =
+            rgb_lib::wallet::vss::VssBackupConfig::new(VSS_URL.to_string(), store_id, signing_key)
+                .with_encryption(false);
+
+        let client =
+            rgb_lib::wallet::vss::VssBackupClient::new(config).expect("unencrypted client");
+        assert!(!client.encryption_enabled());
+
+        let fingerprint = "e5f6a7b8";
+        let original_payload = b"plaintext channel data for unencrypted backup test";
+        let zip_data = create_test_wallet_zip(fingerprint, original_payload);
+
+        let rt = client.handle().clone();
+
+        // Upload unencrypted (sanitized — fingerprint stripped, bdk_db excluded)
+        let version = rt
+            .block_on(client.upload_backup(zip_data.clone()))
+            .expect("upload unencrypted backup");
+        assert!(version > 0);
+
+        // Download — returns sanitized zip (fingerprint replaced with "wallet/")
+        let downloaded = rt
+            .block_on(client.download_backup())
+            .expect("download unencrypted backup");
+
+        // For unencrypted backups, the zip is sanitized:
+        // - fingerprint dir replaced with "wallet/"
+        // - bdk_db files excluded
+        // So downloaded != original zip, but the test data file should be preserved
+        let reader = std::io::Cursor::new(&downloaded);
+        let mut archive = zip::ZipArchive::new(reader).expect("valid zip");
+
+        let mut found_data = false;
+        for i in 0..archive.len() {
+            let mut entry = archive.by_index(i).unwrap();
+            let name = entry.name().to_string();
+            // Fingerprint should be replaced with "wallet/"
+            assert!(
+                !name.contains(fingerprint),
+                "sanitized zip should not contain original fingerprint, found: {name}"
+            );
+            if name.ends_with("test_data.bin") {
+                found_data = true;
+                let mut buf = Vec::new();
+                std::io::Read::read_to_end(&mut entry, &mut buf).unwrap();
+                assert_eq!(buf, original_payload, "payload content mismatch");
+            }
+        }
+        assert!(found_data, "test_data.bin should be in sanitized zip");
+
+        // Cleanup
+        rt.block_on(client.delete_backup()).expect("cleanup");
+    }
+}

--- a/src/test/vss.rs
+++ b/src/test/vss.rs
@@ -38,7 +38,7 @@ mod tests {
         use rln_migration::MigratorTrait;
 
         let tmp = tempfile::tempdir().expect("tempdir");
-        let path = tmp.into_path();
+        let path = tmp.keep();
         let db_path = path.join("test_rln_db");
         let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
         let mut opt = ConnectOptions::new(conn_str);
@@ -259,7 +259,7 @@ mod tests {
         assert_eq!(err.kind(), bitcoin::io::ErrorKind::NotFound);
 
         // --- Phase 3: Restore from VSS ---
-        let restored_count = synced2.restore_from_vss().expect("restore");
+        let restored_count = synced2.restore_from_vss(true).expect("restore");
         assert_eq!(restored_count, test_data.len());
 
         // --- Phase 4: Verify all data matches after restore ---

--- a/src/test/vss.rs
+++ b/src/test/vss.rs
@@ -77,8 +77,8 @@ mod tests {
 
     // --- Integration tests (require VSS server) ---
 
-    #[test]
-    fn vss_kv_store_crud() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn vss_kv_store_crud() {
         if !vss_server_available() {
             eprintln!("SKIP: VSS server not available at {VSS_URL}");
             return;
@@ -125,8 +125,8 @@ mod tests {
         assert!(!keys.contains(&key.to_string()));
     }
 
-    #[test]
-    fn vss_kv_store_multiple_namespaces() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn vss_kv_store_multiple_namespaces() {
         if !vss_server_available() {
             eprintln!("SKIP: VSS server not available at {VSS_URL}");
             return;
@@ -169,8 +169,8 @@ mod tests {
         assert_eq!(cm_keys, vec!["manager"]);
     }
 
-    #[test]
-    fn vss_kv_store_download_all() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn vss_kv_store_download_all() {
         if !vss_server_available() {
             eprintln!("SKIP: VSS server not available at {VSS_URL}");
             return;
@@ -203,8 +203,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn synced_kv_store_backup_restore_cycle() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn synced_kv_store_backup_restore_cycle() {
         if !vss_server_available() {
             eprintln!("SKIP: VSS server not available at {VSS_URL}");
             return;
@@ -271,6 +271,110 @@ mod tests {
         // List should also work
         let cm_keys = synced2.list("channel_manager", "").expect("list");
         assert_eq!(cm_keys, vec!["manager"]);
+    }
+
+    /// Edge case: VSS server unreachable. Writes must still succeed locally
+    /// (the local store is authoritative) and the failed replication must be
+    /// queued for later retry. Does not require a running VSS server.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn synced_kv_store_degrades_when_vss_unreachable() {
+        let (signing_key, store_id) = generate_test_keys();
+        let local = Arc::new(SeaOrmKvStore::from_connection(create_test_sqlite()));
+        // Nothing is listening here, so every VSS request fails fast.
+        let unreachable = Arc::new(
+            VssKvStore::new("http://127.0.0.1:5/vss".to_string(), store_id, signing_key)
+                .expect("vss store"),
+        );
+        let synced = SyncedKvStore::with_vss(local, unreachable);
+
+        // Local write succeeds even though VSS is down.
+        synced
+            .write("channel_manager", "", "manager", b"cm_data".to_vec())
+            .expect("local write should succeed while VSS is unreachable");
+
+        // Data is immediately readable from the local store.
+        assert_eq!(
+            synced.read("channel_manager", "", "manager").unwrap(),
+            b"cm_data"
+        );
+
+        // The failed replication was queued for retry.
+        assert!(
+            synced.pending_remote_writes() > 0,
+            "failed VSS write should be queued for retry"
+        );
+    }
+
+    /// Edge case: node shutdown and recovery on a fresh device using the
+    /// production default (`force = false`). An empty local store is
+    /// repopulated from VSS; a second restore is a no-op so existing state is
+    /// never clobbered.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn synced_kv_store_recovers_with_default_guard() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        // The restore guard keys off LDK's real channel-manager location, so
+        // store the manager under exactly that namespace/key.
+        use lightning::util::persist::{
+            CHANNEL_MANAGER_PERSISTENCE_KEY, CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+            CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
+        };
+
+        let (signing_key, store_id) = generate_test_keys();
+
+        // Original node: persist some state (local + VSS), then "shut down".
+        let original = SyncedKvStore::with_vss(
+            Arc::new(SeaOrmKvStore::from_connection(create_test_sqlite())),
+            Arc::new(
+                VssKvStore::new(VSS_URL.to_string(), store_id.clone(), signing_key)
+                    .expect("vss store"),
+            ),
+        );
+        let state = vec![
+            (
+                CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+                CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
+                CHANNEL_MANAGER_PERSISTENCE_KEY,
+                vec![0x11; 128],
+            ),
+            (
+                "channel_monitors",
+                "funding_xyz",
+                "monitor",
+                vec![0x22; 256],
+            ),
+        ];
+        for (ns, sub, key, val) in &state {
+            original.write(ns, sub, key, val.clone()).expect("write");
+        }
+        drop(original);
+
+        // Recovery on a fresh device: empty local store, same VSS URL + key.
+        let recovered = SyncedKvStore::with_vss(
+            Arc::new(SeaOrmKvStore::from_connection(create_test_sqlite())),
+            Arc::new(
+                VssKvStore::new(VSS_URL.to_string(), store_id, signing_key).expect("vss store"),
+            ),
+        );
+
+        // Production default (force = false) restores because local is empty.
+        let restored = recovered.restore_from_vss(false).expect("restore");
+        assert_eq!(restored, state.len());
+        for (ns, sub, key, val) in &state {
+            assert_eq!(
+                &recovered.read(ns, sub, key).unwrap(),
+                val,
+                "{ns}/{sub}/{key}"
+            );
+        }
+
+        // Second restore is a no-op: local now holds channel-manager state, so
+        // force = false must refuse to clobber it.
+        let again = recovered.restore_from_vss(false).expect("second restore");
+        assert_eq!(again, 0, "force=false must not re-clobber populated state");
     }
 
     /// Helper to create a minimal wallet zip (required format for VssBackupClient)

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -36,7 +36,7 @@ pub fn mock_locked_app_state() -> TestAppState {
             lsp_base_url: None,
             lsp_bearer_token: None,
             vss_url: None,
-            vss_unencrypted: false,
+            vss_allow_empty_restore: false,
         }),
         cancel_token: CancellationToken::new(),
         unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -35,6 +35,8 @@ pub fn mock_locked_app_state() -> TestAppState {
             database: Arc::new(database),
             lsp_base_url: None,
             lsp_bearer_token: None,
+            vss_url: None,
+            vss_unencrypted: false,
         }),
         cancel_token: CancellationToken::new(),
         unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -46,6 +46,8 @@ fn handle_from_request(request: SdkInitRequest) -> Result<NodeHandle, RlnError> 
         virtual_peer_pubkeys: request.virtual_peer_pubkeys.unwrap_or_default(),
         lsp_base_url: request.lsp_base_url,
         lsp_bearer_token: request.lsp_bearer_token,
+        vss_url: None,
+        vss_unencrypted: false,
     };
     block_on_app(NodeHandle::new(config))
 }

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -47,7 +47,7 @@ fn handle_from_request(request: SdkInitRequest) -> Result<NodeHandle, RlnError> 
         lsp_base_url: request.lsp_base_url,
         lsp_bearer_token: request.lsp_bearer_token,
         vss_url: None,
-        vss_unencrypted: false,
+        vss_allow_empty_restore: false,
     };
     block_on_app(NodeHandle::new(config))
 }
@@ -60,7 +60,6 @@ fn send_rgb_from_state(
         donation: request.donation,
         fee_rate: request.fee_rate,
         min_confirmations: request.min_confirmations,
-        skip_sync: request.skip_sync,
         recipient_groups: request
             .recipient_groups
             .into_iter()
@@ -867,7 +866,8 @@ impl SdkNode {
                     crate::sdk::TransactionType::RgbSend => TransactionType::RgbSend,
                     crate::sdk::TransactionType::Drain => TransactionType::Drain,
                     crate::sdk::TransactionType::CreateUtxos => TransactionType::CreateUtxos,
-                    crate::sdk::TransactionType::User => TransactionType::User,
+                    crate::sdk::TransactionType::SendBtc => TransactionType::SendBtc,
+                    crate::sdk::TransactionType::Incoming => TransactionType::Incoming,
                 };
                 Ok(Transaction {
                     transaction_type,

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -67,7 +67,6 @@ mod uniffi_smoke_tests {
             donation: false,
             fee_rate: 1,
             min_confirmations: 1,
-            skip_sync: true,
             recipient_groups: vec![],
         });
         assert!(matches!(send_rgb, Err(RlnError::NotInitialized)));
@@ -98,7 +97,7 @@ mod uniffi_smoke_tests {
                 lsp_base_url: None,
                 lsp_bearer_token: None,
                 vss_url: None,
-                vss_unencrypted: false,
+                vss_allow_empty_restore: false,
             }),
             cancel_token: CancellationToken::new(),
             unlocked_app_state: Arc::new(TokioMutex::new(None)),
@@ -133,7 +132,6 @@ mod uniffi_smoke_tests {
             donation: false,
             fee_rate: 1,
             min_confirmations: 1,
-            skip_sync: true,
             recipient_groups: vec![],
         });
         assert!(matches!(send_rgb, Err(RlnError::InvalidRequest)));
@@ -167,7 +165,6 @@ mod uniffi_smoke_tests {
             donation: false,
             fee_rate: 1,
             min_confirmations: 1,
-            skip_sync: true,
             recipient_groups: vec![],
         });
         assert!(matches!(send_rgb, Err(RlnError::InvalidRequest)));

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -97,6 +97,8 @@ mod uniffi_smoke_tests {
                 database: Arc::new(database),
                 lsp_base_url: None,
                 lsp_bearer_token: None,
+                vss_url: None,
+                vss_unencrypted: false,
             }),
             cancel_token: CancellationToken::new(),
             unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -176,7 +176,8 @@ pub enum TransactionType {
     RgbSend,
     Drain,
     CreateUtxos,
-    User,
+    SendBtc,
+    Incoming,
 }
 
 pub struct Transaction {
@@ -629,7 +630,6 @@ pub struct SendRgbRequest {
     pub donation: bool,
     pub fee_rate: u64,
     pub min_confirmations: u8,
-    pub skip_sync: bool,
     pub recipient_groups: Vec<AssetRecipients>,
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::database::RlnDatabase;
-use crate::kv_store::SeaOrmKvStore;
+use crate::synced_kv_store::SyncedKvStore;
 use amplify::s;
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::Hash;
@@ -106,6 +106,12 @@ pub(crate) struct StaticState {
     pub(crate) database: Arc<DatabaseConnection>,
     pub(crate) lsp_base_url: Option<String>,
     pub(crate) lsp_bearer_token: Option<String>,
+    /// VSS server URL (None = VSS disabled)
+    #[cfg_attr(not(feature = "vss"), allow(dead_code))]
+    pub(crate) vss_url: Option<String>,
+    /// Whether VSS backups should be unencrypted
+    #[cfg_attr(not(feature = "vss"), allow(dead_code))]
+    pub(crate) vss_unencrypted: bool,
 }
 
 pub(crate) struct UnlockedAppState {
@@ -119,7 +125,7 @@ pub(crate) struct UnlockedAppState {
     pub(crate) peer_manager: Arc<PeerManager>,
     pub(crate) async_order_handler: Arc<AsyncOrderMessageHandler>,
     pub(crate) async_payments_preimage_root: Arc<AsyncPaymentsPreimageRoot>,
-    pub(crate) kv_store: Arc<SeaOrmKvStore>,
+    pub(crate) kv_store: Arc<SyncedKvStore>,
     pub(crate) bump_tx_event_handler: Arc<BumpTxEventHandler>,
     pub(crate) maker_swaps: Arc<Mutex<SwapMap>>,
     pub(crate) taker_swaps: Arc<Mutex<SwapMap>>,
@@ -405,6 +411,10 @@ pub(crate) async fn start_daemon(args: &UserArgs) -> Result<Arc<AppState>, AppEr
 
     let cancel_token = CancellationToken::new();
 
+    if args.vss_url.is_some() {
+        tracing::info!(vss_url = ?args.vss_url, "VSS cloud backup enabled");
+    }
+
     let static_state = Arc::new(StaticState {
         enable_virtual_channels_v0: args.enable_virtual_channels_v0,
         ldk_peer_listening_port: args.ldk_peer_listening_port,
@@ -417,6 +427,8 @@ pub(crate) async fn start_daemon(args: &UserArgs) -> Result<Arc<AppState>, AppEr
         database: Arc::new(database),
         lsp_base_url: args.lsp_base_url.clone(),
         lsp_bearer_token: args.lsp_bearer_token.clone(),
+        vss_url: args.vss_url.clone(),
+        vss_unencrypted: args.vss_unencrypted,
     });
 
     let app_state = Arc::new(AppState {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -94,6 +94,12 @@ impl AppState {
     }
 }
 
+// VSS-related fields below are always present on `StaticState` regardless of
+// the `vss` feature flag — they ride the same SDK / NodeConfig surface as the
+// non-VSS knobs. With `vss` off the implementation never reads them, so we
+// silence the dead-code warning at the field level (the older
+// `cfg_attr(dead_code)` annotations made the fields look optional; they
+// aren't, only their consumers are gated).
 pub(crate) struct StaticState {
     pub(crate) enable_virtual_channels_v0: bool,
     pub(crate) ldk_peer_listening_port: u16,
@@ -106,12 +112,14 @@ pub(crate) struct StaticState {
     pub(crate) database: Arc<DatabaseConnection>,
     pub(crate) lsp_base_url: Option<String>,
     pub(crate) lsp_bearer_token: Option<String>,
-    /// VSS server URL (None = VSS disabled)
+    /// VSS server URL (None = VSS disabled). Populated regardless of the
+    /// `vss` feature flag; only the consumer in `start_ldk` is feature-gated.
     #[cfg_attr(not(feature = "vss"), allow(dead_code))]
     pub(crate) vss_url: Option<String>,
-    /// Whether VSS backups should be unencrypted
+    /// When true, a failed VSS restore on a fresh device logs a warning and
+    /// continues with empty local state instead of aborting unlock.
     #[cfg_attr(not(feature = "vss"), allow(dead_code))]
-    pub(crate) vss_unencrypted: bool,
+    pub(crate) vss_allow_empty_restore: bool,
 }
 
 pub(crate) struct UnlockedAppState {
@@ -243,6 +251,44 @@ pub(crate) fn check_port_is_available(port: u16) -> Result<(), AppError> {
         return Err(AppError::UnavailablePort(port));
     }
     Ok(())
+}
+
+/// Validate a VSS URL. By default only `https://` URLs and loopback HTTP
+/// URLs (`http://localhost`, `http://127.0.0.1`, `http://[::1]`) are
+/// accepted; pass `allow_http = true` to allow `http://` on any host (for
+/// private networks with out-of-band trust).
+pub(crate) fn validate_vss_url(url: &str, allow_http: bool) -> Result<(), AppError> {
+    let trimmed = url.trim();
+    if let Some(rest) = trimmed.strip_prefix("https://") {
+        if rest.is_empty() {
+            return Err(AppError::InvalidVssConfig(format!(
+                "VSS URL `{url}` has no host"
+            )));
+        }
+        return Ok(());
+    }
+    if let Some(rest) = trimmed.strip_prefix("http://") {
+        // Strip any optional userinfo (`user:pass@`) and trailing path/query.
+        let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+        let host_with_port = authority
+            .rsplit_once('@')
+            .map(|(_, after)| after)
+            .unwrap_or(authority);
+        let is_loopback_host = ["localhost", "127.0.0.1", "[::1]", "0.0.0.0"]
+            .iter()
+            .any(|h| host_with_port == *h || host_with_port.starts_with(&format!("{h}:")));
+        if is_loopback_host || allow_http {
+            return Ok(());
+        }
+        return Err(AppError::InvalidVssConfig(format!(
+            "VSS URL `{url}` uses http:// on non-loopback host `{host_with_port}`. \
+             Use https:// in production, or pass --vss-allow-http to allow http:// \
+             on a private network you trust out-of-band."
+        )));
+    }
+    Err(AppError::InvalidVssConfig(format!(
+        "VSS URL `{url}` must start with http:// or https://"
+    )))
 }
 
 pub(crate) fn get_db_path(storage_dir_path: &Path) -> PathBuf {
@@ -428,7 +474,7 @@ pub(crate) async fn start_daemon(args: &UserArgs) -> Result<Arc<AppState>, AppEr
         lsp_base_url: args.lsp_base_url.clone(),
         lsp_bearer_token: args.lsp_bearer_token.clone(),
         vss_url: args.vss_url.clone(),
-        vss_unencrypted: args.vss_unencrypted,
+        vss_allow_empty_restore: args.vss_allow_empty_restore,
     });
 
     let app_state = Arc::new(AppState {
@@ -549,4 +595,38 @@ pub(crate) fn validate_and_parse_payment_preimage(
         return Err(APIError::InvalidPaymentPreimage);
     }
     Ok(preimage)
+}
+
+#[cfg(test)]
+mod utils_tests {
+    use super::validate_vss_url;
+
+    #[test]
+    fn vss_url_https_accepted() {
+        assert!(validate_vss_url("https://example.com/vss", false).is_ok());
+        assert!(validate_vss_url("https://example.com/vss", true).is_ok());
+    }
+
+    #[test]
+    fn vss_url_loopback_http_accepted_without_override() {
+        assert!(validate_vss_url("http://localhost:8081/vss", false).is_ok());
+        assert!(validate_vss_url("http://127.0.0.1:8081/vss", false).is_ok());
+        assert!(validate_vss_url("http://[::1]:8081/vss", false).is_ok());
+    }
+
+    #[test]
+    fn vss_url_non_loopback_http_rejected_without_override() {
+        assert!(validate_vss_url("http://example.com/vss", false).is_err());
+    }
+
+    #[test]
+    fn vss_url_non_loopback_http_accepted_with_override() {
+        assert!(validate_vss_url("http://example.com/vss", true).is_ok());
+    }
+
+    #[test]
+    fn vss_url_other_schemes_rejected() {
+        assert!(validate_vss_url("ftp://example.com/vss", true).is_err());
+        assert!(validate_vss_url("example.com/vss", true).is_err());
+    }
 }

--- a/src/vss_kv_store.rs
+++ b/src/vss_kv_store.rs
@@ -1,0 +1,385 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bitcoin::io;
+use bitcoin::secp256k1::SecretKey;
+use lightning::util::persist::KVStoreSync;
+use vss_client::client::VssClient;
+use vss_client::error::VssError;
+use vss_client::headers::sigs_auth::SigsAuthProvider;
+use vss_client::types::{GetObjectRequest, KeyValue, ListKeyVersionsRequest, PutObjectRequest};
+use vss_client::util::retry::{
+    ExponentialBackoffRetryPolicy, MaxAttemptsRetryPolicy, MaxTotalDelayRetryPolicy, RetryPolicy,
+};
+
+/// Type alias for the retry policy used by VssClient.
+type VssRetryPolicy =
+    MaxTotalDelayRetryPolicy<MaxAttemptsRetryPolicy<ExponentialBackoffRetryPolicy<VssError>>>;
+
+/// KVStore implementation backed by a VSS (Versioned Storage Service) server.
+///
+/// Maps LDK's `(primary_namespace, secondary_namespace, key)` triple to a single
+/// VSS key string and provides version tracking for optimistic locking.
+pub struct VssKvStore {
+    client: VssClient<VssRetryPolicy>,
+    store_id: String,
+    /// Tracks the current version for each VSS key for optimistic locking.
+    versions: Mutex<HashMap<String, i64>>,
+    /// Dedicated tokio runtime for async VSS client operations.
+    runtime: tokio::runtime::Runtime,
+}
+
+impl VssKvStore {
+    /// Creates a new VssKvStore connected to the given VSS server.
+    ///
+    /// # Arguments
+    /// * `server_url` - VSS server URL (e.g., "http://localhost:8081/vss")
+    /// * `store_id` - Keyspace identifier (derived from node pubkey)
+    /// * `signing_key` - Secret key for signature-based authentication
+    pub fn new(
+        server_url: String,
+        store_id: String,
+        signing_key: SecretKey,
+    ) -> Result<Self, io::Error> {
+        let auth_provider = SigsAuthProvider::new(signing_key, HashMap::new());
+
+        let retry_policy = ExponentialBackoffRetryPolicy::new(Duration::from_millis(100))
+            .with_max_attempts(3)
+            .with_max_total_delay(Duration::from_secs(5));
+
+        let client = VssClient::new_with_headers(server_url, retry_policy, Arc::new(auth_provider));
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("vss-runtime")
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("Failed to create VSS tokio runtime: {e}"),
+                )
+            })?;
+
+        Ok(Self {
+            client,
+            store_id,
+            versions: Mutex::new(HashMap::new()),
+            runtime,
+        })
+    }
+
+    /// Returns the store_id used by this VssKvStore.
+    pub fn store_id(&self) -> &str {
+        &self.store_id
+    }
+
+    /// Runs an async future on the dedicated VSS runtime, handling the case
+    /// where we may already be inside a tokio context.
+    fn block_on<F>(&self, future: F) -> F::Output
+    where
+        F: std::future::Future + Send,
+        F::Output: Send,
+    {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            // Already inside a tokio runtime — run on a separate thread
+            std::thread::scope(|s| {
+                s.spawn(|| self.runtime.block_on(future))
+                    .join()
+                    .expect("VSS thread panicked")
+            })
+        } else {
+            self.runtime.block_on(future)
+        }
+    }
+
+    /// Gets the cached version for a key, defaulting to 0 (first write).
+    fn get_cached_version(&self, vss_key: &str) -> i64 {
+        self.versions
+            .lock()
+            .unwrap()
+            .get(vss_key)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Updates the cached version for a key after a successful write.
+    fn update_cached_version(&self, vss_key: &str, version: i64) {
+        self.versions
+            .lock()
+            .unwrap()
+            .insert(vss_key.to_string(), version);
+    }
+
+    /// Removes the cached version for a key after deletion.
+    fn remove_cached_version(&self, vss_key: &str) {
+        self.versions.lock().unwrap().remove(vss_key);
+    }
+
+    /// Downloads all key-value pairs from VSS for this store_id.
+    /// Used for restore operations.
+    pub fn download_all(&self) -> Result<Vec<(String, Vec<u8>)>, io::Error> {
+        let mut all_items = Vec::new();
+        let mut page_token: Option<String> = None;
+
+        loop {
+            let request = ListKeyVersionsRequest {
+                store_id: self.store_id.clone(),
+                key_prefix: None,
+                page_size: None,
+                page_token: page_token.clone(),
+            };
+
+            let response = self
+                .block_on(self.client.list_key_versions(&request))
+                .map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("VSS list_key_versions failed: {e}"),
+                    )
+                })?;
+
+            for kv in &response.key_versions {
+                // Fetch each value individually
+                let get_req = GetObjectRequest {
+                    store_id: self.store_id.clone(),
+                    key: kv.key.clone(),
+                };
+                match self.block_on(self.client.get_object(&get_req)) {
+                    Ok(resp) => {
+                        if let Some(value) = resp.value {
+                            all_items.push((value.key, value.value));
+                        }
+                    }
+                    Err(VssError::NoSuchKeyError(_)) => continue,
+                    Err(e) => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Other,
+                            format!("VSS get_object failed during download_all: {e}"),
+                        ));
+                    }
+                }
+            }
+
+            let next_token: Option<String> = response.next_page_token;
+            match next_token {
+                Some(token) if !token.is_empty() => {
+                    page_token = Some(token);
+                }
+                _ => break,
+            }
+        }
+
+        Ok(all_items)
+    }
+}
+
+/// Maps LDK's (primary_namespace, secondary_namespace, key) to a single VSS key.
+///
+/// Format: `{primary_ns}/{secondary_ns}/{key}` where empty namespaces become `_`.
+pub(crate) fn vss_key(primary_namespace: &str, secondary_namespace: &str, key: &str) -> String {
+    let primary = if primary_namespace.is_empty() {
+        "_"
+    } else {
+        primary_namespace
+    };
+    let secondary = if secondary_namespace.is_empty() {
+        "_"
+    } else {
+        secondary_namespace
+    };
+    format!("{primary}/{secondary}/{key}")
+}
+
+/// Parses a VSS key back into (primary_namespace, secondary_namespace, key).
+///
+/// Returns `None` if the key doesn't match the expected format.
+pub(crate) fn parse_vss_key(vss_key: &str) -> Option<(String, String, String)> {
+    let mut parts = vss_key.splitn(3, '/');
+    let primary = parts.next()?;
+    let secondary = parts.next()?;
+    let key = parts.next()?;
+    if key.is_empty() {
+        return None;
+    }
+    let primary = if primary == "_" {
+        String::new()
+    } else {
+        primary.to_string()
+    };
+    let secondary = if secondary == "_" {
+        String::new()
+    } else {
+        secondary.to_string()
+    };
+    Some((primary, secondary, key.to_string()))
+}
+
+/// Returns the VSS key prefix for listing all keys in a namespace.
+fn vss_key_prefix(primary_namespace: &str, secondary_namespace: &str) -> String {
+    let primary = if primary_namespace.is_empty() {
+        "_"
+    } else {
+        primary_namespace
+    };
+    let secondary = if secondary_namespace.is_empty() {
+        "_"
+    } else {
+        secondary_namespace
+    };
+    format!("{primary}/{secondary}/")
+}
+
+impl KVStoreSync for VssKvStore {
+    fn read(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+    ) -> Result<Vec<u8>, io::Error> {
+        let vss_key = vss_key(primary_namespace, secondary_namespace, key);
+        tracing::trace!(vss_key, "VssKvStore read");
+
+        let request = GetObjectRequest {
+            store_id: self.store_id.clone(),
+            key: vss_key.clone(),
+        };
+
+        let response = self.block_on(self.client.get_object(&request));
+
+        match response {
+            Ok(resp) => {
+                if let Some(kv) = resp.value {
+                    self.update_cached_version(&vss_key, kv.version);
+                    Ok(kv.value)
+                } else {
+                    Err(io::Error::new(io::ErrorKind::NotFound, "Key not found"))
+                }
+            }
+            Err(VssError::NoSuchKeyError(_)) => {
+                Err(io::Error::new(io::ErrorKind::NotFound, "Key not found"))
+            }
+            Err(e) => {
+                tracing::error!(vss_key, error = %e, "VssKvStore read failed");
+                Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("VSS read failed: {e}"),
+                ))
+            }
+        }
+    }
+
+    fn write(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        buf: Vec<u8>,
+    ) -> Result<(), io::Error> {
+        let vss_key = vss_key(primary_namespace, secondary_namespace, key);
+        tracing::trace!(vss_key, value_len = buf.len(), "VssKvStore write");
+
+        // Use non-conditional writes (version = -1) to avoid version conflicts
+        // under high-frequency LDK persistence (channel monitor updates).
+        let request = PutObjectRequest {
+            store_id: self.store_id.clone(),
+            global_version: None,
+            transaction_items: vec![KeyValue {
+                key: vss_key.clone(),
+                version: -1,
+                value: buf,
+            }],
+            delete_items: vec![],
+        };
+
+        self.block_on(self.client.put_object(&request))
+            .map_err(|e| {
+                tracing::error!(vss_key, error = %e, "VssKvStore write failed");
+                io::Error::new(io::ErrorKind::Other, format!("VSS write failed: {e}"))
+            })?;
+
+        // After non-conditional write, server resets version to 1
+        self.update_cached_version(&vss_key, 1);
+        Ok(())
+    }
+
+    fn remove(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        _lazy: bool,
+    ) -> Result<(), io::Error> {
+        let vss_key = vss_key(primary_namespace, secondary_namespace, key);
+        tracing::trace!(vss_key, "VssKvStore remove");
+
+        // Use non-conditional delete (version = -1)
+        let request = PutObjectRequest {
+            store_id: self.store_id.clone(),
+            global_version: None,
+            transaction_items: vec![],
+            delete_items: vec![KeyValue {
+                key: vss_key.clone(),
+                version: -1,
+                value: vec![],
+            }],
+        };
+
+        self.block_on(self.client.put_object(&request))
+            .map_err(|e| {
+                tracing::error!(vss_key, error = %e, "VssKvStore remove failed");
+                io::Error::new(io::ErrorKind::Other, format!("VSS remove failed: {e}"))
+            })?;
+
+        self.remove_cached_version(&vss_key);
+        Ok(())
+    }
+
+    fn list(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+    ) -> Result<Vec<String>, io::Error> {
+        let prefix = vss_key_prefix(primary_namespace, secondary_namespace);
+        tracing::trace!(prefix, "VssKvStore list");
+
+        let mut keys = Vec::new();
+        let mut page_token: Option<String> = None;
+
+        loop {
+            let request = ListKeyVersionsRequest {
+                store_id: self.store_id.clone(),
+                key_prefix: Some(prefix.clone()),
+                page_size: None,
+                page_token: page_token.clone(),
+            };
+
+            let response = self
+                .block_on(self.client.list_key_versions(&request))
+                .map_err(|e| {
+                    tracing::error!(prefix, error = %e, "VssKvStore list failed");
+                    io::Error::new(io::ErrorKind::Other, format!("VSS list failed: {e}"))
+                })?;
+
+            for kv in &response.key_versions {
+                // Strip the prefix to get just the key name
+                let kv_key: &str = &kv.key;
+                if let Some(key_name) = kv_key.strip_prefix(prefix.as_str()) {
+                    keys.push(key_name.to_string());
+                    self.update_cached_version(kv_key, kv.version);
+                }
+            }
+
+            let next_token: Option<String> = response.next_page_token;
+            match next_token {
+                Some(token) if !token.is_empty() => {
+                    page_token = Some(token);
+                }
+                _ => break,
+            }
+        }
+
+        Ok(keys)
+    }
+}

--- a/src/vss_kv_store.rs
+++ b/src/vss_kv_store.rs
@@ -1,10 +1,14 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use bitcoin::io;
 use bitcoin::secp256k1::SecretKey;
+use futures::stream::{FuturesUnordered, StreamExt};
+use hex::DisplayHex;
 use lightning::util::persist::KVStoreSync;
+use rgb_lib::wallet::vss::{decrypt_data, encrypt_data, VssEncryptionMetadata};
+use uuid::Uuid;
 use vss_client::client::VssClient;
 use vss_client::error::VssError;
 use vss_client::headers::sigs_auth::SigsAuthProvider;
@@ -17,17 +21,55 @@ use vss_client::util::retry::{
 type VssRetryPolicy =
     MaxTotalDelayRetryPolicy<MaxAttemptsRetryPolicy<ExponentialBackoffRetryPolicy<VssError>>>;
 
+/// Result of a single VSS get-object during a paged `download_all`. `Ok(None)`
+/// means the key disappeared between list and get (race; benign).
+type FetchResult = Result<Option<(String, Vec<u8>)>, VssError>;
+
+/// HKDF info tag used to derive this KV stream's per-value encryption key.
+/// Domain-separates it from rgb-lib's wallet-backup stream so the two derived
+/// keys are distinct even when the signing key and salt happen to match.
+const VSS_KV_HKDF_INFO: &[u8] = b"rgb-ln-vss-kv-encryption-v1";
+
+/// Wire-format version for inline-encrypted values stored on VSS.
+const VSS_KV_FORMAT_VERSION: u8 = 1;
+
+/// Raw salt length (matches rgb-lib's `BACKUP_SALT_LENGTH`).
+const SALT_LEN: usize = 32;
+
+/// Raw nonce length (matches rgb-lib's `BACKUP_NONCE_LENGTH`).
+const NONCE_LEN: usize = 19;
+
+/// Total header length: [1-byte version][32-byte salt][19-byte nonce].
+const HEADER_LEN: usize = 1 + SALT_LEN + NONCE_LEN;
+
+/// VSS key that holds the single-writer fencing token. Anything that writes to
+/// this store_id must hold this token; on takeover the new owner has to delete
+/// this key explicitly.
+const FENCE_KEY: &str = "__rln_instance__";
+
+/// How many writes between periodic fence re-checks.
+///
+/// The startup fence acquire catches the common case (another instance is
+/// already running); a periodic re-check catches the rare case where the fence
+/// key was deleted out-of-band while we kept running.
+const FENCE_CHECK_INTERVAL: u64 = 100;
+
 /// KVStore implementation backed by a VSS (Versioned Storage Service) server.
 ///
-/// Maps LDK's `(primary_namespace, secondary_namespace, key)` triple to a single
-/// VSS key string and provides version tracking for optimistic locking.
+/// Maps the `(primary_namespace, secondary_namespace, key)` triple used by
+/// `lightning::util::persist::KVStoreSync` to a single VSS key string.
+/// Values are always encrypted at rest with XChaCha20-Poly1305 (key derived
+/// from `signing_key` via HKDF-SHA256).
 pub struct VssKvStore {
     client: VssClient<VssRetryPolicy>,
     store_id: String,
-    /// Tracks the current version for each VSS key for optimistic locking.
-    versions: Mutex<HashMap<String, i64>>,
-    /// Dedicated tokio runtime for async VSS client operations.
-    runtime: tokio::runtime::Runtime,
+    signing_key: SecretKey,
+    /// Per-process identity used by [`Self::acquire_fence`] and the periodic
+    /// fence re-check.
+    instance_id: Uuid,
+    /// Counter incremented on every write; modulo [`FENCE_CHECK_INTERVAL`] is
+    /// used to schedule periodic fence re-checks.
+    write_counter: std::sync::atomic::AtomicU64,
 }
 
 impl VssKvStore {
@@ -36,7 +78,8 @@ impl VssKvStore {
     /// # Arguments
     /// * `server_url` - VSS server URL (e.g., "http://localhost:8081/vss")
     /// * `store_id` - Keyspace identifier (derived from node pubkey)
-    /// * `signing_key` - Secret key for signature-based authentication
+    /// * `signing_key` - Secret key used both for sigs-auth and for deriving
+    ///   the per-value encryption key via HKDF-SHA256.
     pub fn new(
         server_url: String,
         store_id: String,
@@ -50,89 +93,215 @@ impl VssKvStore {
 
         let client = VssClient::new_with_headers(server_url, retry_policy, Arc::new(auth_provider));
 
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .thread_name("vss-runtime")
-            .enable_all()
-            .build()
-            .map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("Failed to create VSS tokio runtime: {e}"),
-                )
-            })?;
-
         Ok(Self {
             client,
             store_id,
-            versions: Mutex::new(HashMap::new()),
-            runtime,
+            signing_key,
+            instance_id: Uuid::new_v4(),
+            write_counter: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
-    /// Returns the store_id used by this VssKvStore.
-    pub fn store_id(&self) -> &str {
-        &self.store_id
-    }
-
-    /// Runs an async future on the dedicated VSS runtime, handling the case
-    /// where we may already be inside a tokio context.
+    /// Runs an async future to completion using the ambient Tokio runtime
+    /// (which must be multi-threaded — `#[tokio::main]` in `src/main.rs`
+    /// satisfies this).
     fn block_on<F>(&self, future: F) -> F::Output
     where
         F: std::future::Future + Send,
         F::Output: Send,
     {
-        if tokio::runtime::Handle::try_current().is_ok() {
-            // Already inside a tokio runtime — run on a separate thread
-            std::thread::scope(|s| {
-                s.spawn(|| self.runtime.block_on(future))
-                    .join()
-                    .expect("VSS thread panicked")
-            })
-        } else {
-            self.runtime.block_on(future)
+        tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
+    }
+
+    /// Encrypt a value for storage on VSS using the inline wire format
+    /// `[version|salt|nonce|ciphertext]`.
+    fn encrypt_value(&self, plaintext: Vec<u8>) -> Result<Vec<u8>, io::Error> {
+        let salt_bytes: [u8; SALT_LEN] = rand::random();
+        let nonce_bytes: [u8; NONCE_LEN] = rand::random();
+        let metadata = VssEncryptionMetadata {
+            salt: salt_bytes.as_hex().to_string(),
+            nonce: nonce_bytes.as_hex().to_string(),
+            version: VSS_KV_FORMAT_VERSION,
+        };
+        let ciphertext = encrypt_data(
+            &plaintext,
+            &self.signing_key,
+            &metadata,
+            Some(VSS_KV_HKDF_INFO),
+        )
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("VSS encrypt failed: {e}")))?;
+        let mut out = Vec::with_capacity(HEADER_LEN + ciphertext.len());
+        out.push(VSS_KV_FORMAT_VERSION);
+        out.extend_from_slice(&salt_bytes);
+        out.extend_from_slice(&nonce_bytes);
+        out.extend_from_slice(&ciphertext);
+        Ok(out)
+    }
+
+    /// Decrypt a value retrieved from VSS.
+    fn decrypt_value(&self, stored: Vec<u8>) -> Result<Vec<u8>, io::Error> {
+        if stored.len() < HEADER_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "VSS decrypt: stored value shorter than header",
+            ));
+        }
+        let version = stored[0];
+        if version != VSS_KV_FORMAT_VERSION {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("VSS decrypt: unknown wire format version {version}"),
+            ));
+        }
+        let salt = &stored[1..1 + SALT_LEN];
+        let nonce = &stored[1 + SALT_LEN..HEADER_LEN];
+        let ciphertext = &stored[HEADER_LEN..];
+        let metadata = VssEncryptionMetadata {
+            salt: salt.as_hex().to_string(),
+            nonce: nonce.as_hex().to_string(),
+            version,
+        };
+        decrypt_data(
+            ciphertext,
+            &self.signing_key,
+            &metadata,
+            Some(VSS_KV_HKDF_INFO),
+        )
+        .map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("VSS decrypt failed: {e}"),
+            )
+        })
+    }
+
+    /// Acquires the single-writer fence for this `store_id`.
+    ///
+    /// Read the fence key first; if another instance owns it, refuse to
+    /// proceed (the operator must clear the fence by hand). If no fence
+    /// exists, try to claim it with a conditional create (`version = 0`); a
+    /// `ConflictError` means a concurrent instance won the race.
+    pub fn acquire_fence(&self) -> Result<(), io::Error> {
+        let get_req = GetObjectRequest {
+            store_id: self.store_id.clone(),
+            key: FENCE_KEY.to_string(),
+        };
+        match self.block_on(self.client.get_object(&get_req)) {
+            Ok(resp) => {
+                if let Some(kv) = resp.value {
+                    let remote_id = String::from_utf8_lossy(&kv.value).to_string();
+                    if remote_id == self.instance_id.to_string() {
+                        return Ok(());
+                    }
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!(
+                            "VSS store_id is owned by another rgb-lightning-node \
+                             instance ({remote_id}). Refusing to start to avoid \
+                             concurrent-writer corruption. If this previous owner \
+                             is definitively gone and you want to take over, \
+                             delete the `{FENCE_KEY}` key from VSS first."
+                        ),
+                    ));
+                }
+            }
+            Err(VssError::NoSuchKeyError(_)) => {}
+            Err(e) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("VSS fence read failed: {e}"),
+                ));
+            }
+        }
+
+        let put_req = PutObjectRequest {
+            store_id: self.store_id.clone(),
+            global_version: None,
+            transaction_items: vec![KeyValue {
+                key: FENCE_KEY.to_string(),
+                version: 0,
+                value: self.instance_id.to_string().into_bytes(),
+            }],
+            delete_items: vec![],
+        };
+        match self.block_on(self.client.put_object(&put_req)) {
+            Ok(_) => {
+                tracing::info!(
+                    instance_id = %self.instance_id,
+                    "VSS fence acquired"
+                );
+                Ok(())
+            }
+            Err(VssError::ConflictError(_)) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "VSS fence: another instance won the race to claim this store_id",
+            )),
+            Err(e) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("VSS fence acquire failed: {e}"),
+            )),
         }
     }
 
-    /// Gets the cached version for a key, defaulting to 0 (first write).
-    fn get_cached_version(&self, vss_key: &str) -> i64 {
-        self.versions
-            .lock()
-            .unwrap()
-            .get(vss_key)
-            .copied()
-            .unwrap_or(0)
+    /// Periodic re-check of the fence; panics if the fence has been taken over
+    /// by another instance, since at that point our writes would corrupt the
+    /// other instance's state.
+    fn check_fence_periodic(&self) {
+        let counter = self
+            .write_counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if counter == 0 || !counter.is_multiple_of(FENCE_CHECK_INTERVAL) {
+            return;
+        }
+        let get_req = GetObjectRequest {
+            store_id: self.store_id.clone(),
+            key: FENCE_KEY.to_string(),
+        };
+        match self.block_on(self.client.get_object(&get_req)) {
+            Ok(resp) => {
+                if let Some(kv) = resp.value {
+                    let remote_id = String::from_utf8_lossy(&kv.value).to_string();
+                    if remote_id != self.instance_id.to_string() {
+                        panic!(
+                            "VSS fence broken: another instance ({remote_id}) has \
+                             taken over store_id; refusing to continue writing to \
+                             avoid corrupting their state"
+                        );
+                    }
+                } else {
+                    tracing::warn!(
+                        "VSS fence key disappeared mid-session; another operator \
+                         may have cleared it"
+                    );
+                }
+            }
+            Err(VssError::NoSuchKeyError(_)) => {
+                tracing::warn!(
+                    "VSS fence key missing mid-session; another operator may have \
+                     cleared it"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "VSS fence periodic check failed");
+            }
+        }
     }
 
-    /// Updates the cached version for a key after a successful write.
-    fn update_cached_version(&self, vss_key: &str, version: i64) {
-        self.versions
-            .lock()
-            .unwrap()
-            .insert(vss_key.to_string(), version);
-    }
-
-    /// Removes the cached version for a key after deletion.
-    fn remove_cached_version(&self, vss_key: &str) {
-        self.versions.lock().unwrap().remove(vss_key);
-    }
-
-    /// Downloads all key-value pairs from VSS for this store_id.
-    /// Used for restore operations.
+    /// Downloads all key-value pairs from VSS for this store_id, decrypting
+    /// each value. Used for restore operations.
     pub fn download_all(&self) -> Result<Vec<(String, Vec<u8>)>, io::Error> {
         let mut all_items = Vec::new();
         let mut page_token: Option<String> = None;
 
         loop {
-            let request = ListKeyVersionsRequest {
+            let list_req = ListKeyVersionsRequest {
                 store_id: self.store_id.clone(),
                 key_prefix: None,
                 page_size: None,
                 page_token: page_token.clone(),
             };
-
             let response = self
-                .block_on(self.client.list_key_versions(&request))
+                .block_on(self.client.list_key_versions(&list_req))
                 .map_err(|e| {
                     io::Error::new(
                         io::ErrorKind::Other,
@@ -140,19 +309,51 @@ impl VssKvStore {
                     )
                 })?;
 
-            for kv in &response.key_versions {
-                // Fetch each value individually
-                let get_req = GetObjectRequest {
-                    store_id: self.store_id.clone(),
-                    key: kv.key.clone(),
-                };
-                match self.block_on(self.client.get_object(&get_req)) {
-                    Ok(resp) => {
-                        if let Some(value) = resp.value {
-                            all_items.push((value.key, value.value));
+            // Fetch values for the keys in this page concurrently. VSS
+            // returns one page at a time and pages are typically small, so we
+            // run them through `FuturesUnordered` to avoid the N+1 RTT of the
+            // previous serial implementation. Note: the network library
+            // (vss-client) does its own connection pooling, so we don't add
+            // an extra concurrency cap beyond the page size.
+            let keys: Vec<String> = response
+                .key_versions
+                .iter()
+                .map(|kv| kv.key.clone())
+                .filter(|k| k != FENCE_KEY)
+                .collect();
+            let store_id = self.store_id.clone();
+            let client = &self.client;
+            let fetched: Vec<FetchResult> = self.block_on(async move {
+                let mut in_flight: FuturesUnordered<_> = keys
+                    .into_iter()
+                    .map(|key| {
+                        let req = GetObjectRequest {
+                            store_id: store_id.clone(),
+                            key,
+                        };
+                        async move {
+                            match client.get_object(&req).await {
+                                Ok(resp) => Ok(resp.value.map(|kv| (kv.key, kv.value))),
+                                Err(VssError::NoSuchKeyError(_)) => Ok(None),
+                                Err(e) => Err(e),
+                            }
                         }
+                    })
+                    .collect();
+                let mut out = Vec::with_capacity(in_flight.len());
+                while let Some(res) = in_flight.next().await {
+                    out.push(res);
+                }
+                out
+            });
+
+            for item in fetched {
+                match item {
+                    Ok(Some((key, raw))) => {
+                        let plaintext = self.decrypt_value(raw)?;
+                        all_items.push((key, plaintext));
                     }
-                    Err(VssError::NoSuchKeyError(_)) => continue,
+                    Ok(None) => continue,
                     Err(e) => {
                         return Err(io::Error::new(
                             io::ErrorKind::Other,
@@ -164,9 +365,7 @@ impl VssKvStore {
 
             let next_token: Option<String> = response.next_page_token;
             match next_token {
-                Some(token) if !token.is_empty() => {
-                    page_token = Some(token);
-                }
+                Some(token) if !token.is_empty() => page_token = Some(token),
                 _ => break,
             }
         }
@@ -175,7 +374,8 @@ impl VssKvStore {
     }
 }
 
-/// Maps LDK's (primary_namespace, secondary_namespace, key) to a single VSS key.
+/// Encode a `(primary_namespace, secondary_namespace, key)` triple as a
+/// single VSS key string.
 ///
 /// Format: `{primary_ns}/{secondary_ns}/{key}` where empty namespaces become `_`.
 pub(crate) fn vss_key(primary_namespace: &str, secondary_namespace: &str, key: &str) -> String {
@@ -251,8 +451,7 @@ impl KVStoreSync for VssKvStore {
         match response {
             Ok(resp) => {
                 if let Some(kv) = resp.value {
-                    self.update_cached_version(&vss_key, kv.version);
-                    Ok(kv.value)
+                    self.decrypt_value(kv.value)
                 } else {
                     Err(io::Error::new(io::ErrorKind::NotFound, "Key not found"))
                 }
@@ -280,15 +479,21 @@ impl KVStoreSync for VssKvStore {
         let vss_key = vss_key(primary_namespace, secondary_namespace, key);
         tracing::trace!(vss_key, value_len = buf.len(), "VssKvStore write");
 
-        // Use non-conditional writes (version = -1) to avoid version conflicts
-        // under high-frequency LDK persistence (channel monitor updates).
+        self.check_fence_periodic();
+
+        let stored = self.encrypt_value(buf)?;
+
+        // Use non-conditional writes (version = -1) so high-frequency monitor
+        // updates don't fail on version conflicts. Concurrent writer safety
+        // is provided by [`acquire_fence`] + periodic re-checks rather than
+        // by VSS's optimistic locking.
         let request = PutObjectRequest {
             store_id: self.store_id.clone(),
             global_version: None,
             transaction_items: vec![KeyValue {
                 key: vss_key.clone(),
                 version: -1,
-                value: buf,
+                value: stored,
             }],
             delete_items: vec![],
         };
@@ -298,9 +503,6 @@ impl KVStoreSync for VssKvStore {
                 tracing::error!(vss_key, error = %e, "VssKvStore write failed");
                 io::Error::new(io::ErrorKind::Other, format!("VSS write failed: {e}"))
             })?;
-
-        // After non-conditional write, server resets version to 1
-        self.update_cached_version(&vss_key, 1);
         Ok(())
     }
 
@@ -314,7 +516,8 @@ impl KVStoreSync for VssKvStore {
         let vss_key = vss_key(primary_namespace, secondary_namespace, key);
         tracing::trace!(vss_key, "VssKvStore remove");
 
-        // Use non-conditional delete (version = -1)
+        self.check_fence_periodic();
+
         let request = PutObjectRequest {
             store_id: self.store_id.clone(),
             global_version: None,
@@ -331,8 +534,6 @@ impl KVStoreSync for VssKvStore {
                 tracing::error!(vss_key, error = %e, "VssKvStore remove failed");
                 io::Error::new(io::ErrorKind::Other, format!("VSS remove failed: {e}"))
             })?;
-
-        self.remove_cached_version(&vss_key);
         Ok(())
     }
 
@@ -363,19 +564,18 @@ impl KVStoreSync for VssKvStore {
                 })?;
 
             for kv in &response.key_versions {
-                // Strip the prefix to get just the key name
                 let kv_key: &str = &kv.key;
+                if kv_key == FENCE_KEY {
+                    continue;
+                }
                 if let Some(key_name) = kv_key.strip_prefix(prefix.as_str()) {
                     keys.push(key_name.to_string());
-                    self.update_cached_version(kv_key, kv.version);
                 }
             }
 
             let next_token: Option<String> = response.next_page_token;
             match next_token {
-                Some(token) if !token.is_empty() => {
-                    page_token = Some(token);
-                }
+                Some(token) if !token.is_empty() => page_token = Some(token),
                 _ => break,
             }
         }

--- a/test/kotlin-e2e/KotlinUniffiE2e.kt
+++ b/test/kotlin-e2e/KotlinUniffiE2e.kt
@@ -56,12 +56,12 @@ private val ISSUE_ASSET_SUPPLY: ULong = env("ISSUE_ASSET_SUPPLY", "1000").toULon
 private val OPEN_CHANNEL_ASSET_AMOUNT: ULong = env("OPEN_CHANNEL_ASSET_AMOUNT", "200").toULong()
 private val PAYMENT_ASSET_AMOUNT: ULong = env("PAYMENT_ASSET_AMOUNT", "50").toULong()
 private const val OPEN_CHANNEL_CONFIRM_BLOCKS: Int = 6
-private val CHANNEL_FUNDING_TX_TIMEOUT_SEC: Long = env("CHANNEL_FUNDING_TX_TIMEOUT_SEC", "100").toLong()
-private val CHANNEL_CONFIRM_TIMEOUT_SEC: Long = env("CHANNEL_CONFIRM_TIMEOUT_SEC", "100").toLong()
-private val CHANNEL_READY_TIMEOUT_SEC: Long = env("CHANNEL_READY_TIMEOUT_SEC", "20").toLong()
-private val CHANNEL_COUNT_TIMEOUT_SEC: Long = env("CHANNEL_COUNT_TIMEOUT_SEC", "20").toLong()
-private val BALANCE_TIMEOUT_SEC: Long = env("BALANCE_TIMEOUT_SEC", "140").toLong()
-private val PAYMENT_TIMEOUT_SEC: Long = env("PAYMENT_TIMEOUT_SEC", "80").toLong()
+private val CHANNEL_FUNDING_TX_TIMEOUT_SEC: Long = env("CHANNEL_FUNDING_TX_TIMEOUT_SEC", "240").toLong()
+private val CHANNEL_CONFIRM_TIMEOUT_SEC: Long = env("CHANNEL_CONFIRM_TIMEOUT_SEC", "200").toLong()
+private val CHANNEL_READY_TIMEOUT_SEC: Long = env("CHANNEL_READY_TIMEOUT_SEC", "60").toLong()
+private val CHANNEL_COUNT_TIMEOUT_SEC: Long = env("CHANNEL_COUNT_TIMEOUT_SEC", "60").toLong()
+private val BALANCE_TIMEOUT_SEC: Long = env("BALANCE_TIMEOUT_SEC", "240").toLong()
+private val PAYMENT_TIMEOUT_SEC: Long = env("PAYMENT_TIMEOUT_SEC", "160").toLong()
 private val RESET_DATA: Boolean = env("RESET_DATA", "1") == "1"
 private val SCENARIO: String = env("KOTLIN_E2E_SCENARIO", "payment")
 

--- a/test/kotlin-e2e/KotlinUniffiE2e.kt
+++ b/test/kotlin-e2e/KotlinUniffiE2e.kt
@@ -889,7 +889,6 @@ private fun openchannelPushAssetAmountScenario() {
                 donation = true,
                 feeRate = CREATE_UTXOS_FEE_RATE,
                 minConfirmations = 1u,
-                skipSync = false,
                 recipientGroups = listOf(
                     AssetRecipients(
                         assetId = assetId,

--- a/test/python-e2e/harness.py
+++ b/test/python-e2e/harness.py
@@ -210,7 +210,7 @@ def wait_for_channel_funding_tx(
     node_a: rln.SdkNode,
     node_b: rln.SdkNode,
     asset_id,
-    timeout_sec: int = 120,
+    timeout_sec: int = 240,
 ):
     deadline = time.time() + timeout_sec
     last = "no channels"
@@ -266,7 +266,7 @@ def wait_for_usable_channel(
     node_a: rln.SdkNode,
     node_b: rln.SdkNode,
     asset_id,
-    timeout_sec: int = 120,
+    timeout_sec: int = 240,
     mine_every_polls: int = 5,
 ):
     deadline = time.time() + timeout_sec
@@ -302,7 +302,7 @@ def wait_for_usable_channel(
 def wait_for_channel_ready(
     node: rln.SdkNode,
     channel_id,
-    timeout_sec: int = 10,
+    timeout_sec: int = 60,
 ):
     deadline = time.time() + timeout_sec
     last = "channel not found"
@@ -365,7 +365,7 @@ def wait_for_channel_asset_state(
 def wait_for_channel_id(
     node: rln.SdkNode,
     temporary_channel_id,
-    timeout_sec: int = 10,
+    timeout_sec: int = 60,
 ):
     deadline = time.time() + timeout_sec
     last = "mapping not found"
@@ -386,7 +386,7 @@ def wait_for_channel_id(
     )
 
 
-def wait_payment_final(node: rln.SdkNode, invoice: str, timeout_sec: int = 60):
+def wait_payment_final(node: rln.SdkNode, invoice: str, timeout_sec: int = 120):
     deadline = time.time() + timeout_sec
     last = None
     while time.time() < deadline:
@@ -621,8 +621,8 @@ def keysend_with_ln_balance(
     initial_receiver_balance: int,
 ):
     payment_hash = keysend(sender, dest_pubkey, amt_msat, asset_id, asset_amount)
-    wait_for_ln_balance(sender, asset_id, initial_sender_balance - asset_amount, 60)
-    wait_for_ln_balance(receiver, asset_id, initial_receiver_balance + asset_amount, 60)
+    wait_for_ln_balance(sender, asset_id, initial_sender_balance - asset_amount, 120)
+    wait_for_ln_balance(receiver, asset_id, initial_receiver_balance + asset_amount, 120)
     wait_for_payment_status(
         receiver, payment_hash, rln.PaymentType.INBOUND_AUTO_CLAIM, 60
     )

--- a/test/python-e2e/hodl.py
+++ b/test/python-e2e/hodl.py
@@ -155,7 +155,7 @@ def wait_for_peer_channel_funding_tx(
     sender: rln.SdkNode,
     receiver_pubkey,
     asset_id,
-    timeout_sec: int = 120,
+    timeout_sec: int = 240,
 ):
     deadline = time.time() + timeout_sec
     last = "no channels"
@@ -193,7 +193,7 @@ def wait_for_peer_channel_funding_tx(
 def wait_for_channel_usable(
     node: rln.SdkNode,
     channel_id,
-    timeout_sec: int = 120,
+    timeout_sec: int = 240,
 ):
     deadline = time.time() + timeout_sec
     last = "channel not found"
@@ -279,7 +279,7 @@ def open_hodl_asset_channel(
     print(f"Mining {OPEN_CHANNEL_CONFIRM_BLOCKS} blocks for channel confirmations...")
     run_regtest("mine", str(OPEN_CHANNEL_CONFIRM_BLOCKS))
     channel_id = sender.get_channel_id(open_response.temporary_channel_id)
-    wait_for_channel_ready(sender, channel_id, 10)
+    wait_for_channel_ready(sender, channel_id, 60)
     wait_for_channel_usable(sender, channel_id, CHANNEL_READY_TIMEOUT_SEC)
     wait_for_channel_usable(receiver, channel_id, CHANNEL_READY_TIMEOUT_SEC)
     print(f"Channel to {receiver_name} is usable")
@@ -320,7 +320,7 @@ def send_asset_for_second_channel(
     refresh_transfers(receiver)
     refresh_transfers(receiver)
     refresh_transfers(sender)
-    wait_for_balance(receiver, asset_id, asset_amount, 60)
+    wait_for_balance(receiver, asset_id, asset_amount, 180)
 
 
 def assert_decoded_hodl_invoice(decoded, payment_hash_hex: str, asset_id):
@@ -409,7 +409,7 @@ def assert_offchain_balances(
     expected_outbound: int,
     expected_inbound: int,
     node_name: str,
-    timeout_sec: int = 30,
+    timeout_sec: int = 60,
 ):
     deadline = time.time() + timeout_sec
     last_outbound = None
@@ -1070,9 +1070,9 @@ def hodl_e2e_scenario():
         unlock_if_needed(node_b, NODE_B_PASSWORD, "node B")
         unlock_if_needed(node_c, NODE_C_PASSWORD, "node C")
 
-        wait_for_usable_channels(node_a, 1, 120)
-        wait_for_usable_channels(node_b, 2, 120)
-        wait_for_usable_channels(node_c, 1, 120)
+        wait_for_usable_channels(node_a, 1, 240)
+        wait_for_usable_channels(node_b, 2, 240)
+        wait_for_usable_channels(node_c, 1, 240)
         wait_for_channel_usable(node_a, channel_ab, CHANNEL_READY_TIMEOUT_SEC)
         wait_for_channel_usable(node_b, channel_ab, CHANNEL_READY_TIMEOUT_SEC)
         wait_for_channel_usable(node_b, channel_bc, CHANNEL_READY_TIMEOUT_SEC)

--- a/test/python-e2e/hodl.py
+++ b/test/python-e2e/hodl.py
@@ -299,7 +299,6 @@ def send_asset_for_second_channel(
             donation=True,
             fee_rate=1,
             min_confirmations=1,
-            skip_sync=False,
             recipient_groups=[
                 rln.AssetRecipients(
                     asset_id=asset_id,

--- a/test/python-e2e/hodl.py
+++ b/test/python-e2e/hodl.py
@@ -272,7 +272,7 @@ def open_hodl_asset_channel(
     )
 
     funding_txid = wait_for_peer_channel_funding_tx(
-        sender, receiver_info.pubkey, asset_id, 120
+        sender, receiver_info.pubkey, asset_id, 240
     )
     print(f"Mining blocks until {receiver_name} funding tx is confirmed...")
     mine_until_tx_confirmed(sender, funding_txid, 180)

--- a/test/python-e2e/openchannel.py
+++ b/test/python-e2e/openchannel.py
@@ -255,7 +255,7 @@ def openchannel_push_asset_amount_scenario():
         fund_and_create_utxos(node_c, "node C")
 
         asset_id = issue_asset_nia(node_a, "node A")
-        wait_for_balance(node_a, asset_id, 1000, 60)
+        wait_for_balance(node_a, asset_id, 1000, 180)
         peer_uri = f"{node_b_pubkey}@127.0.0.1:{NODE_B_PEER_PORT + peer_offset}"
         node_a.connectpeer(peer_uri)
         wait_for_peer(node_a, node_b_pubkey, 20)
@@ -282,7 +282,7 @@ def openchannel_push_asset_amount_scenario():
             f"{partial_push_channel.temporary_channel_id}"
         )
 
-        funding_txid = wait_for_channel_funding_tx(node_a, node_b, asset_id, 120)
+        funding_txid = wait_for_channel_funding_tx(node_a, node_b, asset_id, 240)
         print("Mining blocks one by one until funding tx is confirmed...")
         mine_until_tx_confirmed(node_a, funding_txid, 180)
         print(f"Mining {OPEN_CHANNEL_CONFIRM_BLOCKS} blocks for channel confirmations...")
@@ -290,7 +290,7 @@ def openchannel_push_asset_amount_scenario():
         partial_channel_id = wait_for_channel_id(
             node_a, partial_push_channel.temporary_channel_id, 10
         )
-        wait_for_channel_ready(node_a, partial_channel_id, 60)
+        wait_for_channel_ready(node_a, partial_channel_id, 120)
         node_a_partial = next(
             c for c in node_a.list_channels() if c.channel_id == partial_channel_id
         )
@@ -356,8 +356,8 @@ def openchannel_push_asset_amount_scenario():
         )
 
         close_channel(node_a, partial_channel_id, node_b_pubkey)
-        wait_for_balance(node_a, asset_id, 700, 70)
-        wait_for_balance(node_b, asset_id, 300, 70)
+        wait_for_balance(node_a, asset_id, 700, 180)
+        wait_for_balance(node_b, asset_id, 300, 180)
 
         full_push_channel = node_a.openchannel(
             rln.SdkOpenChannelRequest(
@@ -380,13 +380,13 @@ def openchannel_push_asset_amount_scenario():
             f"{full_push_channel.temporary_channel_id}"
         )
 
-        funding_txid = wait_for_channel_funding_tx(node_a, node_b, asset_id, 120)
+        funding_txid = wait_for_channel_funding_tx(node_a, node_b, asset_id, 240)
         print("Mining blocks one by one until funding tx is confirmed...")
         mine_until_tx_confirmed(node_a, funding_txid, 180)
         print(f"Mining {OPEN_CHANNEL_CONFIRM_BLOCKS} blocks for channel confirmations...")
         run_regtest("mine", str(OPEN_CHANNEL_CONFIRM_BLOCKS))
         full_channel_id = wait_for_channel_id(node_a, full_push_channel.temporary_channel_id, 10)
-        wait_for_channel_ready(node_a, full_channel_id, 60)
+        wait_for_channel_ready(node_a, full_channel_id, 120)
 
         node_a.shutdown()
         node_b.shutdown()
@@ -399,8 +399,8 @@ def openchannel_push_asset_amount_scenario():
         node_a.unlock(unlock_request(NODE_A_PASSWORD))
         node_b.unlock(unlock_request(NODE_B_PASSWORD))
 
-        wait_for_usable_channels(node_a, 1, 120)
-        wait_for_usable_channels(node_b, 1, 120)
+        wait_for_usable_channels(node_a, 1, 240)
+        wait_for_usable_channels(node_b, 1, 240)
 
         assert asset_balance_spendable(node_a, asset_id) == 100
         assert asset_balance_spendable(node_b, asset_id) == 300
@@ -432,8 +432,8 @@ def openchannel_push_asset_amount_scenario():
         )
 
         close_channel(node_a, full_channel_id, node_b_pubkey)
-        wait_for_balance(node_a, asset_id, 200, 70)
-        wait_for_balance(node_b, asset_id, 800, 70)
+        wait_for_balance(node_a, asset_id, 200, 180)
+        wait_for_balance(node_b, asset_id, 800, 180)
 
         recipient_id = rgb_invoice(node_c)
         node_b.send_rgb(

--- a/test/python-e2e/openchannel.py
+++ b/test/python-e2e/openchannel.py
@@ -441,7 +441,6 @@ def openchannel_push_asset_amount_scenario():
                 donation=True,
                 fee_rate=CREATE_UTXOS_FEE_RATE,
                 min_confirmations=1,
-                skip_sync=False,
                 recipient_groups=[
                     rln.AssetRecipients(
                         asset_id=asset_id,

--- a/test/python-e2e/payment.py
+++ b/test/python-e2e/payment.py
@@ -105,13 +105,13 @@ def payment_scenario():
         )
         print(f"openchannel temporary_channel_id: {open_response.temporary_channel_id}")
 
-        funding_txid = wait_for_channel_funding_tx(node_a, node_b, asset_id, 120)
+        funding_txid = wait_for_channel_funding_tx(node_a, node_b, asset_id, 240)
         print("Mining blocks one by one until funding tx is confirmed...")
         mine_until_tx_confirmed(node_a, funding_txid, 180)
         print(f"Mining {OPEN_CHANNEL_CONFIRM_BLOCKS} blocks for channel confirmations...")
         run_regtest("mine", str(OPEN_CHANNEL_CONFIRM_BLOCKS))
         channel_id = node_a.get_channel_id(open_response.temporary_channel_id)
-        wait_for_channel_ready(node_a, channel_id, 10)
+        wait_for_channel_ready(node_a, channel_id, 60)
         wait_for_usable_channel(node_a, node_b, asset_id, CHANNEL_READY_TIMEOUT_SEC, 5)
         print("Channel is usable")
 


### PR DESCRIPTION
# VSS Cloud Backup

## Overview

VSS (Versioned Storage Service) cloud backup lets a node replicate its state to a remote server so it can be recovered later on a different device. It is fully optional and opt-in: it must be compiled into the build and turned on at startup by pointing the node at a VSS server URL. With it off, the node behaves exactly as a node without the feature.

The goal is disaster recovery: if the machine running the node is lost, a new node initialized with the **same wallet mnemonic** can pull its state back from the VSS server and resume operation.

## What gets backed up

Two independent streams are replicated to the VSS server:

- **Node key-value state** — the Lightning data the node must never lose: channel manager, channel monitors, payment records, swap data, and RGB channel info.
- **RGB wallet data** — the wallet files (assets, allocations, transfers) managed by the underlying RGB library.

Both streams share one VSS server but use separate, isolated namespaces so they never collide.

## When backups are triggered

- **Node key-value state** is backed up **continuously and automatically**: every time the node persists a piece of Lightning state locally, the same update is also sent to the VSS server. There is no schedule and no batching — a backup happens as part of each state change, so the remote copy tracks the node in near real time.
- **RGB wallet data** is backed up **after every state-changing wallet operation** (sending or receiving assets, issuances, channel funding, etc.). It can also be triggered **on demand** via the HTTP API (see below).
- **Restore** is triggered **once, automatically, at unlock** on a fresh node: if the local database has no Lightning state but the VSS server does, the node restores from VSS before it finishes starting up.

## Configuring the node

VSS is controlled entirely by command-line flags on the standalone node.

| Flag | Purpose |
| --- | --- |
| `--vss-url <URL>` | VSS server URL. Setting it enables VSS backup. |
| `--vss-allow-http` | Permit an `http://` URL for non-loopback hosts (otherwise only `https://` and loopback HTTP are allowed). |
| `--vss-allow-empty-restore` | On a fresh device, start with empty state if a restore fails instead of aborting. Use with care. |

By default, only `https://` URLs (or loopback `http://`, e.g. a local dev server) are accepted, so channel state is never sent in plaintext over an untrusted network by mistake.

### Examples

Enable backup against a remote server:

```sh
rgb-lightning-node /path/to/datadir \
  --daemon-listening-port 3001 \
  --ldk-peer-listening-port 9735 \
  --network mainnet \
  --vss-url https://vss.example.com/vss
```

Local development against the bundled regtest VSS server:

```sh
# start regtest services together with a local VSS server
VSS=1 ./regtest.sh start

# run the node pointing at the local server (loopback http is allowed)
cargo run --features vss -- /tmp/rlndata \
  --network regtest \
  --vss-url http://localhost:8081/vss
```

Recover on a new machine: initialize/unlock the node with the **same mnemonic** and the same `--vss-url`. On unlock, the node detects the empty local state and restores from VSS automatically before coming online.

### HTTP API

When VSS is enabled, two endpoints are available:

```sh
# trigger an immediate RGB wallet backup
curl -X POST http://localhost:3001/vssbackup

# check backup health, including how many writes are still pending replication
curl http://localhost:3001/vssbackupinfo
```

A non-zero pending-writes count in `/vssbackupinfo` means some updates have not yet reached the server; monitoring can alert on this to detect a persistently unreachable VSS server.

## How concurrency and atomicity are handled

### Local store is the source of truth

Every write goes to the **local store first and must succeed there**; only then is it replicated to VSS. If the local write fails, the operation fails. This means the node never depends on the network being up to make progress, and the local copy is always authoritative.

### Backups are eventually consistent, not transactional

Replication to VSS is **best-effort**. If a write cannot reach the server, it is placed on an in-memory retry queue and re-sent opportunistically on the next successful write. The queue is bounded; if it overflows, the oldest entry is dropped (the authoritative local copy still holds it). The result is an eventually-consistent remote copy whose staleness is observable via `/vssbackupinfo`.

### Single-writer ownership (preventing concurrent corruption)

Each VSS store is meant to be owned by **exactly one running node at a time**. Two nodes writing to the same store would interleave and corrupt each other's state. To prevent this:

- **At startup** the node claims an ownership marker in the store using a conditional create that only succeeds if no one already holds it. If another instance owns the marker, the second node refuses to start.
- **While running**, the node periodically re-checks that it still owns the marker. If the marker was taken over by someone else, the node stops rather than risk corrupting the other instance's state.

To migrate a store to a new node after the previous owner is definitively gone, the ownership marker is cleared out-of-band (by hand) before starting the new node.

### Atomicity of individual values

Each value is written and encrypted as a single self-contained unit, so a value on the server is either the old version or the new one — never a partial mix. Restores read each value independently (and in parallel for speed), so an interrupted restore can simply be retried.

### Encryption

The key-value stream is **always encrypted at rest** on the server; there is no option to disable it. The encryption key is derived from the wallet mnemonic, so only a node initialized with the same mnemonic can read or restore the backup. This is also why recovery requires the original mnemonic, not just access to the server.

## SDK support

VSS configuration is currently available **only on the standalone node** (via the command-line flags and HTTP endpoints above). The embedded SDK (UniFFI bindings) does not yet expose VSS configuration, so SDK-driven nodes run without cloud backup for now. Exposing VSS through the SDK is a possible future addition.

## Operational summary

- Turn it on with `--vss-url`; everything else is automatic.
- The node keeps working even if the server is down; catch-up happens automatically once it is reachable again.
- Watch the pending-writes count in `/vssbackupinfo` to confirm backups are current.
- Never point two running nodes at the same VSS store.
- Keep the wallet mnemonic safe — it is required to decrypt and restore.
