### PR TITLE
700 Feat/duplicate payment hash handling

### DIFF
--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/ConcurrentBtcPaymentsTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/ConcurrentBtcPaymentsTest.kt
@@ -14,6 +14,7 @@ import org.utexo.rgblightningnode.InvoiceStatus
 import org.utexo.rgblightningnode.LnInvoiceRequest
 import org.utexo.rgblightningnode.Payment
 import org.utexo.rgblightningnode.PaymentHash
+import org.utexo.rgblightningnode.PaymentType
 import org.utexo.rgblightningnode.RlnException
 import org.utexo.rgblightningnode.SdkCreateUtxosRequest
 import org.utexo.rgblightningnode.SdkInitRequest
@@ -238,6 +239,7 @@ class ConcurrentBtcPaymentsTest {
     private fun waitForObservedPayments(
         node: SdkNode,
         paymentHashes: List<PaymentHash>,
+        paymentType: PaymentType,
         timeoutSec: Long,
     ): List<Payment> {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
@@ -246,7 +248,9 @@ class ConcurrentBtcPaymentsTest {
             node.sync()
             val payments = node.listPayments()
             lastPayments = payments
-            val observed = payments.filter { it.paymentHash in paymentHashes }
+            val observed = payments.filter {
+                it.paymentHash in paymentHashes && it.paymentType == paymentType
+            }
             if (observed.size == paymentHashes.size && observed.none { it.status == HtlcStatus.FAILED }) {
                 return observed
             }
@@ -259,11 +263,18 @@ class ConcurrentBtcPaymentsTest {
         )
     }
 
-    private fun waitForPaymentStatus(node: SdkNode, paymentHash: PaymentHash, timeoutSec: Long): Payment {
+    private fun waitForPaymentStatus(
+        node: SdkNode,
+        paymentHash: PaymentHash,
+        paymentType: PaymentType,
+        timeoutSec: Long,
+    ): Payment {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
         var last = "not found"
         while (System.currentTimeMillis() < deadline) {
-            val payment = node.listPayments().firstOrNull { it.paymentHash == paymentHash }
+            val payment = node.listPayments().firstOrNull {
+                it.paymentHash == paymentHash && it.paymentType == paymentType
+            }
             if (payment != null) {
                 last = payment.status.name
                 if (payment.status == HtlcStatus.SUCCEEDED) {
@@ -272,7 +283,7 @@ class ConcurrentBtcPaymentsTest {
             }
             Thread.sleep(1_000L)
         }
-        error("payment did not succeed after ${timeoutSec}s, last=$last")
+        error("payment did not succeed after ${timeoutSec}s, paymentType=$paymentType, last=$last")
     }
 
     private fun waitForInvoiceStatus(
@@ -534,6 +545,7 @@ class ConcurrentBtcPaymentsTest {
             val receiverPayments = waitForObservedPayments(
                 nodeA,
                 listOf(decoded1.paymentHash, decoded2.paymentHash),
+                PaymentType.INBOUND_AUTO_CLAIM,
                 30L,
             )
             dumpNodeState(nodeA, "node A after receiver observation")
@@ -541,8 +553,10 @@ class ConcurrentBtcPaymentsTest {
             assertTrue(receiverPayments.none { it.status == HtlcStatus.FAILED })
 
             log("waiting for sender-side payment success")
-            val payment1Sender = waitForPaymentStatus(nodeC, response1.paymentHash!!, 60L)
-            val payment2Sender = waitForPaymentStatus(nodeD, response2.paymentHash!!, 60L)
+            val payment1Sender =
+                waitForPaymentStatus(nodeC, response1.paymentHash!!, PaymentType.OUTBOUND, 60L)
+            val payment2Sender =
+                waitForPaymentStatus(nodeD, response2.paymentHash!!, PaymentType.OUTBOUND, 60L)
             dumpNodeState(nodeC, "node C after sender success")
             dumpNodeState(nodeD, "node D after sender success")
             assertEquals(HtlcStatus.SUCCEEDED, payment1Sender.status)

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/ConcurrentBtcPaymentsTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/ConcurrentBtcPaymentsTest.kt
@@ -263,14 +263,12 @@ class ConcurrentBtcPaymentsTest {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
         var last = "not found"
         while (System.currentTimeMillis() < deadline) {
-            try {
-                val payment = node.getPayment(paymentHash)
+            val payment = node.listPayments().firstOrNull { it.paymentHash == paymentHash }
+            if (payment != null) {
                 last = payment.status.name
                 if (payment.status == HtlcStatus.SUCCEEDED) {
                     return payment
                 }
-            } catch (_: RlnException.NotFound) {
-                last = "not found"
             }
             Thread.sleep(1_000L)
         }

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
@@ -14,6 +14,7 @@ import org.utexo.rgblightningnode.ContractId
 import org.utexo.rgblightningnode.HtlcStatus
 import org.utexo.rgblightningnode.LnInvoiceRequest
 import org.utexo.rgblightningnode.PaymentHash
+import org.utexo.rgblightningnode.PaymentType
 import org.utexo.rgblightningnode.RgbRecipient
 import org.utexo.rgblightningnode.RlnException
 import org.utexo.rgblightningnode.SdkCloseChannelRequest
@@ -246,11 +247,18 @@ class MultiOpenCloseTest {
         error("channel not usable after ${timeoutSec}s")
     }
 
-    private fun waitForPaymentStatus(node: SdkNode, paymentHash: PaymentHash, timeoutSec: Long) {
+    private fun waitForPaymentStatus(
+        node: SdkNode,
+        paymentHash: PaymentHash,
+        paymentType: PaymentType,
+        timeoutSec: Long,
+    ) {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
         var last = "not found"
         while (System.currentTimeMillis() < deadline) {
-            val payment = node.listPayments().firstOrNull { it.paymentHash == paymentHash }
+            val payment = node.listPayments().firstOrNull {
+                it.paymentHash == paymentHash && it.paymentType == paymentType
+            }
             if (payment != null) {
                 last = payment.status.name
                 if (payment.status == HtlcStatus.SUCCEEDED) {
@@ -259,7 +267,7 @@ class MultiOpenCloseTest {
             }
             Thread.sleep(1_000L)
         }
-        error("payment did not succeed after ${timeoutSec}s, last=$last")
+        error("payment did not succeed after ${timeoutSec}s, paymentType=$paymentType, last=$last")
     }
 
     private fun keysend(
@@ -281,7 +289,7 @@ class MultiOpenCloseTest {
             "unexpected keysend status: ${response.status}",
             response.status == HtlcStatus.PENDING || response.status == HtlcStatus.SUCCEEDED
         )
-        waitForPaymentStatus(sender, response.paymentHash, 60L)
+        waitForPaymentStatus(sender, response.paymentHash, PaymentType.OUTBOUND, 60L)
         return response.paymentHash
     }
 

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
@@ -250,14 +250,12 @@ class MultiOpenCloseTest {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
         var last = "not found"
         while (System.currentTimeMillis() < deadline) {
-            try {
-                val payment = node.getPayment(paymentHash)
+            val payment = node.listPayments().firstOrNull { it.paymentHash == paymentHash }
+            if (payment != null) {
                 last = payment.status.name
                 if (payment.status == HtlcStatus.SUCCEEDED) {
                     return
                 }
-            } catch (_: RlnException.NotFound) {
-                last = "not found"
             }
             Thread.sleep(1_000L)
         }

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
@@ -299,14 +299,12 @@ class PaymentTest {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
         var last = "not found"
         while (System.currentTimeMillis() < deadline) {
-            try {
-                val payment = node.getPayment(paymentHash)
+            val payment = node.listPayments().firstOrNull { it.paymentHash == paymentHash }
+            if (payment != null) {
                 last = payment.status.name
                 if (payment.status == HtlcStatus.SUCCEEDED) {
                     return payment
                 }
-            } catch (_: RlnException.NotFound) {
-                last = "not found"
             }
             Thread.sleep(1_000L)
         }

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
@@ -18,6 +18,7 @@ import org.utexo.rgblightningnode.InvoiceStatus
 import org.utexo.rgblightningnode.LnInvoiceRequest
 import org.utexo.rgblightningnode.Payment
 import org.utexo.rgblightningnode.PaymentHash
+import org.utexo.rgblightningnode.PaymentType
 import org.utexo.rgblightningnode.RgbRecipient
 import org.utexo.rgblightningnode.RlnException
 import org.utexo.rgblightningnode.SdkCloseChannelRequest
@@ -295,11 +296,18 @@ class PaymentTest {
         error("invoice did not finalize after ${timeoutSec}s, last=$last")
     }
 
-    private fun waitForPaymentStatus(node: SdkNode, paymentHash: PaymentHash, timeoutSec: Long): Payment {
+    private fun waitForPaymentStatus(
+        node: SdkNode,
+        paymentHash: PaymentHash,
+        paymentType: PaymentType,
+        timeoutSec: Long,
+    ): Payment {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
         var last = "not found"
         while (System.currentTimeMillis() < deadline) {
-            val payment = node.listPayments().firstOrNull { it.paymentHash == paymentHash }
+            val payment = node.listPayments().firstOrNull {
+                it.paymentHash == paymentHash && it.paymentType == paymentType
+            }
             if (payment != null) {
                 last = payment.status.name
                 if (payment.status == HtlcStatus.SUCCEEDED) {
@@ -308,22 +316,32 @@ class PaymentTest {
             }
             Thread.sleep(1_000L)
         }
-        error("payment did not succeed after ${timeoutSec}s, last=$last")
+        error("payment did not succeed after ${timeoutSec}s, paymentType=$paymentType, last=$last")
     }
 
-    private fun waitForPaymentPresentInList(node: SdkNode, paymentHash: PaymentHash, timeoutSec: Long): Payment {
+    private fun waitForPaymentPresentInList(
+        node: SdkNode,
+        paymentHash: PaymentHash,
+        paymentType: PaymentType,
+        timeoutSec: Long,
+    ): Payment {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
         var lastCount = 0
         while (System.currentTimeMillis() < deadline) {
             val payments = node.listPayments()
             lastCount = payments.size
-            val payment = payments.firstOrNull { it.paymentHash == paymentHash }
+            val payment = payments.firstOrNull {
+                it.paymentHash == paymentHash && it.paymentType == paymentType
+            }
             if (payment != null) {
                 return payment
             }
             Thread.sleep(1_000L)
         }
-        error("payment not found in listPayments: paymentHash=$paymentHash list_size=$lastCount after ${timeoutSec}s")
+        error(
+            "payment not found in listPayments: paymentHash=$paymentHash paymentType=$paymentType " +
+                "list_size=$lastCount after ${timeoutSec}s"
+        )
     }
 
     private fun sendPaymentWithLnBalance(
@@ -540,23 +558,43 @@ class PaymentTest {
             assertEquals("Regtest", decoded1.network)
             assertEquals(InvoiceStatus.SUCCEEDED, nodeB.invoiceStatus(invoice1))
 
-            val payment1Sender = waitForPaymentStatus(nodeA, decoded1.paymentHash, 60L)
+            val payment1Sender = waitForPaymentStatus(
+                nodeA,
+                decoded1.paymentHash,
+                PaymentType.OUTBOUND,
+                60L,
+            )
             assertEquals(HtlcStatus.SUCCEEDED, payment1Sender.status)
             assertEquals(assetId, payment1Sender.assetId)
             assertEquals(100uL, payment1Sender.assetAmount)
             checkPreimageMatchesHash(payment1Sender, decoded1.paymentHash)
 
-            val payment1Receiver = waitForPaymentStatus(nodeB, decoded1.paymentHash, 60L)
+            val payment1Receiver = waitForPaymentStatus(
+                nodeB,
+                decoded1.paymentHash,
+                PaymentType.INBOUND_AUTO_CLAIM,
+                60L,
+            )
             assertEquals(HtlcStatus.SUCCEEDED, payment1Receiver.status)
             assertEquals(assetId, payment1Receiver.assetId)
             assertEquals(100uL, payment1Receiver.assetAmount)
             checkPreimageMatchesHash(payment1Receiver, decoded1.paymentHash)
 
-            val listedPayment1Sender = waitForPaymentPresentInList(nodeA, decoded1.paymentHash, 60L)
+            val listedPayment1Sender = waitForPaymentPresentInList(
+                nodeA,
+                decoded1.paymentHash,
+                PaymentType.OUTBOUND,
+                60L,
+            )
             assertEquals(decoded1.paymentHash, listedPayment1Sender.paymentHash)
             checkPreimageMatchesHash(listedPayment1Sender, decoded1.paymentHash)
 
-            val listedPayment1Receiver = waitForPaymentPresentInList(nodeB, decoded1.paymentHash, 60L)
+            val listedPayment1Receiver = waitForPaymentPresentInList(
+                nodeB,
+                decoded1.paymentHash,
+                PaymentType.INBOUND_AUTO_CLAIM,
+                60L,
+            )
             assertEquals(decoded1.paymentHash, listedPayment1Receiver.paymentHash)
             checkPreimageMatchesHash(listedPayment1Receiver, decoded1.paymentHash)
 
@@ -573,12 +611,22 @@ class PaymentTest {
             sendPaymentWithLnBalance(nodeB, nodeA, invoice2, assetId, 50u, 100u, 500u)
 
             val decoded2 = nodeA.decodeLnInvoice(invoice2)
-            val payment2Receiver = waitForPaymentStatus(nodeA, decoded2.paymentHash, 60L)
+            val payment2Receiver = waitForPaymentStatus(
+                nodeA,
+                decoded2.paymentHash,
+                PaymentType.INBOUND_AUTO_CLAIM,
+                60L,
+            )
             assertEquals(assetId, payment2Receiver.assetId)
             assertEquals(50uL, payment2Receiver.assetAmount)
             assertEquals(HtlcStatus.SUCCEEDED, payment2Receiver.status)
             checkPreimageMatchesHash(payment2Receiver, decoded2.paymentHash)
-            val payment2Sender = waitForPaymentStatus(nodeB, decoded2.paymentHash, 60L)
+            val payment2Sender = waitForPaymentStatus(
+                nodeB,
+                decoded2.paymentHash,
+                PaymentType.OUTBOUND,
+                60L,
+            )
             assertEquals(assetId, payment2Sender.assetId)
             assertEquals(50uL, payment2Sender.assetAmount)
             assertEquals(HtlcStatus.SUCCEEDED, payment2Sender.status)
@@ -603,12 +651,22 @@ class PaymentTest {
                 )
             )
             val decoded3 = nodeA.decodeLnInvoice(invoice3)
-            val payment3Sender = waitForPaymentStatus(nodeA, decoded3.paymentHash, 60L)
+            val payment3Sender = waitForPaymentStatus(
+                nodeA,
+                decoded3.paymentHash,
+                PaymentType.OUTBOUND,
+                60L,
+            )
             assertEquals(assetId, payment3Sender.assetId)
             assertEquals(50uL, payment3Sender.assetAmount)
             assertEquals(HtlcStatus.SUCCEEDED, payment3Sender.status)
             checkPreimageMatchesHash(payment3Sender, decoded3.paymentHash)
-            val payment3Receiver = waitForPaymentStatus(nodeB, decoded3.paymentHash, 60L)
+            val payment3Receiver = waitForPaymentStatus(
+                nodeB,
+                decoded3.paymentHash,
+                PaymentType.INBOUND_AUTO_CLAIM,
+                60L,
+            )
             assertEquals(assetId, payment3Receiver.assetId)
             assertEquals(50uL, payment3Receiver.assetAmount)
             assertEquals(HtlcStatus.SUCCEEDED, payment3Receiver.status)
@@ -633,12 +691,22 @@ class PaymentTest {
                 )
             )
             val decoded4 = nodeA.decodeLnInvoice(invoice4)
-            val payment4Receiver = waitForPaymentStatus(nodeA, decoded4.paymentHash, 60L)
+            val payment4Receiver = waitForPaymentStatus(
+                nodeA,
+                decoded4.paymentHash,
+                PaymentType.INBOUND_AUTO_CLAIM,
+                60L,
+            )
             assertEquals(assetId, payment4Receiver.assetId)
             assertEquals(50uL, payment4Receiver.assetAmount)
             assertEquals(HtlcStatus.SUCCEEDED, payment4Receiver.status)
             checkPreimageMatchesHash(payment4Receiver, decoded4.paymentHash)
-            val payment4Sender = waitForPaymentStatus(nodeB, decoded4.paymentHash, 60L)
+            val payment4Sender = waitForPaymentStatus(
+                nodeB,
+                decoded4.paymentHash,
+                PaymentType.OUTBOUND,
+                60L,
+            )
             assertEquals(assetId, payment4Sender.assetId)
             assertEquals(50uL, payment4Sender.assetAmount)
             assertEquals(HtlcStatus.SUCCEEDED, payment4Sender.status)

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
@@ -280,14 +280,12 @@ class RestartTest {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
         var last = "not found"
         while (System.currentTimeMillis() < deadline) {
-            try {
-                val payment = node.getPayment(paymentHash)
+            val payment = node.listPayments().firstOrNull { it.paymentHash == paymentHash }
+            if (payment != null) {
                 last = payment.status.name
                 if (payment.status == HtlcStatus.SUCCEEDED) {
                     return payment
                 }
-            } catch (_: RlnException.NotFound) {
-                last = "not found"
             }
             Thread.sleep(1_000L)
         }

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
@@ -15,6 +15,7 @@ import org.utexo.rgblightningnode.HtlcStatus
 import org.utexo.rgblightningnode.LnInvoiceRequest
 import org.utexo.rgblightningnode.Payment
 import org.utexo.rgblightningnode.PaymentHash
+import org.utexo.rgblightningnode.PaymentType
 import org.utexo.rgblightningnode.RgbRecipient
 import org.utexo.rgblightningnode.RlnException
 import org.utexo.rgblightningnode.SdkCloseChannelRequest
@@ -276,11 +277,18 @@ class RestartTest {
         error("usable channel count did not become expected=$expectedCount actual=$lastCount")
     }
 
-    private fun waitForPaymentStatus(node: SdkNode, paymentHash: PaymentHash, timeoutSec: Long): Payment {
+    private fun waitForPaymentStatus(
+        node: SdkNode,
+        paymentHash: PaymentHash,
+        paymentType: PaymentType,
+        timeoutSec: Long,
+    ): Payment {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
         var last = "not found"
         while (System.currentTimeMillis() < deadline) {
-            val payment = node.listPayments().firstOrNull { it.paymentHash == paymentHash }
+            val payment = node.listPayments().firstOrNull {
+                it.paymentHash == paymentHash && it.paymentType == paymentType
+            }
             if (payment != null) {
                 last = payment.status.name
                 if (payment.status == HtlcStatus.SUCCEEDED) {
@@ -289,22 +297,32 @@ class RestartTest {
             }
             Thread.sleep(1_000L)
         }
-        error("payment did not succeed after ${timeoutSec}s, last=$last")
+        error("payment did not succeed after ${timeoutSec}s, paymentType=$paymentType, last=$last")
     }
 
-    private fun waitForSucceededPaymentInList(node: SdkNode, paymentHash: PaymentHash, timeoutSec: Long) {
+    private fun waitForSucceededPaymentInList(
+        node: SdkNode,
+        paymentHash: PaymentHash,
+        paymentType: PaymentType,
+        timeoutSec: Long,
+    ) {
         val deadline = System.currentTimeMillis() + timeoutSec * 1_000L
         var lastCount = 0
         while (System.currentTimeMillis() < deadline) {
             val payments = node.listPayments()
             lastCount = payments.size
-            val payment = payments.firstOrNull { it.paymentHash == paymentHash }
+            val payment = payments.firstOrNull {
+                it.paymentHash == paymentHash && it.paymentType == paymentType
+            }
             if (payment != null && payment.status == HtlcStatus.SUCCEEDED) {
                 return
             }
             Thread.sleep(1_000L)
         }
-        error("succeeded payment not found in listPayments: paymentHash=$paymentHash list_size=$lastCount")
+        error(
+            "succeeded payment not found in listPayments: paymentHash=$paymentHash paymentType=$paymentType " +
+                "list_size=$lastCount"
+        )
     }
 
     private fun closeChannel(node: SdkNode, channelId: String, peerPubkey: String, force: Boolean = false) {
@@ -497,7 +515,7 @@ class RestartTest {
                 )
             )
             val paymentHash = requireNotNull(sendPayment.paymentHash)
-            waitForPaymentStatus(requireNotNull(nodeA), paymentHash, 60L)
+            waitForPaymentStatus(requireNotNull(nodeA), paymentHash, PaymentType.OUTBOUND, 60L)
 
             safeShutdown(nodeA); safeShutdown(nodeB)
             pauseAfterShutdown()
@@ -511,8 +529,18 @@ class RestartTest {
             waitForChannelReady(requireNotNull(nodeA), channelId, 10L)
             waitForUsableChannels(requireNotNull(nodeA), 1, 60L)
             waitForUsableChannels(requireNotNull(nodeB), 1, 60L)
-            waitForSucceededPaymentInList(requireNotNull(nodeA), paymentHash, 30L)
-            waitForSucceededPaymentInList(requireNotNull(nodeB), paymentHash, 30L)
+            waitForSucceededPaymentInList(
+                requireNotNull(nodeA),
+                paymentHash,
+                PaymentType.OUTBOUND,
+                30L,
+            )
+            waitForSucceededPaymentInList(
+                requireNotNull(nodeB),
+                paymentHash,
+                PaymentType.INBOUND_AUTO_CLAIM,
+                30L,
+            )
 
             closeChannel(requireNotNull(nodeA), channelId, nodeBPubkey)
             waitForBalance(requireNotNull(nodeA), assetId, 900uL, 70L)

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -11,7 +11,7 @@ interface SdkNode {
     [Throws=RlnError]
     ChannelId get_channel_id(ChannelId temporary_channel_id);
     [Throws=RlnError]
-    Payment get_payment(PaymentHash payment_hash);
+    Payment get_payment(PaymentHash payment_hash, PaymentType payment_type);
     [Throws=RlnError]
     sequence<Payment> list_payments();
     [Throws=RlnError]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1852,10 +1852,13 @@ components:
       type: object
       required:
         - payment_hash
+        - payment_type
       properties:
         payment_hash:
           type: string
           example: 5ca5d81b482b4015e7b14df7a27fe0a38c226273604ffd3b008b752571811938
+        payment_type:
+          $ref: '#/components/schemas/PaymentType'
     GetPaymentResponse:
       type: object
       required:

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -608,6 +608,7 @@ pub(crate) struct GetChannelIdResponse {
 #[derive(Deserialize, Serialize)]
 pub(crate) struct GetPaymentRequest {
     pub(crate) payment_hash: String,
+    pub(crate) payment_type: PaymentType,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -2050,65 +2051,77 @@ pub(crate) async fn get_payment(
 
     let requested_ph = validate_and_parse_payment_hash(&payload.payment_hash)?;
 
-    let inbound_payments = unlocked_state.list_updated_inbound_payments();
-    let outbound_payments = unlocked_state.outbound_payments();
+    match payload.payment_type {
+        PaymentType::InboundAutoClaim | PaymentType::InboundHodl => {
+            let inbound_payments = unlocked_state.list_updated_inbound_payments();
+            for (payment_hash, payment_info) in &inbound_payments {
+                if payment_hash == &requested_ph
+                    && payment_type_from_invoice(payment_info.invoice_type) == payload.payment_type
+                {
+                    let rgb_payment_info_path_inbound = get_rgb_payment_info_path(
+                        payment_hash,
+                        &state.static_state.ldk_data_dir,
+                        true,
+                    );
 
-    for (payment_hash, payment_info) in &inbound_payments {
-        if payment_hash == &requested_ph {
-            let rgb_payment_info_path_inbound =
-                get_rgb_payment_info_path(payment_hash, &state.static_state.ldk_data_dir, true);
+                    let (asset_amount, asset_id) = if rgb_payment_info_path_inbound.exists() {
+                        let info = parse_rgb_payment_info(&rgb_payment_info_path_inbound);
+                        (Some(info.amount), Some(info.contract_id.to_string()))
+                    } else {
+                        (None, None)
+                    };
 
-            let (asset_amount, asset_id) = if rgb_payment_info_path_inbound.exists() {
-                let info = parse_rgb_payment_info(&rgb_payment_info_path_inbound);
-                (Some(info.amount), Some(info.contract_id.to_string()))
-            } else {
-                (None, None)
-            };
-
-            return Ok(Json(GetPaymentResponse {
-                payment: Payment {
-                    amt_msat: payment_info.amt_msat,
-                    asset_amount,
-                    asset_id,
-                    payment_hash: hex_str(&payment_hash.0),
-                    payment_type: payment_type_from_invoice(payment_info.invoice_type),
-                    status: payment_info.status,
-                    created_at: payment_info.created_at,
-                    updated_at: payment_info.updated_at,
-                    payee_pubkey: payment_info.payee_pubkey.to_string(),
-                    preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
-                },
-            }));
+                    return Ok(Json(GetPaymentResponse {
+                        payment: Payment {
+                            amt_msat: payment_info.amt_msat,
+                            asset_amount,
+                            asset_id,
+                            payment_hash: hex_str(&payment_hash.0),
+                            payment_type: payment_type_from_invoice(payment_info.invoice_type),
+                            status: payment_info.status,
+                            created_at: payment_info.created_at,
+                            updated_at: payment_info.updated_at,
+                            payee_pubkey: payment_info.payee_pubkey.to_string(),
+                            preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                        },
+                    }));
+                }
+            }
         }
-    }
+        PaymentType::Outbound => {
+            let outbound_payments = unlocked_state.outbound_payments();
+            for (payment_id, payment_info) in &outbound_payments {
+                let payment_hash = &PaymentHash(payment_id.0);
+                if payment_hash == &requested_ph {
+                    let rgb_payment_info_path_outbound = get_rgb_payment_info_path(
+                        payment_hash,
+                        &state.static_state.ldk_data_dir,
+                        false,
+                    );
 
-    for (payment_id, payment_info) in &outbound_payments {
-        let payment_hash = &PaymentHash(payment_id.0);
-        if payment_hash == &requested_ph {
-            let rgb_payment_info_path_outbound =
-                get_rgb_payment_info_path(payment_hash, &state.static_state.ldk_data_dir, false);
+                    let (asset_amount, asset_id) = if rgb_payment_info_path_outbound.exists() {
+                        let info = parse_rgb_payment_info(&rgb_payment_info_path_outbound);
+                        (Some(info.amount), Some(info.contract_id.to_string()))
+                    } else {
+                        (None, None)
+                    };
 
-            let (asset_amount, asset_id) = if rgb_payment_info_path_outbound.exists() {
-                let info = parse_rgb_payment_info(&rgb_payment_info_path_outbound);
-                (Some(info.amount), Some(info.contract_id.to_string()))
-            } else {
-                (None, None)
-            };
-
-            return Ok(Json(GetPaymentResponse {
-                payment: Payment {
-                    amt_msat: payment_info.amt_msat,
-                    asset_amount,
-                    asset_id,
-                    payment_hash: hex_str(&payment_hash.0),
-                    payment_type: PaymentType::Outbound,
-                    status: payment_info.status,
-                    created_at: payment_info.created_at,
-                    updated_at: payment_info.updated_at,
-                    payee_pubkey: payment_info.payee_pubkey.to_string(),
-                    preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
-                },
-            }));
+                    return Ok(Json(GetPaymentResponse {
+                        payment: Payment {
+                            amt_msat: payment_info.amt_msat,
+                            asset_amount,
+                            asset_id,
+                            payment_hash: hex_str(&payment_hash.0),
+                            payment_type: PaymentType::Outbound,
+                            status: payment_info.status,
+                            created_at: payment_info.created_at,
+                            updated_at: payment_info.updated_at,
+                            payee_pubkey: payment_info.payee_pubkey.to_string(),
+                            preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                        },
+                    }));
+                }
+            }
         }
     }
 

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -673,7 +673,7 @@ pub(crate) enum ChannelStatus {
 
 pub(crate) type HtlcStatus = crate::core_types::HTLCStatus;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum PaymentType {
     Outbound,
     InboundAutoClaim,
@@ -3282,6 +3282,7 @@ pub(crate) async fn list_payments(state: Arc<AppState>) -> Result<Vec<PaymentDat
 pub(crate) async fn get_payment(
     state: Arc<AppState>,
     payment_hash_hex: String,
+    payment_type: PaymentType,
 ) -> Result<PaymentData, APIError> {
     let guard = check_unlocked(&state).await?;
     let unlocked_state = guard.as_ref().unwrap();
@@ -3292,62 +3293,73 @@ pub(crate) async fn get_payment(
     }
     let requested_ph = PaymentHash(payment_hash_vec.unwrap().try_into().unwrap());
 
-    // Keep inbound invoice status consistent with expiry when a specific payment is read.
-    let inbound_payments = unlocked_state.list_updated_inbound_payments();
-    let outbound_payments = unlocked_state.outbound_payments();
+    match payment_type {
+        PaymentType::InboundAutoClaim | PaymentType::InboundHodl => {
+            let inbound_payments = unlocked_state.list_updated_inbound_payments();
+            for (payment_hash, payment_info) in &inbound_payments {
+                if payment_hash == &requested_ph
+                    && payment_type_from_invoice(payment_info.invoice_type) == payment_type
+                {
+                    let rgb_payment_info_path_inbound = get_rgb_payment_info_path(
+                        payment_hash,
+                        &state.static_state.ldk_data_dir,
+                        true,
+                    );
 
-    for (payment_hash, payment_info) in &inbound_payments {
-        if payment_hash == &requested_ph {
-            let rgb_payment_info_path_inbound =
-                get_rgb_payment_info_path(payment_hash, &state.static_state.ldk_data_dir, true);
+                    let (asset_amount, asset_id) = if rgb_payment_info_path_inbound.exists() {
+                        let info = parse_rgb_payment_info(&rgb_payment_info_path_inbound);
+                        (Some(info.amount), Some(info.contract_id.to_string()))
+                    } else {
+                        (None, None)
+                    };
 
-            let (asset_amount, asset_id) = if rgb_payment_info_path_inbound.exists() {
-                let info = parse_rgb_payment_info(&rgb_payment_info_path_inbound);
-                (Some(info.amount), Some(info.contract_id.to_string()))
-            } else {
-                (None, None)
-            };
-
-            return Ok(PaymentData {
-                amt_msat: payment_info.amt_msat,
-                asset_amount,
-                asset_id,
-                payment_hash: hex_str(&payment_hash.0),
-                payment_type: payment_type_from_invoice(payment_info.invoice_type),
-                status: payment_info.status,
-                created_at: payment_info.created_at,
-                updated_at: payment_info.updated_at,
-                payee_pubkey: payment_info.payee_pubkey.to_string(),
-                preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
-            });
+                    return Ok(PaymentData {
+                        amt_msat: payment_info.amt_msat,
+                        asset_amount,
+                        asset_id,
+                        payment_hash: hex_str(&payment_hash.0),
+                        payment_type: payment_type_from_invoice(payment_info.invoice_type),
+                        status: payment_info.status,
+                        created_at: payment_info.created_at,
+                        updated_at: payment_info.updated_at,
+                        payee_pubkey: payment_info.payee_pubkey.to_string(),
+                        preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                    });
+                }
+            }
         }
-    }
+        PaymentType::Outbound => {
+            let outbound_payments = unlocked_state.outbound_payments();
+            for (payment_id, payment_info) in &outbound_payments {
+                let payment_hash = &PaymentHash(payment_id.0);
+                if payment_hash == &requested_ph {
+                    let rgb_payment_info_path_outbound = get_rgb_payment_info_path(
+                        payment_hash,
+                        &state.static_state.ldk_data_dir,
+                        false,
+                    );
 
-    for (payment_id, payment_info) in &outbound_payments {
-        let payment_hash = &PaymentHash(payment_id.0);
-        if payment_hash == &requested_ph {
-            let rgb_payment_info_path_outbound =
-                get_rgb_payment_info_path(payment_hash, &state.static_state.ldk_data_dir, false);
+                    let (asset_amount, asset_id) = if rgb_payment_info_path_outbound.exists() {
+                        let info = parse_rgb_payment_info(&rgb_payment_info_path_outbound);
+                        (Some(info.amount), Some(info.contract_id.to_string()))
+                    } else {
+                        (None, None)
+                    };
 
-            let (asset_amount, asset_id) = if rgb_payment_info_path_outbound.exists() {
-                let info = parse_rgb_payment_info(&rgb_payment_info_path_outbound);
-                (Some(info.amount), Some(info.contract_id.to_string()))
-            } else {
-                (None, None)
-            };
-
-            return Ok(PaymentData {
-                amt_msat: payment_info.amt_msat,
-                asset_amount,
-                asset_id,
-                payment_hash: hex_str(&payment_hash.0),
-                payment_type: PaymentType::Outbound,
-                status: payment_info.status,
-                created_at: payment_info.created_at,
-                updated_at: payment_info.updated_at,
-                payee_pubkey: payment_info.payee_pubkey.to_string(),
-                preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
-            });
+                    return Ok(PaymentData {
+                        amt_msat: payment_info.amt_msat,
+                        asset_amount,
+                        asset_id,
+                        payment_hash: hex_str(&payment_hash.0),
+                        payment_type: PaymentType::Outbound,
+                        status: payment_info.status,
+                        created_at: payment_info.created_at,
+                        updated_at: payment_info.updated_at,
+                        payee_pubkey: payment_info.payee_pubkey.to_string(),
+                        preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                    });
+                }
+            }
         }
     }
 

--- a/src/test/hodl_invoice.rs
+++ b/src/test/hodl_invoice.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 const TEST_DIR_BASE: &str = "tmp/hodl_invoice/";
+const RGB_PAYMENT_AMOUNT: u64 = 1;
 
 #[derive(Clone, Copy)]
 enum ExpiryTrigger {
@@ -162,7 +163,8 @@ async fn run_expire_hodl_invoice_case(
     wait_for_claimable_state(test_dir_node2, &payment_hash_hex, false)
         .await
         .unwrap_or_else(|err| panic!("wait for claimable entry to be removed: {err}"));
-    let payee_payment = get_payment(node2_addr, &decoded.payment_hash).await;
+    let payee_payment =
+        get_payment(node2_addr, &decoded.payment_hash, PaymentType::InboundHodl).await;
     assert!(matches!(
         invoice_status(node2_addr, &invoice).await,
         InvoiceStatus::Failed
@@ -178,7 +180,8 @@ async fn run_expire_hodl_invoice_case(
         payee_payment_from_list.payment_type,
         PaymentType::InboundHodl
     );
-    let payee_payment_again = get_payment(node2_addr, &decoded.payment_hash).await;
+    let payee_payment_again =
+        get_payment(node2_addr, &decoded.payment_hash, PaymentType::InboundHodl).await;
     assert_eq!(payee_payment_again.payment_type, PaymentType::InboundHodl);
     assert_eq!(payee_payment_again.status, HTLCStatus::Failed);
     wait_for_claimable_state(test_dir_node2, &payment_hash_hex, false)
@@ -243,6 +246,90 @@ async fn setup_two_nodes_with_asset_channel(
         node2_addr,
         test_dir_node1,
         test_dir_node2,
+        asset_id,
+    )
+}
+
+async fn setup_three_virtual_nodes_with_hub_channels(
+    test_dir_suffix: &str,
+) -> (SocketAddr, SocketAddr, SocketAddr, String, String, String) {
+    let test_dir_base = format!("{TEST_DIR_BASE}{test_dir_suffix}/");
+    let test_dir_lsp = format!("{test_dir_base}lsp");
+    let test_dir_payer_client = format!("{test_dir_base}payer_client");
+    let test_dir_recipient_client = format!("{test_dir_base}recipient_client");
+
+    let lsp_peer_port = next_peer_port();
+    let mut payer_client_peer_port = next_peer_port();
+    while payer_client_peer_port == lsp_peer_port {
+        payer_client_peer_port = next_peer_port();
+    }
+    let mut recipient_client_peer_port = next_peer_port();
+    while recipient_client_peer_port == lsp_peer_port
+        || recipient_client_peer_port == payer_client_peer_port
+    {
+        recipient_client_peer_port = next_peer_port();
+    }
+
+    let (lsp_addr, _) =
+        start_node_with_virtual_options(&test_dir_lsp, lsp_peer_port, false, true, vec![]).await;
+    fund_and_create_utxos(lsp_addr, None).await;
+    let asset_id = issue_asset_nia_with_amounts(lsp_addr, vec![500, 500])
+        .await
+        .asset_id;
+    fund_and_create_utxos(lsp_addr, None).await;
+
+    let lsp_pubkey = node_info(lsp_addr).await.pubkey;
+    let trusted_lsp_pubkey = bitcoin::secp256k1::PublicKey::from_str(&lsp_pubkey).unwrap();
+
+    let (payer_client_addr, _) = start_node_with_virtual_options(
+        &test_dir_payer_client,
+        payer_client_peer_port,
+        false,
+        true,
+        vec![trusted_lsp_pubkey],
+    )
+    .await;
+    let (recipient_client_addr, _) = start_node_with_virtual_options(
+        &test_dir_recipient_client,
+        recipient_client_peer_port,
+        false,
+        true,
+        vec![bitcoin::secp256k1::PublicKey::from_str(&lsp_pubkey).unwrap()],
+    )
+    .await;
+
+    let payer_client_pubkey = node_info(payer_client_addr).await.pubkey;
+    let recipient_client_pubkey = node_info(recipient_client_addr).await.pubkey;
+
+    open_virtual_channel(
+        lsp_addr,
+        &payer_client_pubkey,
+        Some(payer_client_peer_port),
+        Some(100_000),
+        Some(10_000_000),
+        Some(RGB_PAYMENT_AMOUNT * 3),
+        Some(&asset_id),
+        Some(RGB_PAYMENT_AMOUNT),
+    )
+    .await;
+    open_virtual_channel(
+        lsp_addr,
+        &recipient_client_pubkey,
+        Some(recipient_client_peer_port),
+        Some(100_000),
+        None,
+        Some(RGB_PAYMENT_AMOUNT * 3),
+        Some(&asset_id),
+        None,
+    )
+    .await;
+
+    (
+        lsp_addr,
+        payer_client_addr,
+        recipient_client_addr,
+        test_dir_lsp,
+        test_dir_recipient_client,
         asset_id,
     )
 }
@@ -634,4 +721,196 @@ async fn claim_hodl_invoice_btc_rgb() {
     .await;
 
     shutdown(&[node1_addr, node2_addr]).await;
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn inbound_payment_blocks_outbound_btc_payment_with_same_hash() {
+    initialize();
+
+    let (
+        lsp_addr,
+        payer_client_addr,
+        recipient_client_addr,
+        test_dir_lsp,
+        _test_dir_recipient_client,
+        asset_id,
+    ) = setup_three_virtual_nodes_with_hub_channels("swap-hodl-btc").await;
+    let _initial_lsp_rgb_balance = asset_balance_offchain_outbound(lsp_addr, &asset_id).await;
+
+    let (_, payment_hash) = random_preimage_and_hash();
+    let LNInvoiceResponse {
+        invoice: inbound_invoice,
+    } = ln_invoice_hodl(
+        lsp_addr,
+        Some(HTLC_MIN_MSAT),
+        Some(&asset_id),
+        Some(RGB_PAYMENT_AMOUNT),
+        600,
+        Some(payment_hash.clone()),
+    )
+    .await;
+
+    let payer_payment = send_payment_with_status(
+        payer_client_addr,
+        inbound_invoice.clone(),
+        HTLCStatus::Pending,
+    )
+    .await;
+    assert_eq!(payer_payment.payment_type, PaymentType::Outbound);
+
+    wait_for_claimable_state(&test_dir_lsp, &payment_hash, true)
+        .await
+        .unwrap_or_else(|err| panic!("wait for claimable entry to appear: {err}"));
+    let lsp_claimable_payment =
+        wait_for_ln_payment(lsp_addr, &payment_hash, HTLCStatus::Claimable).await;
+    assert_eq!(lsp_claimable_payment.payment_type, PaymentType::InboundHodl);
+    assert!(matches!(
+        invoice_status(lsp_addr, &inbound_invoice).await,
+        InvoiceStatus::Claimable
+    ));
+
+    let LNInvoiceResponse {
+        invoice: outbound_invoice,
+    } = ln_invoice_hodl(
+        recipient_client_addr,
+        Some(HTLC_MIN_MSAT * 2),
+        None,
+        None,
+        300,
+        Some(payment_hash.clone()),
+    )
+    .await;
+
+    let send_payment_payload = SendPaymentRequest {
+        invoice: outbound_invoice.clone(),
+        amt_msat: None,
+        asset_id: None,
+        asset_amount: None,
+    };
+    let send_payment_result = reqwest::Client::new()
+        .post(format!("http://{lsp_addr}/sendpayment"))
+        .json(&send_payment_payload)
+        .send()
+        .await;
+    assert!(
+        send_payment_result.is_err(),
+        "expected outbound BTC payment request to fail"
+    );
+    assert!(matches!(
+        invoice_status(recipient_client_addr, &outbound_invoice).await,
+        InvoiceStatus::Pending
+    ));
+
+    shutdown(&[lsp_addr, payer_client_addr, recipient_client_addr]).await;
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn inbound_payment_does_not_block_rgb_outbound_payment_with_same_hash() {
+    initialize();
+
+    let (
+        lsp_addr,
+        payer_client_addr,
+        recipient_client_addr,
+        test_dir_lsp,
+        test_dir_recipient_client,
+        asset_id,
+    ) = setup_three_virtual_nodes_with_hub_channels("swap-hodl-rgb").await;
+    let initial_lsp_rgb_balance = asset_balance_offchain_outbound(lsp_addr, &asset_id).await;
+
+    let (preimage, payment_hash) = random_preimage_and_hash();
+    let LNInvoiceResponse {
+        invoice: inbound_invoice,
+    } = ln_invoice_hodl(
+        lsp_addr,
+        Some(HTLC_MIN_MSAT),
+        Some(&asset_id),
+        Some(RGB_PAYMENT_AMOUNT),
+        600,
+        Some(payment_hash.clone()),
+    )
+    .await;
+
+    let payer_payment = send_payment_with_status(
+        payer_client_addr,
+        inbound_invoice.clone(),
+        HTLCStatus::Pending,
+    )
+    .await;
+    assert_eq!(payer_payment.payment_type, PaymentType::Outbound);
+
+    wait_for_claimable_state(&test_dir_lsp, &payment_hash, true)
+        .await
+        .unwrap_or_else(|err| panic!("wait for claimable entry to appear: {err}"));
+    let lsp_claimable_payment =
+        wait_for_ln_payment(lsp_addr, &payment_hash, HTLCStatus::Claimable).await;
+    assert_eq!(lsp_claimable_payment.payment_type, PaymentType::InboundHodl);
+    assert!(matches!(
+        invoice_status(lsp_addr, &inbound_invoice).await,
+        InvoiceStatus::Claimable
+    ));
+
+    let LNInvoiceResponse {
+        invoice: outbound_invoice,
+    } = ln_invoice_hodl(
+        recipient_client_addr,
+        Some(HTLC_MIN_MSAT * 2),
+        Some(&asset_id),
+        Some(RGB_PAYMENT_AMOUNT),
+        300,
+        Some(payment_hash.clone()),
+    )
+    .await;
+
+    let lsp_payment =
+        send_payment_with_status(lsp_addr, outbound_invoice.clone(), HTLCStatus::Pending).await;
+    assert_eq!(lsp_payment.payment_type, PaymentType::Outbound);
+
+    wait_for_claimable_state(&test_dir_recipient_client, &payment_hash, true)
+        .await
+        .unwrap_or_else(|err| panic!("wait for claimable entry to appear: {err}"));
+    let recipient_payment =
+        wait_for_ln_payment(recipient_client_addr, &payment_hash, HTLCStatus::Claimable).await;
+    assert_eq!(recipient_payment.payment_type, PaymentType::InboundHodl);
+
+    let recipient_claim_response = claim_hodl_invoice(
+        recipient_client_addr,
+        payment_hash.clone(),
+        preimage.clone(),
+    )
+    .await;
+    assert!(recipient_claim_response.changed);
+    wait_for_ln_balance(recipient_client_addr, &asset_id, RGB_PAYMENT_AMOUNT).await;
+    wait_for_ln_balance(
+        lsp_addr,
+        &asset_id,
+        initial_lsp_rgb_balance - RGB_PAYMENT_AMOUNT,
+    )
+    .await;
+
+    let lsp_outbound_payment = wait_for_ln_payment_by_type(
+        lsp_addr,
+        &payment_hash,
+        PaymentType::Outbound,
+        HTLCStatus::Succeeded,
+    )
+    .await;
+    check_preimage_matches_hash(&lsp_outbound_payment, &payment_hash);
+    let outbound_preimage = lsp_outbound_payment
+        .preimage
+        .clone()
+        .expect("outbound payment preimage");
+
+    let lsp_claim_response =
+        claim_hodl_invoice(lsp_addr, payment_hash.clone(), outbound_preimage.clone()).await;
+    assert!(lsp_claim_response.changed);
+
+    wait_for_ln_balance(payer_client_addr, &asset_id, 0).await;
+    wait_for_ln_balance(lsp_addr, &asset_id, initial_lsp_rgb_balance).await;
+
+    shutdown(&[lsp_addr, payer_client_addr, recipient_client_addr]).await;
 }

--- a/src/test/invoice.rs
+++ b/src/test/invoice.rs
@@ -192,7 +192,8 @@ async fn zero_amount_invoice() {
     wait_for_ln_payment(node2_addr, &decoded.payment_hash, HTLCStatus::Succeeded).await;
 
     // Verify that both sender and receiver payments record the actual amount
-    let payment_sender = get_payment(node1_addr, &decoded.payment_hash).await;
+    let payment_sender =
+        get_payment(node1_addr, &decoded.payment_hash, PaymentType::Outbound).await;
     assert_eq!(
         payment_sender.amt_msat,
         Some(payment_amount),
@@ -200,7 +201,12 @@ async fn zero_amount_invoice() {
     );
     assert_eq!(payment_sender.status, HTLCStatus::Succeeded);
 
-    let payment_receiver = get_payment(node2_addr, &decoded.payment_hash).await;
+    let payment_receiver = get_payment(
+        node2_addr,
+        &decoded.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
     assert_eq!(
         payment_receiver.amt_msat,
         Some(payment_amount),
@@ -289,7 +295,12 @@ async fn zero_amount_invoice() {
         HTLCStatus::Succeeded,
     )
     .await;
-    let payment = get_payment(node2_addr, &decoded_with_amount.payment_hash).await;
+    let payment = get_payment(
+        node2_addr,
+        &decoded_with_amount.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, Some(50));
 
@@ -382,6 +393,11 @@ async fn zero_amount_invoice() {
         HTLCStatus::Succeeded,
     )
     .await;
-    let payment = get_payment(node2_addr, &decoded_without_amount.payment_hash).await;
+    let payment = get_payment(
+        node2_addr,
+        &decoded_without_amount.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
     assert_eq!(payment.asset_amount, Some(100));
 }

--- a/src/test/lib_core.rs
+++ b/src/test/lib_core.rs
@@ -8,7 +8,7 @@ use rgb_lightning_node::test_utils::{
 use rgb_lightning_node::{
     sdk_get_channel_id, sdk_get_payment, sdk_get_swap, sdk_ln_invoice, sdk_node_info, sdk_send_rgb,
     uniffi_is_initialized, Bolt11Invoice, ChannelId, ContractId, LnInvoiceRequest, PaymentHash,
-    PublicKey, RecipientId, RlnError, SendRgbRequest, TransportEndpoint, Txid,
+    PaymentType, PublicKey, RecipientId, RlnError, SendRgbRequest, TransportEndpoint, Txid,
     UniffiCustomTypeConverter,
 };
 
@@ -24,7 +24,10 @@ fn uniffi_entrypoints_require_initialized_state() {
         Err(RlnError::NotInitialized)
     ));
     assert!(matches!(
-        sdk_get_payment(lightning::types::payment::PaymentHash([0u8; 32])),
+        sdk_get_payment(
+            lightning::types::payment::PaymentHash([0u8; 32]),
+            PaymentType::Outbound
+        ),
         Err(RlnError::NotInitialized)
     ));
     assert!(matches!(

--- a/src/test/lib_sdk/helpers.rs
+++ b/src/test/lib_sdk/helpers.rs
@@ -541,10 +541,16 @@ pub(crate) fn wait_for_payment_status(
 ) -> Payment {
     let deadline = Instant::now() + timeout;
     loop {
-        if let Ok(payment) = node.get_payment(*payment_hash) {
-            if matches!(payment.status, HtlcStatus::Succeeded) {
-                return payment;
-            }
+        if let Some(payment) = node
+            .list_payments()
+            .expect("list_payments while waiting for payment success")
+            .into_iter()
+            .find(|payment| {
+                payment.payment_hash == *payment_hash
+                    && matches!(payment.status, HtlcStatus::Succeeded)
+            })
+        {
+            return payment;
         }
 
         assert!(

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -425,6 +425,28 @@ async fn check_payment_status(
     None
 }
 
+async fn check_payment_status_by_type(
+    node_address: SocketAddr,
+    payment_hash: &str,
+    payment_type: PaymentType,
+    expected_status: HTLCStatus,
+) -> Option<Payment> {
+    println!(
+        "checking payment {payment_hash} of type {payment_type:?} is {expected_status:?} on node {node_address}"
+    );
+    let payments = list_payments(node_address).await;
+    if let Some(payment) = payments
+        .iter()
+        .find(|p| p.payment_hash == payment_hash && p.payment_type == payment_type)
+    {
+        if payment.status == expected_status {
+            return Some(payment.clone());
+        }
+        println!("payment found but with status: {:?}", payment.status);
+    }
+    None
+}
+
 async fn close_channel(node_address: SocketAddr, channel_id: &str, peer_pubkey: &str, force: bool) {
     println!(
         "{}closing channel {channel_id} from node {node_address}",
@@ -961,10 +983,15 @@ async fn list_payments(node_address: SocketAddr) -> Vec<Payment> {
         .payments
 }
 
-async fn get_payment(node_address: SocketAddr, payment_hash: &str) -> Payment {
-    println!("getting payment for node {node_address}");
+async fn get_payment(
+    node_address: SocketAddr,
+    payment_hash: &str,
+    payment_type: PaymentType,
+) -> Payment {
+    println!("getting {payment_type:?} payment for node {node_address}");
     let payload = GetPaymentRequest {
         payment_hash: payment_hash.to_string(),
+        payment_type,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node_address}/getpayment"))
@@ -1793,10 +1820,11 @@ async fn send_payment_with_status(
     expected_status: HTLCStatus,
 ) -> Payment {
     let send_payment = send_payment_raw(node_address, invoice).await;
-    wait_for_ln_payment(
+    wait_for_ln_payment_by_type(
         node_address,
         // TODO: remove unwrap once RGB offers are enabled
         &send_payment.payment_hash.unwrap(),
+        PaymentType::Outbound,
         expected_status,
     )
     .await
@@ -1981,6 +2009,30 @@ async fn wait_for_ln_payment(
         }
         if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 40.0 {
             panic!("cannot find payment in status {expected_status}")
+        }
+    }
+}
+
+async fn wait_for_ln_payment_by_type(
+    node_address: SocketAddr,
+    payment_hash: &str,
+    payment_type: PaymentType,
+    expected_status: HTLCStatus,
+) -> Payment {
+    println!(
+        "waiting for LN payment {payment_hash} of type {payment_type:?} to become {expected_status:?} on node {node_address}"
+    );
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        if let Some(payment) =
+            check_payment_status_by_type(node_address, payment_hash, payment_type, expected_status)
+                .await
+        {
+            return payment;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 40.0 {
+            panic!("cannot find payment in status {expected_status} for type {payment_type:?}")
         }
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -760,6 +760,28 @@ async fn issue_asset_nia(node_address: SocketAddr) -> AssetNIA {
         .asset
 }
 
+async fn issue_asset_nia_with_amounts(node_address: SocketAddr, amounts: Vec<u64>) -> AssetNIA {
+    println!("issuing NIA asset on node {node_address}");
+    let payload = IssueAssetNIARequest {
+        amounts,
+        ticker: s!("USDT"),
+        name: s!("Tether"),
+        precision: 0,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/issueassetnia"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    _check_response_is_ok(res)
+        .await
+        .json::<IssueAssetNIAResponse>()
+        .await
+        .unwrap()
+        .asset
+}
+
 async fn issue_asset_uda(node_address: SocketAddr, file_path: Option<&str>) -> AssetUDA {
     println!("issuing UDA asset on node {node_address}");
     let mut media_file_digest = None;
@@ -1390,10 +1412,20 @@ async fn open_channel_raw(
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             let channels = list_channels(node_address).await;
             if let Some(channel) = channels.iter().find(|c| {
+                let asset_amounts_match = if asset_id.is_some() {
+                    let local_amount = asset_amount
+                        .unwrap_or(0)
+                        .saturating_sub(push_asset_amount.unwrap_or(0));
+                    let remote_amount = push_asset_amount.unwrap_or(0);
+                    c.asset_local_amount == Some(local_amount)
+                        && c.asset_remote_amount == Some(remote_amount)
+                } else {
+                    c.asset_local_amount.is_none() && c.asset_remote_amount.is_none()
+                };
                 c.peer_pubkey == dest_peer_pubkey
                     && c.asset_id == expected_asset_id
-                    && c.asset_local_amount == asset_amount
                     && c.virtual_open_mode.as_deref() == virtual_open_mode
+                    && asset_amounts_match
             }) {
                 if channel.ready && channel.is_usable {
                     return Ok(channel.clone());
@@ -1493,6 +1525,7 @@ async fn open_channel_with_custom_data(
     .expect("channel opening should succeed")
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn open_virtual_channel(
     node_address: SocketAddr,
     dest_peer_pubkey: &str,
@@ -1501,6 +1534,7 @@ async fn open_virtual_channel(
     push_msat: Option<u64>,
     asset_amount: Option<u64>,
     asset_id: Option<&str>,
+    push_asset_amount: Option<u64>,
 ) -> Channel {
     open_channel_raw(
         node_address,
@@ -1510,7 +1544,7 @@ async fn open_virtual_channel(
         push_msat,
         asset_amount,
         asset_id,
-        None,
+        push_asset_amount,
         None,
         None,
         None,

--- a/src/test/payment.rs
+++ b/src/test/payment.rs
@@ -60,12 +60,17 @@ async fn success() {
     let status = invoice_status(node2_addr, &invoice).await;
     assert!(matches!(status, InvoiceStatus::Succeeded));
 
-    let payment = get_payment(node1_addr, &decoded.payment_hash).await;
+    let payment = get_payment(node1_addr, &decoded.payment_hash, PaymentType::Outbound).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
     check_preimage_matches_hash(&payment, &decoded.payment_hash);
-    let payment = get_payment(node2_addr, &decoded.payment_hash).await;
+    let payment = get_payment(
+        node2_addr,
+        &decoded.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
@@ -96,12 +101,17 @@ async fn success() {
     .await;
 
     let decoded = decode_ln_invoice(node1_addr, &invoice).await;
-    let payment = get_payment(node1_addr, &decoded.payment_hash).await;
+    let payment = get_payment(node1_addr, &decoded.payment_hash, PaymentType::Outbound).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
     check_preimage_matches_hash(&payment, &decoded.payment_hash);
-    let payment = get_payment(node2_addr, &decoded.payment_hash).await;
+    let payment = get_payment(
+        node2_addr,
+        &decoded.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
@@ -112,12 +122,17 @@ async fn success() {
     let _ = send_payment(node1_addr, invoice.clone()).await;
 
     let decoded = decode_ln_invoice(node1_addr, &invoice).await;
-    let payment = get_payment(node1_addr, &decoded.payment_hash).await;
+    let payment = get_payment(node1_addr, &decoded.payment_hash, PaymentType::Outbound).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
     check_preimage_matches_hash(&payment, &decoded.payment_hash);
-    let payment = get_payment(node2_addr, &decoded.payment_hash).await;
+    let payment = get_payment(
+        node2_addr,
+        &decoded.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
@@ -128,12 +143,17 @@ async fn success() {
     let _ = send_payment(node2_addr, invoice.clone()).await;
 
     let decoded = decode_ln_invoice(node1_addr, &invoice).await;
-    let payment = get_payment(node1_addr, &decoded.payment_hash).await;
+    let payment = get_payment(node1_addr, &decoded.payment_hash, PaymentType::Outbound).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
     check_preimage_matches_hash(&payment, &decoded.payment_hash);
-    let payment = get_payment(node2_addr, &decoded.payment_hash).await;
+    let payment = get_payment(
+        node2_addr,
+        &decoded.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
@@ -333,7 +353,12 @@ async fn same_invoice_twice_and_expired_inbound_payments() {
     tokio::time::sleep(std::time::Duration::from_secs(SHORT_EXPIRY_SEC as u64 + 1)).await;
 
     // getting a payment should trigger expiration-based status transition
-    let payment = get_payment(node2_addr, &decoded1.payment_hash).await;
+    let payment = get_payment(
+        node2_addr,
+        &decoded1.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
     assert_eq!(
         payment.status,
         HTLCStatus::Failed,

--- a/src/test/payment.rs
+++ b/src/test/payment.rs
@@ -101,13 +101,13 @@ async fn success() {
     .await;
 
     let decoded = decode_ln_invoice(node1_addr, &invoice).await;
-    let payment = get_payment(node1_addr, &decoded.payment_hash, PaymentType::Outbound).await;
+    let payment = get_payment(node2_addr, &decoded.payment_hash, PaymentType::Outbound).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
     check_preimage_matches_hash(&payment, &decoded.payment_hash);
     let payment = get_payment(
-        node2_addr,
+        node1_addr,
         &decoded.payment_hash,
         PaymentType::InboundAutoClaim,
     )
@@ -143,13 +143,13 @@ async fn success() {
     let _ = send_payment(node2_addr, invoice.clone()).await;
 
     let decoded = decode_ln_invoice(node1_addr, &invoice).await;
-    let payment = get_payment(node1_addr, &decoded.payment_hash, PaymentType::Outbound).await;
+    let payment = get_payment(node2_addr, &decoded.payment_hash, PaymentType::Outbound).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
     check_preimage_matches_hash(&payment, &decoded.payment_hash);
     let payment = get_payment(
-        node2_addr,
+        node1_addr,
         &decoded.payment_hash,
         PaymentType::InboundAutoClaim,
     )

--- a/src/test/virtual_channels.rs
+++ b/src/test/virtual_channels.rs
@@ -23,28 +23,6 @@ async fn close_channel_response(
         .unwrap()
 }
 
-async fn issue_asset_nia_with_amounts(node_address: SocketAddr, amounts: Vec<u64>) -> AssetNIA {
-    println!("issuing NIA asset on node {node_address}");
-    let payload = IssueAssetNIARequest {
-        amounts,
-        ticker: s!("USDT"),
-        name: s!("Tether"),
-        precision: 0,
-    };
-    let res = reqwest::Client::new()
-        .post(format!("http://{node_address}/issueassetnia"))
-        .json(&payload)
-        .send()
-        .await
-        .unwrap();
-    _check_response_is_ok(res)
-        .await
-        .json::<IssueAssetNIAResponse>()
-        .await
-        .unwrap()
-        .asset
-}
-
 async fn mine_blocks_and_wait_for_sync(
     host_node_address: SocketAddr,
     client_node_address: SocketAddr,
@@ -429,6 +407,7 @@ async fn virtual_trusted_no_broadcast_survives_funding_timeout_and_routes_btc_an
         Some(client_a_push_msat),
         Some(funded_rgb_amount),
         Some(&issued_asset_id),
+        None,
     )
     .await;
     assert_eq!(
@@ -577,6 +556,7 @@ async fn virtual_trusted_no_broadcast_survives_funding_timeout_and_routes_btc_an
         Some(0),
         Some(channel_b_funded_rgb_amount),
         Some(&issued_asset_id),
+        None,
     )
     .await;
     assert_eq!(
@@ -705,6 +685,7 @@ async fn virtual_close_rejects_client_side_without_host_session() {
         Some(0),
         None,
         None,
+        None,
     )
     .await;
 
@@ -761,6 +742,7 @@ async fn virtual_close_rejects_force_true_on_host() {
         Some(client_node_peer_port),
         Some(100_000),
         Some(0),
+        None,
         None,
         None,
     )
@@ -822,6 +804,7 @@ async fn virtual_close_succeeds_without_remote_value_and_is_idempotent() {
         Some(0),
         Some(200),
         Some(&issued_asset_id),
+        None,
     )
     .await;
 
@@ -897,6 +880,7 @@ async fn virtual_close_rejects_after_rgb_round_trip_when_remote_btc_remains() {
         Some(0),
         None,
         None,
+        None,
     )
     .await;
 
@@ -931,6 +915,7 @@ async fn virtual_close_rejects_after_rgb_round_trip_when_remote_btc_remains() {
         Some(0),
         Some(funded_rgb_amount),
         Some(&issued_asset_id),
+        None,
     )
     .await;
 
@@ -1061,6 +1046,7 @@ async fn virtual_close_succeeds_after_client_returns_full_btc_and_rgb() {
         Some(0),
         Some(funded_rgb_amount),
         Some(&issued_asset_id),
+        None,
     )
     .await;
 

--- a/src/uniffi_api/examples/python-interop/manual_py_virtual_channels_sdk.py
+++ b/src/uniffi_api/examples/python-interop/manual_py_virtual_channels_sdk.py
@@ -162,10 +162,14 @@ def wait_payment_final(node: rln.SdkNode, payment_hash, timeout_sec: int = 60):
     last = None
     while time.time() < deadline:
         node.sync()
-        payment = node.get_payment(payment_hash)
-        last = payment.status
-        if payment.status != rln.HtlcStatus.PENDING:
-            return payment.status
+        payment = next(
+            (p for p in node.list_payments() if p.payment_hash == payment_hash),
+            None,
+        )
+        if payment is not None:
+            last = payment.status
+            if payment.status != rln.HtlcStatus.PENDING:
+                return payment.status
         time.sleep(1)
     raise RuntimeError(f"keysend did not finalize in time, last={last}")
 

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -736,9 +736,22 @@ impl SdkNode {
         Ok(lightning::ln::types::ChannelId(arr))
     }
 
-    pub fn get_payment(&self, payment_hash: PaymentHash) -> Result<Payment, RlnError> {
+    pub fn get_payment(
+        &self,
+        payment_hash: PaymentHash,
+        payment_type: PaymentType,
+    ) -> Result<Payment, RlnError> {
         let state = self.handle.app_state();
-        let data = block_on_sdk(sdk::get_payment(state, payment_hash.0.as_hex().to_string()))?;
+        let sdk_payment_type = match payment_type {
+            PaymentType::Outbound => crate::sdk::PaymentType::Outbound,
+            PaymentType::InboundAutoClaim => crate::sdk::PaymentType::InboundAutoClaim,
+            PaymentType::InboundHodl => crate::sdk::PaymentType::InboundHodl,
+        };
+        let data = block_on_sdk(sdk::get_payment(
+            state,
+            payment_hash.0.as_hex().to_string(),
+            sdk_payment_type,
+        ))?;
         map_payment_data(data)
     }
 
@@ -1318,9 +1331,12 @@ pub fn sdk_get_channel_id(temporary_channel_id: ChannelId) -> Result<ChannelId, 
     SdkNode { handle }.get_channel_id(temporary_channel_id)
 }
 
-pub fn sdk_get_payment(payment_hash: PaymentHash) -> Result<Payment, RlnError> {
+pub fn sdk_get_payment(
+    payment_hash: PaymentHash,
+    payment_type: PaymentType,
+) -> Result<Payment, RlnError> {
     let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
-    SdkNode { handle }.get_payment(payment_hash)
+    SdkNode { handle }.get_payment(payment_hash, payment_type)
 }
 
 pub fn sdk_list_payments() -> Result<Vec<Payment>, RlnError> {

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -23,7 +23,7 @@ mod uniffi_smoke_tests {
         let channel_id = sdk_get_channel_id(lightning::ln::types::ChannelId([0u8; 32]));
         assert!(matches!(channel_id, Err(RlnError::NotInitialized)));
         let payment_hash = lightning::types::payment::PaymentHash([0u8; 32]);
-        let payment = sdk_get_payment(payment_hash);
+        let payment = sdk_get_payment(payment_hash, PaymentType::Outbound);
         assert!(matches!(payment, Err(RlnError::NotInitialized)));
         let swap = sdk_get_swap(lightning::types::payment::PaymentHash([0u8; 32]), true);
         assert!(matches!(swap, Err(RlnError::NotInitialized)));

--- a/test/kotlin-e2e/KotlinUniffiE2e.kt
+++ b/test/kotlin-e2e/KotlinUniffiE2e.kt
@@ -6,6 +6,7 @@ import org.utexo.rgblightningnode.InvoiceStatus
 import org.utexo.rgblightningnode.LnInvoiceRequest
 import org.utexo.rgblightningnode.Payment
 import org.utexo.rgblightningnode.PaymentHash
+import org.utexo.rgblightningnode.PaymentType
 import org.utexo.rgblightningnode.RgbRecipient
 import org.utexo.rgblightningnode.RlnException
 import org.utexo.rgblightningnode.SdkCloseChannelRequest
@@ -378,11 +379,18 @@ private fun waitForLnBalance(node: SdkNode, assetId: ContractId, expected: ULong
     error("offchain_outbound balance did not become expected=$expected actual=$lastBalance assetId=$assetId after ${timeoutSec}s")
 }
 
-private fun waitForPaymentStatus(node: SdkNode, paymentHash: PaymentHash, timeoutSec: Long): Payment {
+private fun waitForPaymentStatus(
+    node: SdkNode,
+    paymentHash: PaymentHash,
+    paymentType: PaymentType,
+    timeoutSec: Long,
+): Payment {
     val deadline = System.currentTimeMillis() + timeoutSec * 1000L
     var lastStatus: String = "not found"
     while (System.currentTimeMillis() < deadline) {
-        val payment = node.listPayments().firstOrNull { it.paymentHash == paymentHash }
+        val payment = node.listPayments().firstOrNull {
+            it.paymentHash == paymentHash && it.paymentType == paymentType
+        }
         if (payment != null) {
             lastStatus = payment.status.name
             if (payment.status == HtlcStatus.SUCCEEDED) {
@@ -391,22 +399,35 @@ private fun waitForPaymentStatus(node: SdkNode, paymentHash: PaymentHash, timeou
         }
         Thread.sleep(1000L)
     }
-    error("timeout waiting for payment success: paymentHash=$paymentHash last_status=$lastStatus after ${timeoutSec}s")
+    error(
+        "timeout waiting for payment success: paymentHash=$paymentHash paymentType=$paymentType " +
+            "last_status=$lastStatus after ${timeoutSec}s"
+    )
 }
 
-private fun waitForPaymentPresentInList(node: SdkNode, paymentHash: PaymentHash, timeoutSec: Long): Payment {
+private fun waitForPaymentPresentInList(
+    node: SdkNode,
+    paymentHash: PaymentHash,
+    paymentType: PaymentType,
+    timeoutSec: Long,
+): Payment {
     val deadline = System.currentTimeMillis() + timeoutSec * 1000L
     var lastCount = 0
     while (System.currentTimeMillis() < deadline) {
         val payments = node.listPayments()
         lastCount = payments.size
-        val payment = payments.firstOrNull { it.paymentHash == paymentHash }
+        val payment = payments.firstOrNull {
+            it.paymentHash == paymentHash && it.paymentType == paymentType
+        }
         if (payment != null) {
             return payment
         }
         Thread.sleep(1000L)
     }
-    error("payment not found in listPayments: paymentHash=$paymentHash list_size=$lastCount after ${timeoutSec}s")
+    error(
+        "payment not found in listPayments: paymentHash=$paymentHash paymentType=$paymentType " +
+            "list_size=$lastCount after ${timeoutSec}s"
+    )
 }
 
 private fun hexToBytes(value: String): ByteArray {
@@ -462,7 +483,12 @@ private fun keysend(
     check(response.status == HtlcStatus.PENDING || response.status == HtlcStatus.SUCCEEDED) {
         "unexpected keysend status: ${response.status}"
     }
-    waitForPaymentStatus(sender, response.paymentHash, PAYMENT_TIMEOUT_SEC)
+    waitForPaymentStatus(
+        sender,
+        response.paymentHash,
+        PaymentType.OUTBOUND,
+        PAYMENT_TIMEOUT_SEC,
+    )
     return response.paymentHash
 }
 
@@ -479,7 +505,12 @@ private fun keysendWithLnBalance(
     val paymentHash = keysend(sender, destPubkey, amtMsat, assetId, assetAmount)
     waitForLnBalance(sender, assetId, initialSenderBalance - assetAmount, BALANCE_TIMEOUT_SEC)
     waitForLnBalance(receiver, assetId, initialReceiverBalance + assetAmount, BALANCE_TIMEOUT_SEC)
-    waitForPaymentStatus(receiver, paymentHash, PAYMENT_TIMEOUT_SEC)
+    waitForPaymentStatus(
+        receiver,
+        paymentHash,
+        PaymentType.INBOUND_AUTO_CLAIM,
+        PAYMENT_TIMEOUT_SEC,
+    )
 }
 
 private fun closeChannel(node: SdkNode, channelId: String, peerPubkey: String, force: Boolean = false) {
@@ -649,16 +680,36 @@ private fun paymentScenario() {
         }
 
         val decoded = nodeA.decodeLnInvoice(invoice)
-        val senderPayment = waitForPaymentStatus(nodeA, decoded.paymentHash, PAYMENT_TIMEOUT_SEC)
-        val receiverPayment = waitForPaymentStatus(nodeB, decoded.paymentHash, PAYMENT_TIMEOUT_SEC)
+        val senderPayment = waitForPaymentStatus(
+            nodeA,
+            decoded.paymentHash,
+            PaymentType.OUTBOUND,
+            PAYMENT_TIMEOUT_SEC,
+        )
+        val receiverPayment = waitForPaymentStatus(
+            nodeB,
+            decoded.paymentHash,
+            PaymentType.INBOUND_AUTO_CLAIM,
+            PAYMENT_TIMEOUT_SEC,
+        )
         checkPreimageMatchesHash(senderPayment, decoded.paymentHash)
         checkPreimageMatchesHash(receiverPayment, decoded.paymentHash)
 
-        val listedSenderPayment = waitForPaymentPresentInList(nodeA, decoded.paymentHash, PAYMENT_TIMEOUT_SEC)
+        val listedSenderPayment = waitForPaymentPresentInList(
+            nodeA,
+            decoded.paymentHash,
+            PaymentType.OUTBOUND,
+            PAYMENT_TIMEOUT_SEC,
+        )
         check(listedSenderPayment.paymentHash == decoded.paymentHash)
         checkPreimageMatchesHash(listedSenderPayment, decoded.paymentHash)
 
-        val listedReceiverPayment = waitForPaymentPresentInList(nodeB, decoded.paymentHash, PAYMENT_TIMEOUT_SEC)
+        val listedReceiverPayment = waitForPaymentPresentInList(
+            nodeB,
+            decoded.paymentHash,
+            PaymentType.INBOUND_AUTO_CLAIM,
+            PAYMENT_TIMEOUT_SEC,
+        )
         check(listedReceiverPayment.paymentHash == decoded.paymentHash)
         checkPreimageMatchesHash(listedReceiverPayment, decoded.paymentHash)
 
@@ -978,8 +1029,18 @@ private fun closeCoopVanillaScenario(name: String, portOffset: UInt, withAnchors
             )
         )
         val paymentHash = requireNotNull(sendPayment.paymentHash) { "vanilla payment hash missing" }
-        waitForPaymentStatus(nodeB, paymentHash, PAYMENT_TIMEOUT_SEC)
-        waitForPaymentPresentInList(nodeA, paymentHash, PAYMENT_TIMEOUT_SEC)
+        waitForPaymentStatus(
+            nodeB,
+            paymentHash,
+            PaymentType.OUTBOUND,
+            PAYMENT_TIMEOUT_SEC,
+        )
+        waitForPaymentPresentInList(
+            nodeA,
+            paymentHash,
+            PaymentType.INBOUND_AUTO_CLAIM,
+            PAYMENT_TIMEOUT_SEC,
+        )
         check(nodeA.listPayments().size == 3) { "node A should have 3 payments after invoice payment" }
         check(nodeB.listPayments().size == 3) { "node B should have 3 payments after invoice payment" }
 

--- a/test/kotlin-e2e/KotlinUniffiE2e.kt
+++ b/test/kotlin-e2e/KotlinUniffiE2e.kt
@@ -382,14 +382,12 @@ private fun waitForPaymentStatus(node: SdkNode, paymentHash: PaymentHash, timeou
     val deadline = System.currentTimeMillis() + timeoutSec * 1000L
     var lastStatus: String = "not found"
     while (System.currentTimeMillis() < deadline) {
-        try {
-            val payment = node.getPayment(paymentHash)
+        val payment = node.listPayments().firstOrNull { it.paymentHash == paymentHash }
+        if (payment != null) {
             lastStatus = payment.status.name
             if (payment.status == HtlcStatus.SUCCEEDED) {
                 return payment
             }
-        } catch (_: RlnException.NotFound) {
-            lastStatus = "not found"
         }
         Thread.sleep(1000L)
     }

--- a/test/python-e2e/PythonUniffiE2e.py
+++ b/test/python-e2e/PythonUniffiE2e.py
@@ -381,7 +381,9 @@ def wait_for_balance(node: rln.SdkNode, asset_id, expected: int, timeout_sec: in
         node.refreshtransfers(rln.SdkRefreshTransfersRequest(skip_sync=False))
         time.sleep(1)
     raise RuntimeError(
-        f"spendable balance did not become expected={expected} actual={last_balance} asset_id={asset_id} after {timeout_sec}s"
+        "spendable balance did not become "
+        f"expected={expected} actual={last_balance} "
+        f"asset_id={asset_id} after {timeout_sec}s"
     )
 
 
@@ -395,20 +397,27 @@ def wait_for_ln_balance(node: rln.SdkNode, asset_id, expected: int, timeout_sec:
             return
         time.sleep(1)
     raise RuntimeError(
-        f"offchain_outbound balance did not become expected={expected} actual={last_balance} asset_id={asset_id} after {timeout_sec}s"
+        "offchain_outbound balance did not become "
+        f"expected={expected} actual={last_balance} "
+        f"asset_id={asset_id} after {timeout_sec}s"
     )
 
 
 def wait_for_payment_status(
     node: rln.SdkNode,
     payment_hash,
+    payment_type,
     timeout_sec: int,
 ):
     deadline = time.time() + timeout_sec
     last_status = "not found"
     while time.time() < deadline:
         payment = next(
-            (p for p in node.list_payments() if p.payment_hash == payment_hash),
+            (
+                p
+                for p in node.list_payments()
+                if p.payment_hash == payment_hash and p.payment_type == payment_type
+            ),
             None,
         )
         if payment is not None:
@@ -417,22 +426,36 @@ def wait_for_payment_status(
                 return payment
         time.sleep(1)
     raise RuntimeError(
-        f"timeout waiting for payment success: payment_hash={payment_hash} last_status={last_status} after {timeout_sec}s"
+        f"timeout waiting for payment success: payment_hash={payment_hash} "
+        f"payment_type={payment_type.name} last_status={last_status} after {timeout_sec}s"
     )
 
 
-def wait_for_payment_present_in_list(node: rln.SdkNode, payment_hash, timeout_sec: int):
+def wait_for_payment_present_in_list(
+    node: rln.SdkNode,
+    payment_hash,
+    payment_type,
+    timeout_sec: int,
+):
     deadline = time.time() + timeout_sec
     last_count = 0
     while time.time() < deadline:
         payments = node.list_payments()
         last_count = len(payments)
-        payment = next((p for p in payments if p.payment_hash == payment_hash), None)
+        payment = next(
+            (
+                p
+                for p in payments
+                if p.payment_hash == payment_hash and p.payment_type == payment_type
+            ),
+            None,
+        )
         if payment is not None:
             return payment
         time.sleep(1)
     raise RuntimeError(
-        f"payment not found in list_payments: payment_hash={payment_hash} list_size={last_count} after {timeout_sec}s"
+        f"payment not found in list_payments: payment_hash={payment_hash} "
+        f"payment_type={payment_type.name} list_size={last_count} after {timeout_sec}s"
     )
 
 
@@ -485,7 +508,7 @@ def keysend(sender: rln.SdkNode, dest_pubkey: str, amt_msat, asset_id, asset_amo
     )
     if response.status not in (rln.HtlcStatus.PENDING, rln.HtlcStatus.SUCCEEDED):
         raise RuntimeError(f"unexpected keysend status: {response.status}")
-    wait_for_payment_status(sender, response.payment_hash, 60)
+    wait_for_payment_status(sender, response.payment_hash, rln.PaymentType.OUTBOUND, 60)
     return response.payment_hash
 
 
@@ -502,7 +525,7 @@ def keysend_with_ln_balance(
     payment_hash = keysend(sender, dest_pubkey, amt_msat, asset_id, asset_amount)
     wait_for_ln_balance(sender, asset_id, initial_sender_balance - asset_amount, 60)
     wait_for_ln_balance(receiver, asset_id, initial_receiver_balance + asset_amount, 60)
-    wait_for_payment_status(receiver, payment_hash, 60)
+    wait_for_payment_status(receiver, payment_hash, rln.PaymentType.INBOUND_AUTO_CLAIM, 60)
 
 
 def close_channel(node: rln.SdkNode, channel_id: str, peer_pubkey: str, force: bool = False):
@@ -830,20 +853,24 @@ def payment_scenario():
             raise RuntimeError(f"Payment did not succeed (status={final_status})")
 
         decoded = node_a.decode_ln_invoice(invoice)
-        sender_payment = wait_for_payment_status(node_a, decoded.payment_hash, 60)
-        receiver_payment = wait_for_payment_status(node_b, decoded.payment_hash, 60)
+        sender_payment = wait_for_payment_status(
+            node_a, decoded.payment_hash, rln.PaymentType.OUTBOUND, 60
+        )
+        receiver_payment = wait_for_payment_status(
+            node_b, decoded.payment_hash, rln.PaymentType.INBOUND_AUTO_CLAIM, 60
+        )
         check_preimage_matches_hash(sender_payment, decoded.payment_hash)
         check_preimage_matches_hash(receiver_payment, decoded.payment_hash)
 
         listed_sender_payment = wait_for_payment_present_in_list(
-            node_a, decoded.payment_hash, 60
+            node_a, decoded.payment_hash, rln.PaymentType.OUTBOUND, 60
         )
         if listed_sender_payment.payment_hash != decoded.payment_hash:
             raise RuntimeError("sender payment hash mismatch in list_payments")
         check_preimage_matches_hash(listed_sender_payment, decoded.payment_hash)
 
         listed_receiver_payment = wait_for_payment_present_in_list(
-            node_b, decoded.payment_hash, 60
+            node_b, decoded.payment_hash, rln.PaymentType.INBOUND_AUTO_CLAIM, 60
         )
         if listed_receiver_payment.payment_hash != decoded.payment_hash:
             raise RuntimeError("receiver payment hash mismatch in list_payments")
@@ -933,7 +960,7 @@ def openchannel_push_asset_amount_scenario():
 
         keysend_with_ln_balance(node_a, node_b, node_b_pubkey, None, asset_id, 100, 350, 250)
         btc_payment_hash = keysend(node_a, node_b_pubkey, 10_000_000, None, None)
-        wait_for_payment_status(node_b, btc_payment_hash, 60)
+        wait_for_payment_status(node_b, btc_payment_hash, rln.PaymentType.INBOUND_AUTO_CLAIM, 60)
         keysend_with_ln_balance(node_b, node_a, node_a_pubkey, None, asset_id, 50, 350, 250)
 
         node_a_partial_after = next(c for c in node_a.list_channels() if c.channel_id == partial_channel_id)
@@ -995,7 +1022,7 @@ def openchannel_push_asset_amount_scenario():
         assert node_b_full.asset_local_amount == 600 and node_b_full.asset_remote_amount == 0
 
         btc_payment_hash = keysend(node_a, node_b_pubkey, 10_000_000, None, None)
-        wait_for_payment_status(node_b, btc_payment_hash, 60)
+        wait_for_payment_status(node_b, btc_payment_hash, rln.PaymentType.INBOUND_AUTO_CLAIM, 60)
         keysend_with_ln_balance(node_b, node_a, node_a_pubkey, None, asset_id, 100, 600, 0)
 
         node_a_full_after = next(c for c in node_a.list_channels() if c.channel_id == full_channel_id)

--- a/test/python-e2e/PythonUniffiE2e.py
+++ b/test/python-e2e/PythonUniffiE2e.py
@@ -407,13 +407,14 @@ def wait_for_payment_status(
     deadline = time.time() + timeout_sec
     last_status = "not found"
     while time.time() < deadline:
-        try:
-            payment = node.get_payment(payment_hash)
+        payment = next(
+            (p for p in node.list_payments() if p.payment_hash == payment_hash),
+            None,
+        )
+        if payment is not None:
             last_status = payment.status.name
             if payment.status == rln.HtlcStatus.SUCCEEDED:
                 return payment
-        except rln.RlnError.NotFound:
-            last_status = "not found"
         time.sleep(1)
     raise RuntimeError(
         f"timeout waiting for payment success: payment_hash={payment_hash} last_status={last_status} after {timeout_sec}s"


### PR DESCRIPTION
This PR adds payment-type-aware /getpayment (needed for async payments), new duplicate-hash HODL coverage, and a virtual-channel helper tweak for pushed RGB balances.