### PR TITLE
700 Async-payments control plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,7 +2477,6 @@ name = "lightning"
 version = "0.2.2"
 dependencies = [
  "bech32 0.11.1",
- "bincode",
  "bitcoin",
  "dnssec-prover",
  "futures",
@@ -2488,8 +2487,9 @@ dependencies = [
  "lightning-types",
  "musig2",
  "possiblyrandom",
- "rgb-lib",
+ "rgb-lib 0.3.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -2536,7 +2536,7 @@ dependencies = [
  "bech32 0.11.1",
  "bitcoin",
  "lightning-types",
- "rgb-lib",
+ "rgb-lib 0.3.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
 ]
 
@@ -3734,7 +3734,8 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.5"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#5aabef63b8fc004fa51a143f47c687fc6dc9c0e5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a09de20d5b52c051897e4d990615fc8110f9efbf1bb43c033cec2dfeddd7691"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -3748,7 +3749,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.13.2",
  "rgb-invoicing",
- "rgb-lib-migration",
+ "rgb-lib-migration 0.3.0-beta.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rgb-ops",
  "rgb-psbt-utils",
  "rgb-schemas",
@@ -3771,6 +3772,58 @@ dependencies = [
  "url",
  "walkdir",
  "zip 8.5.1",
+]
+
+[[package]]
+name = "rgb-lib"
+version = "0.3.0-beta.5"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#5aabef63b8fc004fa51a143f47c687fc6dc9c0e5"
+dependencies = [
+ "amplify",
+ "base64 0.22.1",
+ "bdk_electrum",
+ "bdk_esplora",
+ "bdk_wallet",
+ "chacha20poly1305",
+ "file-format",
+ "generic-array",
+ "hex",
+ "rand 0.10.1",
+ "reqwest 0.13.2",
+ "rgb-invoicing",
+ "rgb-lib-migration 0.3.0-beta.3 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev)",
+ "rgb-ops",
+ "rgb-psbt-utils",
+ "rgb-schemas",
+ "rgb-strict-encoding",
+ "rgb-strict-types",
+ "rustls 0.23.39",
+ "scrypt",
+ "sea-orm",
+ "sea-query",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-async",
+ "slog-term",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "typenum",
+ "url",
+ "walkdir",
+ "zip 8.5.1",
+]
+
+[[package]]
+name = "rgb-lib-migration"
+version = "0.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4dd5262d25fe54dd65afa13c19859abba7f81d130fa26d10f018e30bfdd333a"
+dependencies = [
+ "sea-orm-migration",
+ "tokio",
 ]
 
 [[package]]
@@ -3819,7 +3872,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
- "rgb-lib",
+ "rgb-lib 0.3.0-beta.5 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev)",
  "rln-migration",
  "scrypt",
  "sea-orm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,6 +2477,7 @@ name = "lightning"
 version = "0.2.2"
 dependencies = [
  "bech32 0.11.1",
+ "bincode",
  "bitcoin",
  "dnssec-prover",
  "futures",
@@ -2487,9 +2488,8 @@ dependencies = [
  "lightning-types",
  "musig2",
  "possiblyrandom",
- "rgb-lib 0.3.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rgb-lib",
  "serde",
- "serde_json",
  "tokio",
 ]
 
@@ -2536,7 +2536,7 @@ dependencies = [
  "bech32 0.11.1",
  "bitcoin",
  "lightning-types",
- "rgb-lib 0.3.0-beta.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rgb-lib",
  "serde",
 ]
 
@@ -3734,49 +3734,6 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a09de20d5b52c051897e4d990615fc8110f9efbf1bb43c033cec2dfeddd7691"
-dependencies = [
- "amplify",
- "base64 0.22.1",
- "bdk_electrum",
- "bdk_esplora",
- "bdk_wallet",
- "chacha20poly1305",
- "file-format",
- "generic-array",
- "hex",
- "rand 0.10.1",
- "reqwest 0.13.2",
- "rgb-invoicing",
- "rgb-lib-migration 0.3.0-beta.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rgb-ops",
- "rgb-psbt-utils",
- "rgb-schemas",
- "rgb-strict-encoding",
- "rgb-strict-types",
- "rustls 0.23.39",
- "scrypt",
- "sea-orm",
- "sea-query",
- "serde",
- "serde_json",
- "slog",
- "slog-async",
- "slog-term",
- "tempfile",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "typenum",
- "url",
- "walkdir",
- "zip 8.5.1",
-]
-
-[[package]]
-name = "rgb-lib"
-version = "0.3.0-beta.5"
 source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#5aabef63b8fc004fa51a143f47c687fc6dc9c0e5"
 dependencies = [
  "amplify",
@@ -3791,7 +3748,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.13.2",
  "rgb-invoicing",
- "rgb-lib-migration 0.3.0-beta.3 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev)",
+ "rgb-lib-migration",
  "rgb-ops",
  "rgb-psbt-utils",
  "rgb-schemas",
@@ -3814,16 +3771,6 @@ dependencies = [
  "url",
  "walkdir",
  "zip 8.5.1",
-]
-
-[[package]]
-name = "rgb-lib-migration"
-version = "0.3.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dd5262d25fe54dd65afa13c19859abba7f81d130fa26d10f018e30bfdd333a"
-dependencies = [
- "sea-orm-migration",
- "tokio",
 ]
 
 [[package]]
@@ -3872,7 +3819,7 @@ dependencies = [
  "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
- "rgb-lib 0.3.0-beta.5 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev)",
+ "rgb-lib",
  "rln-migration",
  "scrypt",
  "sea-orm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ lightning-rapid-gossip-sync = { version = "0.2.0", path = "./rust-lightning/ligh
 magic-crypt = "4.0.1"
 rand = "0.8.5"
 regex = { version = "1.11", default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
 rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", branch = "dev", features = [
     "electrum",
     "esplora",

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ curl -X POST -H "Content-type: application/json" \
 
 The node currently exposes the following APIs:
 - `/address` (POST)
+- `/apay/new` (POST)
 - `/assetbalance` (POST)
 - `/assetmetadata` (POST)
 - `/backup` (POST)

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/ConcurrentBtcPaymentsTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/ConcurrentBtcPaymentsTest.kt
@@ -103,6 +103,8 @@ class ConcurrentBtcPaymentsTest {
                 maxMediaUploadSizeMb = 20u,
                 enableVirtualChannelsV0 = false,
                 virtualPeerPubkeys = null,
+                lspBaseUrl = null,
+                lspBearerToken = null,
             )
         )
     }

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
@@ -104,6 +104,8 @@ class MultiOpenCloseTest {
                 maxMediaUploadSizeMb = 20u,
                 enableVirtualChannelsV0 = false,
                 virtualPeerPubkeys = null,
+                lspBaseUrl = null,
+                lspBearerToken = null,
             )
         )
     }

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
@@ -115,6 +115,8 @@ class PaymentTest {
                 maxMediaUploadSizeMb = 20u,
                 enableVirtualChannelsV0 = false,
                 virtualPeerPubkeys = null,
+                lspBaseUrl = null,
+                lspBearerToken = null,
             )
         )
     }

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
@@ -105,6 +105,8 @@ class RestartTest {
                 maxMediaUploadSizeMb = 20u,
                 enableVirtualChannelsV0 = false,
                 virtualPeerPubkeys = null,
+                lspBaseUrl = null,
+                lspBearerToken = null,
             )
         )
     }

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/SwapRoundtripBuyTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/SwapRoundtripBuyTest.kt
@@ -132,6 +132,8 @@ class SwapRoundtripBuyTest {
                 maxMediaUploadSizeMb = 20u,
                 enableVirtualChannelsV0 = false,
                 virtualPeerPubkeys = null,
+                lspBaseUrl = null,
+                lspBearerToken = null,
             )
         )
     }

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -528,6 +528,8 @@ dictionary SdkInitRequest {
     u16 max_media_upload_size_mb;
     boolean? enable_virtual_channels_v0;
     sequence<PublicKey>? virtual_peer_pubkeys;
+    string? lsp_base_url;
+    string? lsp_bearer_token;
 };
 
 dictionary SdkUnlockRequest {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -43,6 +43,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AddressResponse'
+  /apay/new:
+    post:
+      tags:
+        - Payments
+      summary: Send a new order with async-payment hashes
+      description: Derive deterministic payment hashes for async payments from the unlocked wallet. Send an async_order.new JSON-RPC request to the connected invoice-host peer so it can track those hashes and process asynchronous payments.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AsyncOrderNewRequest'
+      responses:
+        '200':
+          description: Host accepted the async order request and returned order state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncOrderNewResponse'
   /assetbalance:
     post:
       tags:
@@ -1058,6 +1076,79 @@ components:
         address:
           type: string
           example: bcrt1qnc5y6j6dmejrkwy93farhvpezk0lf46gk7aecs
+    AsyncOrderNewHash:
+      type: object
+      required:
+        - hash_index
+        - payment_hash
+      properties:
+        hash_index:
+          type: integer
+          example: 1
+        payment_hash:
+          type: string
+          example: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    AsyncOrderNewRequest:
+      type: object
+      required:
+        - host_node_id
+      properties:
+        host_node_id:
+          type: string
+          example: 02123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0
+    AsyncOrderNewResponse:
+      type: object
+      required:
+        - request_id
+        - host_node_id
+        - protocol_version
+        - order_id
+        - status
+        - accepted_through_index
+        - next_index_expected
+        - unused_hashes
+        - refill_batch_size
+        - first_hash_index
+        - last_hash_index
+        - hashes
+      properties:
+        request_id:
+          type: string
+          example: 3aebcbb3-1230-4e78-933f-cdfba5ac9f30
+        host_node_id:
+          type: string
+          example: 02123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0
+        protocol_version:
+          type: integer
+          example: 1
+        order_id:
+          type: string
+          example: '1'
+        status:
+          type: string
+          example: active
+        accepted_through_index:
+          type: integer
+          example: 200
+        next_index_expected:
+          type: integer
+          example: 201
+        unused_hashes:
+          type: integer
+          example: 200
+        refill_batch_size:
+          type: integer
+          example: 200
+        first_hash_index:
+          type: integer
+          example: 1
+        last_hash_index:
+          type: integer
+          example: 200
+        hashes:
+          type: array
+          items:
+            $ref: '#/components/schemas/AsyncOrderNewHash'
     AssetBalanceRequest:
       type: object
       required:

--- a/src/args.rs
+++ b/src/args.rs
@@ -42,6 +42,12 @@ struct Args {
 
     #[arg(long, value_delimiter = ',')]
     virtual_peer_pubkeys: Vec<String>,
+
+    #[arg(long)]
+    lsp_base_url: Option<String>,
+
+    #[arg(long)]
+    lsp_bearer_token: Option<String>,
 }
 
 pub(crate) struct UserArgs {
@@ -53,6 +59,8 @@ pub(crate) struct UserArgs {
     pub(crate) root_public_key: Option<biscuit_auth::PublicKey>,
     pub(crate) enable_virtual_channels_v0: bool,
     pub(crate) virtual_peer_pubkeys: Vec<PublicKey>,
+    pub(crate) lsp_base_url: Option<String>,
+    pub(crate) lsp_bearer_token: Option<String>,
 }
 
 pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
@@ -84,5 +92,7 @@ pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
         root_public_key,
         enable_virtual_channels_v0: args.enable_virtual_channels_v0,
         virtual_peer_pubkeys,
+        lsp_base_url: args.lsp_base_url,
+        lsp_bearer_token: args.lsp_bearer_token,
     })
 }

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -1,26 +1,39 @@
+use bitcoin::hashes::{sha256, Hash as BitcoinHash};
 use bitcoin::secp256k1::PublicKey;
+use bitcoin::Network;
 use lightning::io;
 use lightning::ln::msgs::{DecodeError, Init, LightningError};
 use lightning::ln::peer_handler::CustomMessageHandler;
 use lightning::ln::wire::{CustomMessageReader, Type};
 use lightning::types::features::{InitFeatures, NodeFeatures};
+use lightning::types::payment::{PaymentHash, PaymentPreimage};
+use lightning::util::persist::KVStoreSync;
 use lightning::util::ser::{LengthLimitedRead, LengthReadable, WithoutLength, Writeable, Writer};
+use rgb_lib::{
+    bdk_wallet::keys::{bip39::Mnemonic, DerivableKey, ExtendedKey},
+    bitcoin::{
+        bip32::{ChildNumber, Xpriv},
+        secp256k1::Secp256k1 as Secp256k1_30,
+    },
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::runtime::Handle;
+use tokio::sync::oneshot;
 use tracing::warn;
 
 use crate::utils::{hex_str, validate_and_parse_payment_hash};
 
 pub(crate) const ASYNC_ORDER_MESSAGE_TYPE_ID: u16 = 37915;
+pub(crate) const ASYNC_ORDER_MAX_HASH_BATCH_SIZE: usize = 200;
+pub(crate) const ASYNC_ORDER_RESPONSE_TIMEOUT_SECS: u64 = 30;
 const ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT: i64 = 1004;
 const ASYNC_ERROR_DUPLICATE_HASH_CONFLICT: i64 = 1005;
 const ASYNC_ERROR_INVALID_HASH_BATCH: i64 = 1003;
 const ASYNC_ERROR_UNSUPPORTED_PROTOCOL_VERSION: i64 = 1000;
-const ASYNC_ORDER_MAX_HASH_BATCH_SIZE: usize = 200;
 const JSONRPC_INVALID_REQUEST: i64 = -32600;
 const JSONRPC_INVALID_PARAMS: i64 = -32602;
 const JSONRPC_INTERNAL_ERROR: i64 = -32603;
@@ -29,6 +42,13 @@ const JSONRPC_PARSE_ERROR: i64 = -32700;
 const JSONRPC_VERSION: &str = "2.0";
 const PROTOCOL_VERSION: u64 = 1;
 const ASYNC_ORDER_LSP_REQUEST_TIMEOUT_SECS: u64 = 25; // Must be above utexo-lsp's default 15s HTTP timeout with a buffer.
+const ASYNC_ORDER_FIRST_HASH_INDEX: u64 = 1;
+const ASYNC_PAYMENTS_ACCOUNT_INDEX: u32 = 0;
+const ASYNC_PAYMENTS_BIP32_MAX_CHILD_INDEX: u32 = 0x7fff_ffff;
+const ASYNC_PAYMENTS_PREIMAGE_DOMAIN: &[u8] = b"async-payments/v0";
+const ASYNC_PAYMENTS_PURPOSE_APAY_INDEX: u32 = 0x4150_4159;
+const ASYNC_PAYMENTS_KV_NAMESPACE: &str = "async_payments";
+const ASYNC_PAYMENTS_NEXT_INDEX_KV_NAMESPACE: &str = "next_hash_index";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct AsyncOrderMessage {
@@ -75,7 +95,7 @@ struct AsyncOrderEnvelope {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AsyncOrderNewHashWire {
-    pub(crate) hash_index: String,
+    pub(crate) hash_index: u64,
     pub(crate) payment_hash: String,
 }
 
@@ -87,14 +107,14 @@ pub(crate) struct AsyncOrderNewParamsWire {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-struct AsyncOrderNewResultWire {
-    protocol_version: u64,
-    order_id: String,
-    status: String,
-    accepted_through_index: String,
-    next_index_expected: String,
-    unused_hashes: String,
-    refill_batch_size: String,
+pub(crate) struct AsyncOrderNewResultWire {
+    pub(crate) protocol_version: u64,
+    pub(crate) order_id: String,
+    pub(crate) status: String,
+    pub(crate) accepted_through_index: u64,
+    pub(crate) next_index_expected: u64,
+    pub(crate) unused_hashes: u64,
+    pub(crate) refill_batch_size: u64,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -109,9 +129,71 @@ struct AsyncOrderHttpResponseWire {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct JsonRpcErrorWire {
-    code: i64,
-    message: String,
+pub(crate) struct JsonRpcErrorWire {
+    pub(crate) code: i64,
+    pub(crate) message: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct AsyncPaymentsPreimageRoot {
+    account_xprv: Xpriv,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AsyncPaymentHashMaterial {
+    pub(crate) hash_index: u64,
+    pub(crate) payment_preimage: PaymentPreimage,
+    pub(crate) payment_hash: PaymentHash,
+}
+
+pub(crate) fn read_async_payments_next_hash_index(
+    kv_store: &dyn KVStoreSync,
+    host_node_id: &PublicKey,
+) -> Result<u64, JsonRpcErrorWire> {
+    match kv_store.read(
+        ASYNC_PAYMENTS_KV_NAMESPACE,
+        ASYNC_PAYMENTS_NEXT_INDEX_KV_NAMESPACE,
+        &hex_str(&host_node_id.serialize()),
+    ) {
+        Ok(bytes) => {
+            let value = String::from_utf8(bytes).map_err(|err| {
+                JsonRpcErrorWire::internal_error(format!(
+                    "async_payments_next_index_invalid_utf8: {err}"
+                ))
+            })?;
+            let next_index = value.parse::<u64>().map_err(|err| {
+                JsonRpcErrorWire::internal_error(format!(
+                    "async_payments_next_index_invalid_value: {err}"
+                ))
+            })?;
+            validate_async_payments_next_hash_index(next_index)?;
+            Ok(next_index)
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(ASYNC_ORDER_FIRST_HASH_INDEX),
+        Err(err) => Err(JsonRpcErrorWire::internal_error(format!(
+            "async_payments_next_index_read_failed: {err}"
+        ))),
+    }
+}
+
+pub(crate) fn write_async_payments_next_hash_index(
+    kv_store: &dyn KVStoreSync,
+    host_node_id: &PublicKey,
+    next_index: u64,
+) -> Result<(), JsonRpcErrorWire> {
+    validate_async_payments_next_hash_index(next_index)?;
+    kv_store
+        .write(
+            ASYNC_PAYMENTS_KV_NAMESPACE,
+            ASYNC_PAYMENTS_NEXT_INDEX_KV_NAMESPACE,
+            &hex_str(&host_node_id.serialize()),
+            next_index.to_string().into_bytes(),
+        )
+        .map_err(|err| {
+            JsonRpcErrorWire::internal_error(format!(
+                "async_payments_next_index_write_failed: {err}"
+            ))
+        })
 }
 
 pub(crate) trait AsyncOrderAccessControl: Send + Sync {
@@ -134,12 +216,16 @@ pub(crate) struct AsyncOrderMessageHandler {
     state: Arc<Mutex<AsyncOrderState>>,
 }
 
-#[derive(Debug)]
 struct AsyncOrderState {
     next_order_id: u64,
     peers: HashMap<PublicKey, PeerOrderState>,
     pending: Vec<(PublicKey, AsyncOrderMessage)>,
+    pending_responses: HashMap<(PublicKey, String), AsyncOrderResponseSender>,
 }
+
+type AsyncOrderResponse = Result<AsyncOrderNewResultWire, JsonRpcErrorWire>;
+type AsyncOrderResponseSender = oneshot::Sender<AsyncOrderResponse>;
+pub(crate) type AsyncOrderResponseReceiver = oneshot::Receiver<AsyncOrderResponse>;
 
 #[derive(Debug, Default)]
 struct PeerOrderState {
@@ -173,6 +259,7 @@ impl Default for AsyncOrderState {
             next_order_id: 1,
             peers: HashMap::new(),
             pending: Vec::new(),
+            pending_responses: HashMap::new(),
         }
     }
 }
@@ -288,6 +375,105 @@ impl AsyncOrderLspClient {
     }
 }
 
+impl AsyncPaymentsPreimageRoot {
+    pub(crate) fn build_from_mnemonic(
+        mnemonic: &Mnemonic,
+        network: Network,
+        this_node_pubkey: &PublicKey,
+    ) -> Result<Self, JsonRpcErrorWire> {
+        let xkey: ExtendedKey = mnemonic.clone().into_extended_key().map_err(|err| {
+            let message = format!("async_payment_root_derivation_failed: {err}");
+            JsonRpcErrorWire::internal_error(message)
+        })?;
+        let mut account_xprv = xkey.into_xprv(network).ok_or_else(|| {
+            JsonRpcErrorWire::internal_error("async_payment_xprv_not_available".to_owned())
+        })?;
+
+        let h31 = u32::from_be_bytes(
+            sha256::Hash::hash(&this_node_pubkey.serialize()).to_byte_array()[0..4]
+                .try_into()
+                .expect("sha256 hash is 32 bytes"),
+        ) & ASYNC_PAYMENTS_BIP32_MAX_CHILD_INDEX;
+
+        let path = [
+            ASYNC_PAYMENTS_PURPOSE_APAY_INDEX,
+            ASYNC_PAYMENTS_ACCOUNT_INDEX,
+            h31,
+        ];
+        for index in path {
+            account_xprv = derive_hardened_child(&account_xprv, index)?;
+        }
+
+        Ok(Self { account_xprv })
+    }
+
+    pub(crate) fn derive_hash_material(
+        &self,
+        hash_index: u64,
+    ) -> Result<AsyncPaymentHashMaterial, JsonRpcErrorWire> {
+        if hash_index < ASYNC_ORDER_FIRST_HASH_INDEX {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+
+        let index =
+            u32::try_from(hash_index).map_err(|_| JsonRpcErrorWire::invalid_hash_batch())?;
+        if index > ASYNC_PAYMENTS_BIP32_MAX_CHILD_INDEX {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+
+        let child_xprv = derive_hardened_child(&self.account_xprv, index)?;
+        let child_secret = child_xprv.private_key.secret_bytes();
+        let mut preimage_material =
+            Vec::with_capacity(ASYNC_PAYMENTS_PREIMAGE_DOMAIN.len() + child_secret.len());
+        preimage_material.extend_from_slice(ASYNC_PAYMENTS_PREIMAGE_DOMAIN);
+        preimage_material.extend_from_slice(&child_secret);
+
+        let payment_preimage =
+            PaymentPreimage(sha256::Hash::hash(&preimage_material).to_byte_array());
+        let payment_hash = PaymentHash(sha256::Hash::hash(&payment_preimage.0).to_byte_array());
+
+        Ok(AsyncPaymentHashMaterial {
+            hash_index,
+            payment_preimage,
+            payment_hash,
+        })
+    }
+
+    pub(crate) fn prepare_async_order_new_params(
+        &self,
+        start_index: u64,
+        batch_size: usize,
+    ) -> Result<AsyncOrderNewParamsWire, JsonRpcErrorWire> {
+        if start_index < ASYNC_ORDER_FIRST_HASH_INDEX
+            || batch_size == 0
+            || batch_size > ASYNC_ORDER_MAX_HASH_BATCH_SIZE
+        {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+
+        let last_index = start_index
+            .checked_add((batch_size - 1) as u64)
+            .ok_or_else(JsonRpcErrorWire::invalid_hash_batch)?;
+        if last_index > ASYNC_PAYMENTS_BIP32_MAX_CHILD_INDEX as u64 {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+
+        let mut hashes = Vec::with_capacity(batch_size);
+        for hash_index in start_index..=last_index {
+            let material = self.derive_hash_material(hash_index)?;
+            hashes.push(AsyncOrderNewHashWire {
+                hash_index: material.hash_index,
+                payment_hash: hex_str(&material.payment_hash.0),
+            });
+        }
+
+        Ok(AsyncOrderNewParamsWire {
+            protocol_version: PROTOCOL_VERSION,
+            hashes,
+        })
+    }
+}
+
 impl AsyncOrderMessageHandler {
     pub(crate) fn new(access_control: Arc<dyn AsyncOrderAccessControl>) -> Self {
         Self {
@@ -348,6 +534,51 @@ impl AsyncOrderMessageHandler {
                 "result": result,
             }),
         );
+    }
+
+    pub(crate) fn queue_async_order_new_request(
+        &self,
+        host_node_id: PublicKey,
+        id: Value,
+        params: AsyncOrderNewParamsWire,
+    ) -> Result<AsyncOrderResponseReceiver, JsonRpcErrorWire> {
+        Self::validate_async_order_new_params(&params)?;
+        let Some(request_id) = id.as_str().map(str::to_owned) else {
+            return Err(JsonRpcErrorWire::invalid_request());
+        };
+
+        let (response_sender, response_receiver) = oneshot::channel();
+        let mut state = self.state.lock().unwrap();
+        let response_key = (host_node_id, request_id);
+        if state.pending_responses.contains_key(&response_key) {
+            return Err(JsonRpcErrorWire::internal_error(
+                "async_order_request_id_already_pending".to_owned(),
+            ));
+        }
+        state
+            .pending_responses
+            .insert(response_key, response_sender);
+        state.pending.push((
+            host_node_id,
+            AsyncOrderMessage {
+                payload: json!({
+                    "jsonrpc": JSONRPC_VERSION,
+                    "id": id,
+                    "method": "async_order.new",
+                    "params": params,
+                })
+                .to_string(),
+            },
+        ));
+
+        Ok(response_receiver)
+    }
+
+    pub(crate) fn forget_async_order_response(&self, host_node_id: PublicKey, request_id: &str) {
+        let mut state = self.state.lock().unwrap();
+        state
+            .pending_responses
+            .remove(&(host_node_id, request_id.to_owned()));
     }
 
     fn queue_jsonrpc_error(&self, peer: PublicKey, id: Value, code: i64, message: &str) {
@@ -412,6 +643,50 @@ impl AsyncOrderMessageHandler {
                 "error": JsonRpcErrorWire::invalid_request(),
             }),
         );
+    }
+
+    fn complete_async_order_response(
+        &self,
+        sender_node_id: PublicKey,
+        id: Option<Value>,
+        result: Option<Value>,
+        error: Option<Value>,
+    ) {
+        let Some(Value::String(request_id)) = id else {
+            warn!(peer = %sender_node_id, "ignoring async_order response with missing or non-string id");
+            return;
+        };
+
+        let response = match (result, error) {
+            (Some(result), None) => serde_json::from_value::<AsyncOrderNewResultWire>(result)
+                .map_err(|err| {
+                    JsonRpcErrorWire::internal_error(format!(
+                        "invalid_async_order_response_result: {err}"
+                    ))
+                }),
+            (None, Some(error)) => match serde_json::from_value::<JsonRpcErrorWire>(error) {
+                Ok(err) => Err(err),
+                Err(err) => Err(JsonRpcErrorWire::internal_error(format!(
+                    "invalid_async_order_response_error: {err}"
+                ))),
+            },
+            (Some(_), Some(_)) => Err(JsonRpcErrorWire::internal_error(
+                "invalid_async_order_response: contained both result and error".to_owned(),
+            )),
+            (None, None) => Err(JsonRpcErrorWire::internal_error(
+                "invalid_async_order_response: missing result and error".to_owned(),
+            )),
+        };
+
+        let response_sender = {
+            let mut state = self.state.lock().unwrap();
+            state
+                .pending_responses
+                .remove(&(sender_node_id, request_id))
+        };
+        if let Some(response_sender) = response_sender {
+            let _ = response_sender.send(response);
+        }
     }
 
     fn record_async_order_new(
@@ -567,13 +842,23 @@ impl CustomMessageHandler for AsyncOrderMessageHandler {
             return Ok(());
         }
 
-        if envelope.result.is_some() || envelope.error.is_some() {
+        let response_like = envelope.result.is_some()
+            || envelope.error.is_some()
+            || (envelope.method.is_none() && envelope.id.is_some() && envelope.params.is_none());
+        if response_like {
             if envelope.method.is_some() {
                 warn!(
                     peer = %sender_node_id,
                     "ignoring malformed async_order response envelope with method field"
                 );
+                return Ok(());
             }
+            self.complete_async_order_response(
+                sender_node_id,
+                envelope.id,
+                envelope.result,
+                envelope.error,
+            );
             return Ok(());
         }
 
@@ -758,10 +1043,10 @@ impl AsyncOrderRecord {
             protocol_version: PROTOCOL_VERSION,
             order_id: self.order_id.to_string(),
             status: "active".to_owned(),
-            accepted_through_index: self.highest_hash_index().to_string(),
-            next_index_expected: self.next_hash_index().to_string(),
-            unused_hashes: self.available_hashes().to_string(),
-            refill_batch_size: ASYNC_ORDER_MAX_HASH_BATCH_SIZE.to_string(),
+            accepted_through_index: self.highest_hash_index(),
+            next_index_expected: self.next_hash_index(),
+            unused_hashes: self.available_hashes(),
+            refill_batch_size: ASYNC_ORDER_MAX_HASH_BATCH_SIZE as u64,
         }
     }
 }
@@ -817,6 +1102,19 @@ impl JsonRpcErrorWire {
     }
 }
 
+fn derive_hardened_child(parent: &Xpriv, index: u32) -> Result<Xpriv, JsonRpcErrorWire> {
+    if index > ASYNC_PAYMENTS_BIP32_MAX_CHILD_INDEX {
+        return Err(JsonRpcErrorWire::invalid_hash_batch());
+    }
+    parent
+        .derive_priv(&Secp256k1_30::new(), &ChildNumber::Hardened { index })
+        .map_err(|err| {
+            JsonRpcErrorWire::internal_error(format!(
+                "async_payment_preimage_derivation_failed: {err}"
+            ))
+        })
+}
+
 fn parse_hash_batch(
     hashes: Vec<AsyncOrderNewHashWire>,
 ) -> Result<Vec<(u64, String)>, JsonRpcErrorWire> {
@@ -824,10 +1122,7 @@ fn parse_hash_batch(
     let mut previous_index: Option<u64> = None;
 
     for entry in hashes {
-        let index = entry
-            .hash_index
-            .parse::<u64>()
-            .map_err(|_| JsonRpcErrorWire::invalid_hash_batch())?;
+        let index = entry.hash_index;
         let payment_hash = validate_and_parse_payment_hash(&entry.payment_hash)
             .map_err(|_| JsonRpcErrorWire::invalid_hash_batch())?;
 
@@ -844,18 +1139,106 @@ fn parse_hash_batch(
     Ok(parsed)
 }
 
+fn validate_async_payments_next_hash_index(next_index: u64) -> Result<(), JsonRpcErrorWire> {
+    if !(ASYNC_ORDER_FIRST_HASH_INDEX..=ASYNC_PAYMENTS_BIP32_MAX_CHILD_INDEX as u64 + 1)
+        .contains(&next_index)
+    {
+        return Err(JsonRpcErrorWire::internal_error(
+            "async_payments_next_index_out_of_range".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::utils::new_jsonrpc_request_id;
     use axum::{extract::Json, http::StatusCode, routing::post, Router};
     use bitcoin::secp256k1::{Secp256k1, SecretKey};
-    use std::sync::Arc;
+    use std::collections::HashMap as StdHashMap;
+    use std::str::FromStr;
+    use std::sync::{Arc, Mutex as StdMutex};
     use std::time::Duration;
     use tokio::net::TcpListener;
     use tokio::time::sleep;
 
     struct DenyAllAccess;
+
+    #[derive(Default)]
+    struct MemoryKvStore {
+        entries: StdMutex<StdHashMap<(String, String, String), Vec<u8>>>,
+    }
+
+    impl KVStoreSync for MemoryKvStore {
+        fn read(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+        ) -> Result<Vec<u8>, io::Error> {
+            self.entries
+                .lock()
+                .unwrap()
+                .get(&(
+                    primary_namespace.to_owned(),
+                    secondary_namespace.to_owned(),
+                    key.to_owned(),
+                ))
+                .cloned()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "missing key"))
+        }
+
+        fn write(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            buf: Vec<u8>,
+        ) -> Result<(), io::Error> {
+            self.entries.lock().unwrap().insert(
+                (
+                    primary_namespace.to_owned(),
+                    secondary_namespace.to_owned(),
+                    key.to_owned(),
+                ),
+                buf,
+            );
+            Ok(())
+        }
+
+        fn remove(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            _lazy: bool,
+        ) -> Result<(), io::Error> {
+            self.entries.lock().unwrap().remove(&(
+                primary_namespace.to_owned(),
+                secondary_namespace.to_owned(),
+                key.to_owned(),
+            ));
+            Ok(())
+        }
+
+        fn list(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+        ) -> Result<Vec<String>, io::Error> {
+            Ok(self
+                .entries
+                .lock()
+                .unwrap()
+                .keys()
+                .filter(|(primary, secondary, _)| {
+                    primary == primary_namespace && secondary == secondary_namespace
+                })
+                .map(|(_, _, key)| key.clone())
+                .collect())
+        }
+    }
 
     impl AsyncOrderAccessControl for DenyAllAccess {
         fn allows_peer(&self, _peer: &PublicKey) -> bool {
@@ -871,12 +1254,35 @@ mod tests {
         PublicKey::from_secret_key(&secp, &secret_key)
     }
 
+    #[test]
+    fn async_payments_next_hash_index_defaults_and_persists_per_host() {
+        let kv_store = MemoryKvStore::default();
+        let first_host = test_peer_pubkey(31);
+        let second_host = test_peer_pubkey(32);
+
+        assert_eq!(
+            read_async_payments_next_hash_index(&kv_store, &first_host).unwrap(),
+            ASYNC_ORDER_FIRST_HASH_INDEX
+        );
+
+        write_async_payments_next_hash_index(&kv_store, &first_host, 201).unwrap();
+
+        assert_eq!(
+            read_async_payments_next_hash_index(&kv_store, &first_host).unwrap(),
+            201
+        );
+        assert_eq!(
+            read_async_payments_next_hash_index(&kv_store, &second_host).unwrap(),
+            ASYNC_ORDER_FIRST_HASH_INDEX
+        );
+    }
+
     fn new_order_request_payload(id: &str, hashes: &[(u64, &str)]) -> String {
         let hashes = hashes
             .iter()
             .map(|(hash_index, payment_hash)| {
                 json!({
-                    "hash_index": hash_index.to_string(),
+                    "hash_index": hash_index,
                     "payment_hash": payment_hash,
                 })
             })
@@ -909,13 +1315,13 @@ mod tests {
             protocol_version: PROTOCOL_VERSION,
             hashes: vec![
                 AsyncOrderNewHashWire {
-                    hash_index: "1".to_owned(),
+                    hash_index: 1,
                     payment_hash:
                         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                             .to_owned(),
                 },
                 AsyncOrderNewHashWire {
-                    hash_index: "2".to_owned(),
+                    hash_index: 2,
                     payment_hash:
                         "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                             .to_owned(),
@@ -929,11 +1335,18 @@ mod tests {
             protocol_version: PROTOCOL_VERSION,
             order_id: "1".to_owned(),
             status: "active".to_owned(),
-            accepted_through_index: "2".to_owned(),
-            next_index_expected: "3".to_owned(),
-            unused_hashes: "2".to_owned(),
-            refill_batch_size: ASYNC_ORDER_MAX_HASH_BATCH_SIZE.to_string(),
+            accepted_through_index: 2,
+            next_index_expected: 3,
+            unused_hashes: 2,
+            refill_batch_size: ASYNC_ORDER_MAX_HASH_BATCH_SIZE as u64,
         }
+    }
+
+    fn test_mnemonic() -> Mnemonic {
+        Mnemonic::from_str(
+            "legal winner thank year wave sausage worth useful legal winner thank yellow",
+        )
+        .unwrap()
     }
 
     async fn spawn_async_order_http_server(app: Router) -> String {
@@ -943,6 +1356,133 @@ mod tests {
             axum::serve(listener, app).await.unwrap();
         });
         format!("http://{}", addr)
+    }
+
+    #[test]
+    fn async_payment_hash_derivation_is_deterministic_and_index_scoped() {
+        let node_pubkey = test_peer_pubkey(21);
+        let root = AsyncPaymentsPreimageRoot::build_from_mnemonic(
+            &test_mnemonic(),
+            Network::Regtest,
+            &node_pubkey,
+        )
+        .unwrap();
+
+        let first = root.derive_hash_material(1).unwrap();
+        let first_again = root.derive_hash_material(1).unwrap();
+        let second = root.derive_hash_material(2).unwrap();
+
+        assert_eq!(first.payment_preimage, first_again.payment_preimage);
+        assert_eq!(first.payment_hash, first_again.payment_hash);
+        assert_ne!(first.payment_preimage, second.payment_preimage);
+        assert_ne!(first.payment_hash, second.payment_hash);
+        assert_eq!(
+            first.payment_hash,
+            PaymentHash(sha256::Hash::hash(&first.payment_preimage.0).to_byte_array())
+        );
+    }
+
+    #[test]
+    fn async_payment_hash_derivation_is_node_scoped() {
+        let first_root = AsyncPaymentsPreimageRoot::build_from_mnemonic(
+            &test_mnemonic(),
+            Network::Regtest,
+            &test_peer_pubkey(22),
+        )
+        .unwrap();
+        let second_root = AsyncPaymentsPreimageRoot::build_from_mnemonic(
+            &test_mnemonic(),
+            Network::Regtest,
+            &test_peer_pubkey(23),
+        )
+        .unwrap();
+
+        assert_ne!(
+            first_root.derive_hash_material(1).unwrap().payment_hash,
+            second_root.derive_hash_material(1).unwrap().payment_hash
+        );
+    }
+
+    #[test]
+    fn async_payment_hash_batch_builds_protocol_params() {
+        let root = AsyncPaymentsPreimageRoot::build_from_mnemonic(
+            &test_mnemonic(),
+            Network::Regtest,
+            &test_peer_pubkey(24),
+        )
+        .unwrap();
+
+        let params = root.prepare_async_order_new_params(1, 2).unwrap();
+
+        assert_eq!(params.protocol_version, PROTOCOL_VERSION);
+        assert_eq!(params.hashes.len(), 2);
+        assert_eq!(params.hashes[0].hash_index, 1);
+        assert_eq!(params.hashes[1].hash_index, 2);
+        assert_eq!(params.hashes[0].payment_hash.len(), 64);
+        assert_eq!(params.hashes[1].payment_hash.len(), 64);
+        assert_ne!(params.hashes[0].payment_hash, params.hashes[1].payment_hash);
+    }
+
+    #[test]
+    fn async_order_sender_queues_jsonrpc_request() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let host_node_id = test_peer_pubkey(25);
+        let request_id = Value::String(new_jsonrpc_request_id());
+
+        let _response_rx = handler
+            .queue_async_order_new_request(
+                host_node_id,
+                request_id.clone(),
+                test_async_order_new_params(),
+            )
+            .unwrap();
+
+        let pending = handler.get_and_clear_pending_msg();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].0, host_node_id);
+
+        let request_value: Value = serde_json::from_str(&pending[0].1.payload).unwrap();
+        assert_eq!(request_value["jsonrpc"], JSONRPC_VERSION);
+        assert_eq!(request_value["id"], request_id);
+        assert_eq!(request_value["method"], "async_order.new");
+        assert_eq!(
+            request_value["params"]["protocol_version"],
+            PROTOCOL_VERSION
+        );
+        assert_eq!(request_value["params"]["hashes"][0]["hash_index"], json!(1));
+        assert_eq!(request_value["params"]["hashes"][1]["hash_index"], json!(2));
+    }
+
+    #[tokio::test]
+    async fn async_order_sender_completes_matching_jsonrpc_response() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let host_node_id = test_peer_pubkey(26);
+        let request_id = Value::String(new_jsonrpc_request_id());
+        let response_rx = handler
+            .queue_async_order_new_request(
+                host_node_id,
+                request_id.clone(),
+                test_async_order_new_params(),
+            )
+            .unwrap();
+        handler.get_and_clear_pending_msg();
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: json!({
+                        "jsonrpc": JSONRPC_VERSION,
+                        "id": request_id,
+                        "result": test_async_order_new_result(),
+                    })
+                    .to_string(),
+                },
+                host_node_id,
+            )
+            .unwrap();
+
+        let response = response_rx.await.unwrap().unwrap();
+        assert_eq!(response, test_async_order_new_result());
     }
 
     #[test]
@@ -982,15 +1522,13 @@ mod tests {
         );
         assert_eq!(response_value["result"]["order_id"], "1");
         assert_eq!(response_value["result"]["status"], "active");
-        assert_eq!(response_value["result"]["accepted_through_index"], "2");
-        assert_eq!(response_value["result"]["next_index_expected"], "3");
-        assert_eq!(response_value["result"]["unused_hashes"], "2");
-        let refill_batch_size = response_value["result"]["refill_batch_size"]
-            .as_str()
-            .unwrap()
-            .parse::<usize>()
-            .unwrap();
-        assert_eq!(refill_batch_size, ASYNC_ORDER_MAX_HASH_BATCH_SIZE);
+        assert_eq!(response_value["result"]["accepted_through_index"], json!(2));
+        assert_eq!(response_value["result"]["next_index_expected"], json!(3));
+        assert_eq!(response_value["result"]["unused_hashes"], json!(2));
+        assert_eq!(
+            response_value["result"]["refill_batch_size"],
+            json!(ASYNC_ORDER_MAX_HASH_BATCH_SIZE)
+        );
     }
 
     #[test]
@@ -1193,7 +1731,7 @@ mod tests {
                             "protocol_version": PROTOCOL_VERSION,
                             "hashes": [
                                 {
-                                    "hash_index": "1",
+                                    "hash_index": 1,
                                     "payment_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                                 }
                             ],
@@ -1226,6 +1764,28 @@ mod tests {
                         "result": {
                             "status": "active",
                         },
+                    })
+                    .to_string(),
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        assert!(handler.get_and_clear_pending_msg().is_empty());
+    }
+
+    #[test]
+    fn async_order_ignores_null_result_response_payloads() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let test_peer = test_peer_pubkey(27);
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: json!({
+                        "jsonrpc": JSONRPC_VERSION,
+                        "id": new_jsonrpc_request_id(),
+                        "result": Value::Null,
                     })
                     .to_string(),
                 },
@@ -1308,8 +1868,8 @@ mod tests {
                     assert_eq!(payload["peer_pubkey"], expected_peer_pubkey);
                     assert_eq!(payload["protocol_version"], json!(PROTOCOL_VERSION));
                     assert_eq!(payload["id"], request_id);
-                    assert_eq!(payload["hashes"][0]["hash_index"], json!("1"));
-                    assert_eq!(payload["hashes"][1]["hash_index"], json!("2"));
+                    assert_eq!(payload["hashes"][0]["hash_index"], json!(1));
+                    assert_eq!(payload["hashes"][1]["hash_index"], json!(2));
                     Json(json!({
                         "jsonrpc": JSONRPC_VERSION,
                         "id": request_id,

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::runtime::Handle;
 use tracing::warn;
 
@@ -27,6 +28,7 @@ const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
 const JSONRPC_PARSE_ERROR: i64 = -32700;
 const JSONRPC_VERSION: &str = "2.0";
 const PROTOCOL_VERSION: u64 = 1;
+const ASYNC_ORDER_LSP_REQUEST_TIMEOUT_SECS: u64 = 25; // Must be above utexo-lsp's default 15s HTTP timeout with a buffer.
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct AsyncOrderMessage {
@@ -176,11 +178,15 @@ impl Default for AsyncOrderState {
 }
 
 impl AsyncOrderLspClient {
-    fn new(base_url: String, lsp_bearer_token: Option<String>) -> Self {
+    fn new(base_url: String, lsp_bearer_token: Option<String>, request_timeout: Duration) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(request_timeout)
+            .build()
+            .expect("reqwest client builder to succeed");
         Self {
             base_url: base_url.trim_end_matches('/').to_owned(),
             lsp_bearer_token,
-            client: reqwest::Client::new(),
+            client,
         }
     }
 
@@ -209,7 +215,16 @@ impl AsyncOrderLspClient {
         }
 
         let response = builder.send().await.map_err(|err| {
-            JsonRpcErrorWire::internal_error(format!("utexo_lsp_request_failed: {err}"))
+            if err.is_timeout() {
+                JsonRpcErrorWire::internal_error(
+                    "async_order_lsp_request_failed: POST /internal/async_order/new timed out"
+                        .to_owned(),
+                )
+            } else {
+                JsonRpcErrorWire::internal_error(format!(
+                    "async_order_lsp_request_failed: POST /internal/async_order/new failed: {err}"
+                ))
+            }
         })?;
         let status = response.status();
         let envelope = response
@@ -291,7 +306,11 @@ impl AsyncOrderMessageHandler {
     ) -> Self {
         Self {
             access_control,
-            lsp_client: Some(AsyncOrderLspClient::new(lsp_base_url, lsp_bearer_token)),
+            lsp_client: Some(AsyncOrderLspClient::new(
+                lsp_base_url,
+                lsp_bearer_token,
+                Duration::from_secs(ASYNC_ORDER_LSP_REQUEST_TIMEOUT_SECS),
+            )),
             runtime_handle: Some(runtime_handle),
             state: Arc::new(Mutex::new(AsyncOrderState::default())),
         }
@@ -832,7 +851,9 @@ mod tests {
     use axum::{extract::Json, http::StatusCode, routing::post, Router};
     use bitcoin::secp256k1::{Secp256k1, SecretKey};
     use std::sync::Arc;
+    use std::time::Duration;
     use tokio::net::TcpListener;
+    use tokio::time::sleep;
 
     struct DenyAllAccess;
 
@@ -1299,7 +1320,7 @@ mod tests {
         );
 
         let base_url = spawn_async_order_http_server(app).await;
-        let client = AsyncOrderLspClient::new(base_url, None);
+        let client = AsyncOrderLspClient::new(base_url, None, Duration::from_secs(1));
         let result = client
             .async_order_new(test_peer, request_id, test_async_order_new_params())
             .await
@@ -1340,7 +1361,7 @@ mod tests {
         );
 
         let base_url = spawn_async_order_http_server(app).await;
-        let client = AsyncOrderLspClient::new(base_url, None);
+        let client = AsyncOrderLspClient::new(base_url, None, Duration::from_secs(1));
         let err = client
             .async_order_new(test_peer, request_id, test_async_order_new_params())
             .await
@@ -1348,5 +1369,44 @@ mod tests {
 
         assert_eq!(err.code, ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT);
         assert_eq!(err.message, "duplicate_index_conflict");
+    }
+
+    #[tokio::test]
+    async fn async_order_lsp_client_times_out_on_slow_response() {
+        let test_peer = test_peer_pubkey(12);
+        let expected_peer_pubkey = hex_str(&test_peer.serialize());
+        let request_id = Value::String(new_jsonrpc_request_id());
+        let request_id_for_server = request_id.clone();
+
+        let app = Router::new().route(
+            "/internal/async_order/new",
+            post(move |Json(payload): Json<Value>| {
+                let expected_peer_pubkey = expected_peer_pubkey.clone();
+                let request_id = request_id_for_server.clone();
+                async move {
+                    assert_eq!(payload["peer_pubkey"], expected_peer_pubkey);
+                    assert_eq!(payload["id"], request_id);
+                    sleep(Duration::from_millis(150)).await;
+                    Json(json!({
+                        "jsonrpc": JSONRPC_VERSION,
+                        "id": request_id,
+                        "result": test_async_order_new_result(),
+                    }))
+                }
+            }),
+        );
+
+        let base_url = spawn_async_order_http_server(app).await;
+        let client = AsyncOrderLspClient::new(base_url, None, Duration::from_millis(50));
+        let err = client
+            .async_order_new(test_peer, request_id, test_async_order_new_params())
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, JSONRPC_INTERNAL_ERROR);
+        assert_eq!(
+            err.message,
+            "async_order_lsp_request_failed: POST /internal/async_order/new timed out"
+        );
     }
 }

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -1,0 +1,815 @@
+use bitcoin::secp256k1::PublicKey;
+use lightning::io;
+use lightning::ln::msgs::{DecodeError, Init, LightningError};
+use lightning::ln::peer_handler::CustomMessageHandler;
+use lightning::ln::wire::{CustomMessageReader, Type};
+use lightning::types::features::{InitFeatures, NodeFeatures};
+use lightning::util::ser::{LengthLimitedRead, LengthReadable, WithoutLength, Writeable, Writer};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Mutex;
+use tracing::warn;
+
+use crate::utils::{hex_str, validate_and_parse_payment_hash};
+
+pub(crate) const ASYNC_ORDER_MESSAGE_TYPE_ID: u16 = 37915;
+const ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT: i64 = 1004;
+const ASYNC_ERROR_DUPLICATE_HASH_CONFLICT: i64 = 1005;
+const ASYNC_ERROR_INVALID_HASH_BATCH: i64 = 1003;
+const ASYNC_ERROR_UNSUPPORTED_PROTOCOL_VERSION: i64 = 1000;
+const DEFAULT_REFILL_BATCH_SIZE: &str = "200";
+const JSONRPC_INVALID_PARAMS: i64 = -32600;
+const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
+const JSONRPC_PARSE_ERROR: i64 = -32700;
+const JSONRPC_VERSION: &str = "2.0";
+const PROTOCOL_VERSION: &str = "1";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AsyncOrderMessage {
+    pub(crate) payload: String,
+}
+
+impl Type for AsyncOrderMessage {
+    fn type_id(&self) -> u16 {
+        ASYNC_ORDER_MESSAGE_TYPE_ID
+    }
+}
+
+impl Writeable for AsyncOrderMessage {
+    fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+        WithoutLength(&self.payload).write(w)
+    }
+}
+
+impl LengthReadable for AsyncOrderMessage {
+    fn read_from_fixed_length_buffer<R: LengthLimitedRead>(r: &mut R) -> Result<Self, DecodeError> {
+        let payload_without_length: WithoutLength<String> =
+            LengthReadable::read_from_fixed_length_buffer(r)?;
+        Ok(Self {
+            payload: payload_without_length.0,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct AsyncOrderEnvelope {
+    jsonrpc: String,
+    #[serde(default)]
+    id: Option<Value>,
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    params: Option<Value>,
+    #[serde(default)]
+    result: Option<Value>,
+    #[serde(default)]
+    error: Option<Value>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AsyncOrderNewHashWire {
+    pub(crate) hash_index: String,
+    pub(crate) payment_hash: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AsyncOrderNewParamsWire {
+    pub(crate) protocol_version: String,
+    pub(crate) hashes: Vec<AsyncOrderNewHashWire>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct AsyncOrderNewResultWire {
+    protocol_version: String,
+    order_id: String,
+    status: String,
+    accepted_through_index: String,
+    next_index_expected: String,
+    unused_hashes: String,
+    refill_batch_size: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct JsonRpcErrorWire {
+    code: i64,
+    message: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct AsyncOrderMessageHandler {
+    state: Mutex<AsyncOrderState>,
+}
+
+#[derive(Debug)]
+struct AsyncOrderState {
+    next_order_id: u64,
+    peers: HashMap<PublicKey, PeerOrderState>,
+    pending: Vec<(PublicKey, AsyncOrderMessage)>,
+}
+
+#[derive(Debug, Default)]
+struct PeerOrderState {
+    active_order: Option<AsyncOrderRecord>,
+}
+
+#[derive(Debug, Clone)]
+struct AsyncOrderRecord {
+    order_id: u64,
+    hashes: BTreeMap<u64, String>,
+}
+
+impl Default for AsyncOrderState {
+    fn default() -> Self {
+        Self {
+            next_order_id: 1,
+            peers: HashMap::new(),
+            pending: Vec::new(),
+        }
+    }
+}
+
+impl AsyncOrderMessageHandler {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(AsyncOrderState::default()),
+        }
+    }
+
+    fn queue_jsonrpc_value(&self, peer: PublicKey, value: Value) {
+        let mut state = self.state.lock().unwrap();
+        state.pending.push((
+            peer,
+            AsyncOrderMessage {
+                payload: value.to_string(),
+            },
+        ));
+    }
+
+    fn queue_jsonrpc_result(&self, peer: PublicKey, id: Value, result: AsyncOrderNewResultWire) {
+        self.queue_jsonrpc_value(
+            peer,
+            json!({
+                "jsonrpc": JSONRPC_VERSION,
+                "id": id,
+                "result": result,
+            }),
+        );
+    }
+
+    fn queue_jsonrpc_error(&self, peer: PublicKey, id: Value, code: i64, message: &str) {
+        self.queue_jsonrpc_value(
+            peer,
+            json!({
+                "jsonrpc": JSONRPC_VERSION,
+                "id": id,
+                "error": JsonRpcErrorWire {
+                    code,
+                    message: message.to_owned(),
+                },
+            }),
+        );
+    }
+
+    fn queue_jsonrpc_parse_error(&self, peer: PublicKey) {
+        self.queue_jsonrpc_value(
+            peer,
+            json!({
+                "jsonrpc": JSONRPC_VERSION,
+                "id": Value::Null,
+                "error": JsonRpcErrorWire::parse_error(),
+            }),
+        );
+    }
+
+    fn apply_async_order_new(
+        &self,
+        sender_node_id: PublicKey,
+        params: AsyncOrderNewParamsWire,
+    ) -> Result<AsyncOrderNewResultWire, JsonRpcErrorWire> {
+        if params.protocol_version != PROTOCOL_VERSION {
+            return Err(JsonRpcErrorWire::unsupported_protocol_version());
+        }
+        if params.hashes.is_empty() {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+
+        let parsed_hashes = parse_hash_batch(params.hashes)?;
+
+        let mut state = self.state.lock().unwrap();
+        let needs_new_order = match state.peers.get(&sender_node_id) {
+            Some(peer_state) => peer_state.active_order.is_none(),
+            None => true,
+        };
+        if needs_new_order {
+            let order_id = state.next_order_id;
+            state.next_order_id = state
+                .next_order_id
+                .checked_add(1)
+                .expect("order id counter to not overflow");
+            state.peers.entry(sender_node_id).or_default().active_order =
+                Some(AsyncOrderRecord::new(order_id));
+        }
+
+        let peer_state = state.peers.get_mut(&sender_node_id).unwrap();
+        let order = peer_state.active_order.as_mut().unwrap();
+        order.merge_hashes(&parsed_hashes)?;
+
+        Ok(order.snapshot_result())
+    }
+}
+
+impl Default for AsyncOrderMessageHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CustomMessageReader for AsyncOrderMessageHandler {
+    type CustomMessage = AsyncOrderMessage;
+
+    fn read<RD: LengthLimitedRead>(
+        &self,
+        message_type: u16,
+        buffer: &mut RD,
+    ) -> Result<Option<Self::CustomMessage>, DecodeError> {
+        if message_type != ASYNC_ORDER_MESSAGE_TYPE_ID {
+            return Ok(None);
+        }
+
+        Ok(Some(AsyncOrderMessage::read_from_fixed_length_buffer(
+            buffer,
+        )?))
+    }
+}
+
+impl CustomMessageHandler for AsyncOrderMessageHandler {
+    fn handle_custom_message(
+        &self,
+        msg: Self::CustomMessage,
+        sender_node_id: PublicKey,
+    ) -> Result<(), LightningError> {
+        if msg.payload.as_bytes().contains(&0) {
+            warn!(payload = %msg.payload, "async_order peer message contained a NUL byte");
+            self.queue_jsonrpc_parse_error(sender_node_id);
+            return Ok(());
+        }
+
+        let envelope: AsyncOrderEnvelope = match serde_json::from_str(&msg.payload) {
+            Ok(envelope) => envelope,
+            Err(err) => {
+                warn!(error = %err, payload = %msg.payload, "failed to decode async_order peer message");
+                self.queue_jsonrpc_parse_error(sender_node_id);
+                return Ok(());
+            }
+        };
+
+        if envelope.jsonrpc != JSONRPC_VERSION {
+            self.queue_jsonrpc_parse_error(sender_node_id);
+            return Ok(());
+        }
+
+        if envelope.result.is_some() || envelope.error.is_some() {
+            self.queue_jsonrpc_parse_error(sender_node_id);
+            return Ok(());
+        }
+
+        let Some(method) = envelope.method else {
+            self.queue_jsonrpc_parse_error(sender_node_id);
+            return Ok(());
+        };
+
+        let Some(id) = envelope.id else {
+            self.queue_jsonrpc_parse_error(sender_node_id);
+            return Ok(());
+        };
+
+        if method == "async_order.new" {
+            let params_value = match envelope.params {
+                Some(params) => params,
+                None => {
+                    self.queue_jsonrpc_error(
+                        sender_node_id,
+                        id,
+                        JSONRPC_INVALID_PARAMS,
+                        "missing params",
+                    );
+                    return Ok(());
+                }
+            };
+
+            let params: AsyncOrderNewParamsWire = match serde_json::from_value(params_value) {
+                Ok(params) => params,
+                Err(err) => {
+                    warn!(error = %err, "invalid async_order.new params from {sender_node_id}");
+                    self.queue_jsonrpc_error(
+                        sender_node_id,
+                        id,
+                        ASYNC_ERROR_INVALID_HASH_BATCH,
+                        "invalid_hash_batch",
+                    );
+                    return Ok(());
+                }
+            };
+
+            match self.apply_async_order_new(sender_node_id, params) {
+                Ok(result) => self.queue_jsonrpc_result(sender_node_id, id, result),
+                Err(err) => self.queue_jsonrpc_error(sender_node_id, id, err.code, &err.message),
+            }
+            return Ok(());
+        }
+
+        self.queue_jsonrpc_error(
+            sender_node_id,
+            id,
+            JSONRPC_METHOD_NOT_FOUND,
+            "method not found",
+        );
+        Ok(())
+    }
+
+    fn get_and_clear_pending_msg(&self) -> Vec<(PublicKey, Self::CustomMessage)> {
+        let mut state = self.state.lock().unwrap();
+        std::mem::take(&mut state.pending)
+    }
+
+    fn peer_disconnected(&self, _their_node_id: PublicKey) {}
+
+    fn peer_connected(
+        &self,
+        _their_node_id: PublicKey,
+        _msg: &Init,
+        _inbound: bool,
+    ) -> Result<(), ()> {
+        Ok(())
+    }
+
+    fn provided_node_features(&self) -> NodeFeatures {
+        NodeFeatures::empty()
+    }
+
+    fn provided_init_features(&self, _their_node_id: PublicKey) -> InitFeatures {
+        InitFeatures::empty()
+    }
+}
+
+impl AsyncOrderRecord {
+    fn new(order_id: u64) -> Self {
+        Self {
+            order_id,
+            hashes: BTreeMap::new(),
+        }
+    }
+
+    fn highest_hash_index(&self) -> u64 {
+        self.hashes.keys().next_back().copied().unwrap_or(0)
+    }
+
+    fn next_hash_index(&self) -> u64 {
+        self.highest_hash_index().saturating_add(1)
+    }
+
+    fn available_hashes(&self) -> u64 {
+        self.hashes.len() as u64
+    }
+
+    fn merge_hashes(&mut self, hashes: &[(u64, String)]) -> Result<(), JsonRpcErrorWire> {
+        if hashes.is_empty() {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+
+        let expected_start = self.next_hash_index();
+        let mut saw_existing = false;
+        let mut saw_missing = false;
+        let mut seen_batch_hashes = HashSet::new();
+
+        for (index, payment_hash) in hashes {
+            if !seen_batch_hashes.insert(payment_hash.clone()) {
+                return Err(JsonRpcErrorWire::duplicate_hash_conflict());
+            }
+
+            match self.hashes.get(index) {
+                Some(existing) if existing == payment_hash => {
+                    saw_existing = true;
+                }
+                Some(_) => {
+                    return Err(JsonRpcErrorWire::duplicate_index_conflict());
+                }
+                None => {
+                    saw_missing = true;
+                }
+            }
+
+            if self.hashes.iter().any(|(existing_index, existing_hash)| {
+                *existing_index != *index && existing_hash == payment_hash
+            }) {
+                return Err(JsonRpcErrorWire::duplicate_hash_conflict());
+            }
+        }
+
+        if saw_existing && saw_missing {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+
+        if saw_existing {
+            return Ok(());
+        }
+
+        if hashes.first().map(|(index, _)| *index) != Some(expected_start) {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+
+        for (index, payment_hash) in hashes {
+            self.hashes.insert(*index, payment_hash.clone());
+        }
+
+        Ok(())
+    }
+
+    fn snapshot_result(&self) -> AsyncOrderNewResultWire {
+        AsyncOrderNewResultWire {
+            protocol_version: PROTOCOL_VERSION.to_owned(),
+            order_id: self.order_id.to_string(),
+            status: "active".to_owned(),
+            accepted_through_index: self.highest_hash_index().to_string(),
+            next_index_expected: self.next_hash_index().to_string(),
+            unused_hashes: self.available_hashes().to_string(),
+            refill_batch_size: DEFAULT_REFILL_BATCH_SIZE.to_owned(),
+        }
+    }
+}
+
+impl JsonRpcErrorWire {
+    fn parse_error() -> Self {
+        Self {
+            code: JSONRPC_PARSE_ERROR,
+            message: "parse error".to_owned(),
+        }
+    }
+
+    fn duplicate_index_conflict() -> Self {
+        Self {
+            code: ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT,
+            message: "duplicate_index_conflict".to_owned(),
+        }
+    }
+
+    fn duplicate_hash_conflict() -> Self {
+        Self {
+            code: ASYNC_ERROR_DUPLICATE_HASH_CONFLICT,
+            message: "duplicate_hash_conflict".to_owned(),
+        }
+    }
+
+    fn invalid_hash_batch() -> Self {
+        Self {
+            code: ASYNC_ERROR_INVALID_HASH_BATCH,
+            message: "invalid_hash_batch".to_owned(),
+        }
+    }
+
+    fn unsupported_protocol_version() -> Self {
+        Self {
+            code: ASYNC_ERROR_UNSUPPORTED_PROTOCOL_VERSION,
+            message: "unsupported_protocol_version".to_owned(),
+        }
+    }
+}
+
+fn parse_hash_batch(
+    hashes: Vec<AsyncOrderNewHashWire>,
+) -> Result<Vec<(u64, String)>, JsonRpcErrorWire> {
+    let mut parsed = Vec::with_capacity(hashes.len());
+    let mut previous_index: Option<u64> = None;
+
+    for entry in hashes {
+        let index = entry
+            .hash_index
+            .parse::<u64>()
+            .map_err(|_| JsonRpcErrorWire::invalid_hash_batch())?;
+        let payment_hash = validate_and_parse_payment_hash(&entry.payment_hash)
+            .map_err(|_| JsonRpcErrorWire::invalid_hash_batch())?;
+
+        if let Some(previous) = previous_index {
+            if index != previous.saturating_add(1) {
+                return Err(JsonRpcErrorWire::invalid_hash_batch());
+            }
+        }
+
+        previous_index = Some(index);
+        parsed.push((index, hex_str(&payment_hash.0)));
+    }
+
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::new_jsonrpc_request_id;
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
+
+    fn test_peer_pubkey(tag: u8) -> PublicKey {
+        let secp = Secp256k1::new();
+        let mut key_bytes = [0u8; 32];
+        key_bytes[31] = tag.max(1);
+        let secret_key = SecretKey::from_slice(&key_bytes).unwrap();
+        PublicKey::from_secret_key(&secp, &secret_key)
+    }
+
+    fn new_request_payload(id: &str, hashes: &[(u64, &str)]) -> String {
+        let hashes = hashes
+            .iter()
+            .map(|(hash_index, payment_hash)| {
+                json!({
+                    "hash_index": hash_index.to_string(),
+                    "payment_hash": payment_hash,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        json!({
+            "jsonrpc": JSONRPC_VERSION,
+            "id": id,
+            "method": "async_order.new",
+            "params": {
+                "protocol_version": PROTOCOL_VERSION,
+                "hashes": hashes,
+            },
+        })
+        .to_string()
+    }
+
+    fn read_single_response(handler: &AsyncOrderMessageHandler) -> Value {
+        let pending = handler.get_and_clear_pending_msg();
+        assert_eq!(pending.len(), 1);
+        serde_json::from_str(&pending[0].1.payload).unwrap()
+    }
+
+    #[test]
+    fn async_order_new_creates_order_and_returns_state() {
+        let handler = AsyncOrderMessageHandler::new();
+        let test_peer = test_peer_pubkey(1);
+        let request_id = new_jsonrpc_request_id();
+        let request_payload = new_request_payload(
+            &request_id,
+            &[
+                (
+                    1,
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                ),
+                (
+                    2,
+                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                ),
+            ],
+        );
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_payload,
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        let response_value = read_single_response(&handler);
+        assert_eq!(response_value["jsonrpc"], JSONRPC_VERSION);
+        assert_eq!(response_value["id"], request_id);
+        assert_eq!(
+            response_value["result"]["protocol_version"],
+            PROTOCOL_VERSION
+        );
+        assert_eq!(response_value["result"]["order_id"], "1");
+        assert_eq!(response_value["result"]["status"], "active");
+        assert_eq!(response_value["result"]["accepted_through_index"], "2");
+        assert_eq!(response_value["result"]["next_index_expected"], "3");
+        assert_eq!(response_value["result"]["unused_hashes"], "2");
+        assert_eq!(
+            response_value["result"]["refill_batch_size"],
+            DEFAULT_REFILL_BATCH_SIZE
+        );
+    }
+
+    #[test]
+    fn async_order_new_is_idempotent_for_identical_batch() {
+        let handler = AsyncOrderMessageHandler::new();
+        let test_peer = test_peer_pubkey(2);
+        let request_id = new_jsonrpc_request_id();
+        let request_payload = new_request_payload(
+            &request_id,
+            &[
+                (
+                    1,
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                ),
+                (
+                    2,
+                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                ),
+            ],
+        );
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_payload.clone(),
+                },
+                test_peer,
+            )
+            .unwrap();
+        let first_response = read_single_response(&handler);
+        assert_eq!(first_response["id"], request_id);
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_payload,
+                },
+                test_peer,
+            )
+            .unwrap();
+        let second_response = read_single_response(&handler);
+
+        assert_eq!(first_response, second_response);
+    }
+
+    #[test]
+    fn async_order_new_rejects_conflicting_index() {
+        let handler = AsyncOrderMessageHandler::new();
+        let test_peer = test_peer_pubkey(3);
+        let initial_request_id = new_jsonrpc_request_id();
+        let initial_request_payload = new_request_payload(
+            &initial_request_id,
+            &[
+                (
+                    1,
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                ),
+                (
+                    2,
+                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                ),
+            ],
+        );
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: initial_request_payload,
+                },
+                test_peer,
+            )
+            .unwrap();
+        read_single_response(&handler);
+
+        let conflicting_request_id = new_jsonrpc_request_id();
+        let conflicting_request_payload = new_request_payload(
+            &conflicting_request_id,
+            &[(
+                1,
+                "accccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            )],
+        );
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: conflicting_request_payload,
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        let response_value = read_single_response(&handler);
+        assert_eq!(response_value["id"], conflicting_request_id);
+        assert_eq!(
+            response_value["error"]["code"],
+            ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT
+        );
+        assert_eq!(
+            response_value["error"]["message"],
+            "duplicate_index_conflict"
+        );
+    }
+
+    #[test]
+    fn async_order_new_rejects_repeated_payment_hash() {
+        let handler = AsyncOrderMessageHandler::new();
+        let test_peer = test_peer_pubkey(6);
+        let initial_request_id = new_jsonrpc_request_id();
+
+        let initial_request_payload = new_request_payload(
+            &initial_request_id,
+            &[
+                (
+                    1,
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                ),
+                (
+                    2,
+                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                ),
+            ],
+        );
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: initial_request_payload,
+                },
+                test_peer,
+            )
+            .unwrap();
+        read_single_response(&handler);
+
+        let repeated_hash_request_id = new_jsonrpc_request_id();
+        let repeated_hash_payload = new_request_payload(
+            &repeated_hash_request_id,
+            &[
+                (
+                    3,
+                    "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                ),
+                (
+                    4,
+                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                ),
+            ],
+        );
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: repeated_hash_payload,
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        let response_value = read_single_response(&handler);
+        assert_eq!(response_value["id"], repeated_hash_request_id);
+        assert_eq!(
+            response_value["error"]["code"],
+            ASYNC_ERROR_DUPLICATE_HASH_CONFLICT
+        );
+        assert_eq!(
+            response_value["error"]["message"],
+            "duplicate_hash_conflict"
+        );
+    }
+
+    #[test]
+    fn async_order_new_rejects_malformed_json_with_parse_error() {
+        let handler = AsyncOrderMessageHandler::new();
+        let test_peer = test_peer_pubkey(4);
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: "{".to_owned(),
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        let response_value = read_single_response(&handler);
+        assert_eq!(response_value["jsonrpc"], JSONRPC_VERSION);
+        assert_eq!(response_value["id"], Value::Null);
+        assert_eq!(response_value["error"]["code"], JSONRPC_PARSE_ERROR);
+        assert_eq!(response_value["error"]["message"], "parse error");
+    }
+
+    #[test]
+    fn async_order_new_rejects_notification_like_payload_with_parse_error() {
+        let handler = AsyncOrderMessageHandler::new();
+        let test_peer = test_peer_pubkey(5);
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: json!({
+                        "jsonrpc": JSONRPC_VERSION,
+                        "method": "async_order.new",
+                        "params": {
+                            "protocol_version": PROTOCOL_VERSION,
+                            "hashes": [
+                                {
+                                    "hash_index": "1",
+                                    "payment_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                }
+                            ],
+                        },
+                    })
+                    .to_string(),
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        let response_value = read_single_response(&handler);
+        assert_eq!(response_value["jsonrpc"], JSONRPC_VERSION);
+        assert_eq!(response_value["id"], Value::Null);
+        assert_eq!(response_value["error"]["code"], JSONRPC_PARSE_ERROR);
+        assert_eq!(response_value["error"]["message"], "parse error");
+    }
+}

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -26,7 +26,7 @@ const JSONRPC_INTERNAL_ERROR: i64 = -32603;
 const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
 const JSONRPC_PARSE_ERROR: i64 = -32700;
 const JSONRPC_VERSION: &str = "2.0";
-const PROTOCOL_VERSION: &str = "1";
+const PROTOCOL_VERSION: u64 = 1;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct AsyncOrderMessage {
@@ -80,19 +80,30 @@ pub(crate) struct AsyncOrderNewHashWire {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AsyncOrderNewParamsWire {
-    pub(crate) protocol_version: String,
+    pub(crate) protocol_version: u64,
     pub(crate) hashes: Vec<AsyncOrderNewHashWire>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 struct AsyncOrderNewResultWire {
-    protocol_version: String,
+    protocol_version: u64,
     order_id: String,
     status: String,
     accepted_through_index: String,
     next_index_expected: String,
     unused_hashes: String,
     refill_batch_size: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct AsyncOrderHttpResponseWire {
+    jsonrpc: String,
+    #[serde(default)]
+    id: Option<Value>,
+    #[serde(default)]
+    result: Option<AsyncOrderNewResultWire>,
+    #[serde(default)]
+    error: Option<JsonRpcErrorWire>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -148,8 +159,9 @@ struct AsyncOrderLspClient {
 
 #[derive(Clone, Debug, Serialize)]
 struct AsyncOrderNewStoreRequest {
+    id: Value,
     peer_pubkey: String,
-    protocol_version: String,
+    protocol_version: u64,
     hashes: Vec<AsyncOrderNewHashWire>,
 }
 
@@ -175,9 +187,11 @@ impl AsyncOrderLspClient {
     async fn async_order_new(
         &self,
         sender_node_id: PublicKey,
+        request_id: Value,
         params: AsyncOrderNewParamsWire,
     ) -> Result<AsyncOrderNewResultWire, JsonRpcErrorWire> {
         let request = AsyncOrderNewStoreRequest {
+            id: request_id.clone(),
             peer_pubkey: hex_str(&sender_node_id.serialize()),
             protocol_version: params.protocol_version,
             hashes: params.hashes,
@@ -198,19 +212,62 @@ impl AsyncOrderLspClient {
             JsonRpcErrorWire::internal_error(format!("utexo_lsp_request_failed: {err}"))
         })?;
         let status = response.status();
-        if status.is_success() {
-            return response
-                .json::<AsyncOrderNewResultWire>()
-                .await
-                .map_err(|err| {
-                    JsonRpcErrorWire::internal_error(format!("utexo_lsp_invalid_response: {err}"))
-                });
+        let envelope = response
+            .json::<AsyncOrderHttpResponseWire>()
+            .await
+            .map_err(|err| {
+                JsonRpcErrorWire::internal_error(format!("utexo_lsp_invalid_response: {err}"))
+            })?;
+
+        let AsyncOrderHttpResponseWire {
+            jsonrpc,
+            id,
+            result,
+            error,
+        } = envelope;
+
+        if jsonrpc != JSONRPC_VERSION {
+            return Err(JsonRpcErrorWire::internal_error(format!(
+                "utexo_lsp_invalid_response: expected jsonrpc {JSONRPC_VERSION}, got {jsonrpc}"
+            )));
         }
 
-        match response.json::<JsonRpcErrorWire>().await {
-            Ok(err) => Err(err),
-            Err(err) => Err(JsonRpcErrorWire::internal_error(format!(
-                "utexo_lsp_error_status_{status}: {err}"
+        if id != Some(request_id) {
+            return Err(JsonRpcErrorWire::internal_error(
+                "utexo_lsp_invalid_response: response id did not match request id".to_owned(),
+            ));
+        }
+
+        if result.is_some() && error.is_some() {
+            return Err(JsonRpcErrorWire::internal_error(
+                "utexo_lsp_invalid_response: response contained both result and error".to_owned(),
+            ));
+        }
+
+        if status.is_success() {
+            return match (result, error) {
+                (Some(result), None) => Ok(result),
+                (None, Some(err)) => Err(err),
+                (Some(_), Some(_)) => Err(JsonRpcErrorWire::internal_error(
+                    "utexo_lsp_invalid_response: response contained both result and error"
+                        .to_owned(),
+                )),
+                (None, None) => Err(JsonRpcErrorWire::internal_error(
+                    "utexo_lsp_invalid_response: response missing result".to_owned(),
+                )),
+            };
+        }
+
+        match (result, error) {
+            (Some(_), Some(_)) => Err(JsonRpcErrorWire::internal_error(format!(
+                "utexo_lsp_error_status_{status}: response contained both result and error"
+            ))),
+            (Some(_), None) => Err(JsonRpcErrorWire::internal_error(format!(
+                "utexo_lsp_error_status_{status}: response unexpectedly contained result"
+            ))),
+            (None, Some(err)) => Err(err),
+            (None, None) => Err(JsonRpcErrorWire::internal_error(format!(
+                "utexo_lsp_error_status_{status}: missing error envelope"
             ))),
         }
     }
@@ -373,16 +430,21 @@ impl AsyncOrderMessageHandler {
         sender_node_id: PublicKey,
         id: Value,
         params: AsyncOrderNewParamsWire,
-    ) -> bool {
+    ) -> Result<(), JsonRpcErrorWire> {
         let (Some(lsp_client), Some(runtime_handle)) =
             (self.lsp_client.clone(), self.runtime_handle.clone())
         else {
-            return false;
+            return Err(JsonRpcErrorWire::internal_error(
+                "async_order_lsp_client_not_available".to_owned(),
+            ));
         };
 
         let state = Arc::clone(&self.state);
         runtime_handle.spawn(async move {
-            match lsp_client.async_order_new(sender_node_id, params).await {
+            match lsp_client
+                .async_order_new(sender_node_id, id.clone(), params)
+                .await
+            {
                 Ok(result) => {
                     AsyncOrderMessageHandler::queue_jsonrpc_result_to_state(
                         &state,
@@ -402,7 +464,7 @@ impl AsyncOrderMessageHandler {
                 }
             }
         });
-        true
+        Ok(())
     }
 
     fn validate_async_order_new_params(
@@ -537,13 +599,10 @@ impl CustomMessageHandler for AsyncOrderMessageHandler {
             if self.lsp_client.is_some() {
                 match Self::validate_async_order_new_params(&params) {
                     Ok(()) => {
-                        if !self.send_new_async_order_to_lsp(sender_node_id, id.clone(), params) {
-                            self.queue_jsonrpc_error(
-                                sender_node_id,
-                                id,
-                                JSONRPC_INTERNAL_ERROR,
-                                "async_order_lsp_client_not_available",
-                            );
+                        if let Err(err) =
+                            self.send_new_async_order_to_lsp(sender_node_id, id.clone(), params)
+                        {
+                            self.queue_jsonrpc_error(sender_node_id, id, err.code, &err.message);
                         }
                     }
                     Err(err) => {
@@ -677,7 +736,7 @@ impl AsyncOrderRecord {
 
     fn snapshot_result(&self) -> AsyncOrderNewResultWire {
         AsyncOrderNewResultWire {
-            protocol_version: PROTOCOL_VERSION.to_owned(),
+            protocol_version: PROTOCOL_VERSION,
             order_id: self.order_id.to_string(),
             status: "active".to_owned(),
             accepted_through_index: self.highest_hash_index().to_string(),
@@ -770,8 +829,10 @@ fn parse_hash_batch(
 mod tests {
     use super::*;
     use crate::utils::new_jsonrpc_request_id;
+    use axum::{extract::Json, http::StatusCode, routing::post, Router};
     use bitcoin::secp256k1::{Secp256k1, SecretKey};
     use std::sync::Arc;
+    use tokio::net::TcpListener;
 
     struct DenyAllAccess;
 
@@ -820,6 +881,47 @@ mod tests {
 
     fn payment_hash_for_index(index: u64) -> String {
         format!("{index:064x}")
+    }
+
+    fn test_async_order_new_params() -> AsyncOrderNewParamsWire {
+        AsyncOrderNewParamsWire {
+            protocol_version: PROTOCOL_VERSION,
+            hashes: vec![
+                AsyncOrderNewHashWire {
+                    hash_index: "1".to_owned(),
+                    payment_hash:
+                        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                            .to_owned(),
+                },
+                AsyncOrderNewHashWire {
+                    hash_index: "2".to_owned(),
+                    payment_hash:
+                        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                            .to_owned(),
+                },
+            ],
+        }
+    }
+
+    fn test_async_order_new_result() -> AsyncOrderNewResultWire {
+        AsyncOrderNewResultWire {
+            protocol_version: PROTOCOL_VERSION,
+            order_id: "1".to_owned(),
+            status: "active".to_owned(),
+            accepted_through_index: "2".to_owned(),
+            next_index_expected: "3".to_owned(),
+            unused_hashes: "2".to_owned(),
+            refill_batch_size: ASYNC_ORDER_MAX_HASH_BATCH_SIZE.to_string(),
+        }
+    }
+
+    async fn spawn_async_order_http_server(app: Router) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{}", addr)
     }
 
     #[test]
@@ -1167,5 +1269,84 @@ mod tests {
             .unwrap();
 
         assert!(handler.get_and_clear_pending_msg().is_empty());
+    }
+
+    #[tokio::test]
+    async fn async_order_lsp_client_parses_jsonrpc_response_envelope() {
+        let test_peer = test_peer_pubkey(10);
+        let expected_peer_pubkey = hex_str(&test_peer.serialize());
+        let request_id = Value::String(new_jsonrpc_request_id());
+        let request_id_for_server = request_id.clone();
+
+        let app = Router::new().route(
+            "/internal/async_order/new",
+            post(move |Json(payload): Json<Value>| {
+                let expected_peer_pubkey = expected_peer_pubkey.clone();
+                let request_id = request_id_for_server.clone();
+                async move {
+                    assert_eq!(payload["peer_pubkey"], expected_peer_pubkey);
+                    assert_eq!(payload["protocol_version"], json!(PROTOCOL_VERSION));
+                    assert_eq!(payload["id"], request_id);
+                    assert_eq!(payload["hashes"][0]["hash_index"], json!("1"));
+                    assert_eq!(payload["hashes"][1]["hash_index"], json!("2"));
+                    Json(json!({
+                        "jsonrpc": JSONRPC_VERSION,
+                        "id": request_id,
+                        "result": test_async_order_new_result(),
+                    }))
+                }
+            }),
+        );
+
+        let base_url = spawn_async_order_http_server(app).await;
+        let client = AsyncOrderLspClient::new(base_url, None);
+        let result = client
+            .async_order_new(test_peer, request_id, test_async_order_new_params())
+            .await
+            .unwrap();
+
+        assert_eq!(result, test_async_order_new_result());
+    }
+
+    #[tokio::test]
+    async fn async_order_lsp_client_parses_jsonrpc_error_envelope() {
+        let test_peer = test_peer_pubkey(11);
+        let expected_peer_pubkey = hex_str(&test_peer.serialize());
+        let request_id = Value::String(new_jsonrpc_request_id());
+        let request_id_for_server = request_id.clone();
+
+        let app = Router::new().route(
+            "/internal/async_order/new",
+            post(move |Json(payload): Json<Value>| {
+                let expected_peer_pubkey = expected_peer_pubkey.clone();
+                let request_id = request_id_for_server.clone();
+                async move {
+                    assert_eq!(payload["peer_pubkey"], expected_peer_pubkey);
+                    assert_eq!(payload["protocol_version"], json!(PROTOCOL_VERSION));
+                    assert_eq!(payload["id"], request_id);
+                    (
+                        StatusCode::CONFLICT,
+                        Json(json!({
+                            "jsonrpc": JSONRPC_VERSION,
+                            "id": request_id,
+                            "error": {
+                                "code": ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT,
+                                "message": "duplicate_index_conflict",
+                            },
+                        })),
+                    )
+                }
+            }),
+        );
+
+        let base_url = spawn_async_order_http_server(app).await;
+        let client = AsyncOrderLspClient::new(base_url, None);
+        let err = client
+            .async_order_new(test_peer, request_id, test_async_order_new_params())
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT);
+        assert_eq!(err.message, "duplicate_index_conflict");
     }
 }

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -8,7 +8,8 @@ use lightning::util::ser::{LengthLimitedRead, LengthReadable, WithoutLength, Wri
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
+use tokio::runtime::Handle;
 use tracing::warn;
 
 use crate::utils::{hex_str, validate_and_parse_payment_hash};
@@ -18,8 +19,10 @@ const ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT: i64 = 1004;
 const ASYNC_ERROR_DUPLICATE_HASH_CONFLICT: i64 = 1005;
 const ASYNC_ERROR_INVALID_HASH_BATCH: i64 = 1003;
 const ASYNC_ERROR_UNSUPPORTED_PROTOCOL_VERSION: i64 = 1000;
-const DEFAULT_REFILL_BATCH_SIZE: &str = "200";
-const JSONRPC_INVALID_PARAMS: i64 = -32600;
+const ASYNC_ORDER_MAX_HASH_BATCH_SIZE: usize = 200;
+const JSONRPC_INVALID_REQUEST: i64 = -32600;
+const JSONRPC_INVALID_PARAMS: i64 = -32602;
+const JSONRPC_INTERNAL_ERROR: i64 = -32603;
 const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
 const JSONRPC_PARSE_ERROR: i64 = -32700;
 const JSONRPC_VERSION: &str = "2.0";
@@ -81,7 +84,7 @@ pub(crate) struct AsyncOrderNewParamsWire {
     pub(crate) hashes: Vec<AsyncOrderNewHashWire>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct AsyncOrderNewResultWire {
     protocol_version: String,
     order_id: String,
@@ -92,15 +95,30 @@ struct AsyncOrderNewResultWire {
     refill_batch_size: String,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct JsonRpcErrorWire {
     code: i64,
     message: String,
 }
 
+pub(crate) trait AsyncOrderAccessControl: Send + Sync {
+    fn allows_peer(&self, peer: &PublicKey) -> bool;
+}
+
 #[derive(Debug)]
+struct AllowFreeAccess;
+
+impl AsyncOrderAccessControl for AllowFreeAccess {
+    fn allows_peer(&self, _peer: &PublicKey) -> bool {
+        true
+    }
+}
+
 pub(crate) struct AsyncOrderMessageHandler {
-    state: Mutex<AsyncOrderState>,
+    access_control: Arc<dyn AsyncOrderAccessControl>,
+    lsp_client: Option<AsyncOrderLspClient>,
+    runtime_handle: Option<Handle>,
+    state: Arc<Mutex<AsyncOrderState>>,
 }
 
 #[derive(Debug)]
@@ -121,6 +139,20 @@ struct AsyncOrderRecord {
     hashes: BTreeMap<u64, String>,
 }
 
+#[derive(Clone)]
+struct AsyncOrderLspClient {
+    base_url: String,
+    lsp_bearer_token: Option<String>,
+    client: reqwest::Client,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct AsyncOrderNewStoreRequest {
+    peer_pubkey: String,
+    protocol_version: String,
+    hashes: Vec<AsyncOrderNewHashWire>,
+}
+
 impl Default for AsyncOrderState {
     fn default() -> Self {
         Self {
@@ -131,21 +163,104 @@ impl Default for AsyncOrderState {
     }
 }
 
-impl AsyncOrderMessageHandler {
-    pub(crate) fn new() -> Self {
+impl AsyncOrderLspClient {
+    fn new(base_url: String, lsp_bearer_token: Option<String>) -> Self {
         Self {
-            state: Mutex::new(AsyncOrderState::default()),
+            base_url: base_url.trim_end_matches('/').to_owned(),
+            lsp_bearer_token,
+            client: reqwest::Client::new(),
         }
     }
 
-    fn queue_jsonrpc_value(&self, peer: PublicKey, value: Value) {
-        let mut state = self.state.lock().unwrap();
+    async fn async_order_new(
+        &self,
+        sender_node_id: PublicKey,
+        params: AsyncOrderNewParamsWire,
+    ) -> Result<AsyncOrderNewResultWire, JsonRpcErrorWire> {
+        let request = AsyncOrderNewStoreRequest {
+            peer_pubkey: hex_str(&sender_node_id.serialize()),
+            protocol_version: params.protocol_version,
+            hashes: params.hashes,
+        };
+        let mut builder = self
+            .client
+            .post(format!("{}/internal/async_order/new", self.base_url))
+            .json(&request);
+        if let Some(token) = self
+            .lsp_bearer_token
+            .as_deref()
+            .filter(|token| !token.is_empty())
+        {
+            builder = builder.bearer_auth(token);
+        }
+
+        let response = builder.send().await.map_err(|err| {
+            JsonRpcErrorWire::internal_error(format!("utexo_lsp_request_failed: {err}"))
+        })?;
+        let status = response.status();
+        if status.is_success() {
+            return response
+                .json::<AsyncOrderNewResultWire>()
+                .await
+                .map_err(|err| {
+                    JsonRpcErrorWire::internal_error(format!("utexo_lsp_invalid_response: {err}"))
+                });
+        }
+
+        match response.json::<JsonRpcErrorWire>().await {
+            Ok(err) => Err(err),
+            Err(err) => Err(JsonRpcErrorWire::internal_error(format!(
+                "utexo_lsp_error_status_{status}: {err}"
+            ))),
+        }
+    }
+}
+
+impl AsyncOrderMessageHandler {
+    pub(crate) fn new(access_control: Arc<dyn AsyncOrderAccessControl>) -> Self {
+        Self {
+            access_control,
+            lsp_client: None,
+            runtime_handle: None,
+            state: Arc::new(Mutex::new(AsyncOrderState::default())),
+        }
+    }
+
+    pub(crate) fn new_with_lsp_client(
+        access_control: Arc<dyn AsyncOrderAccessControl>,
+        lsp_base_url: String,
+        lsp_bearer_token: Option<String>,
+        runtime_handle: Handle,
+    ) -> Self {
+        Self {
+            access_control,
+            lsp_client: Some(AsyncOrderLspClient::new(lsp_base_url, lsp_bearer_token)),
+            runtime_handle: Some(runtime_handle),
+            state: Arc::new(Mutex::new(AsyncOrderState::default())),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_allowing_all_peers() -> Self {
+        Self::new(Arc::new(AllowFreeAccess))
+    }
+
+    fn queue_jsonrpc_value_to_state(
+        state: &Arc<Mutex<AsyncOrderState>>,
+        peer: PublicKey,
+        value: Value,
+    ) {
+        let mut state = state.lock().unwrap();
         state.pending.push((
             peer,
             AsyncOrderMessage {
                 payload: value.to_string(),
             },
         ));
+    }
+
+    fn queue_jsonrpc_value(&self, peer: PublicKey, value: Value) {
+        Self::queue_jsonrpc_value_to_state(&self.state, peer, value);
     }
 
     fn queue_jsonrpc_result(&self, peer: PublicKey, id: Value, result: AsyncOrderNewResultWire) {
@@ -160,7 +275,18 @@ impl AsyncOrderMessageHandler {
     }
 
     fn queue_jsonrpc_error(&self, peer: PublicKey, id: Value, code: i64, message: &str) {
-        self.queue_jsonrpc_value(
+        Self::queue_jsonrpc_error_to_state(&self.state, peer, id, code, message);
+    }
+
+    fn queue_jsonrpc_error_to_state(
+        state: &Arc<Mutex<AsyncOrderState>>,
+        peer: PublicKey,
+        id: Value,
+        code: i64,
+        message: &str,
+    ) {
+        Self::queue_jsonrpc_value_to_state(
+            state,
             peer,
             json!({
                 "jsonrpc": JSONRPC_VERSION,
@@ -169,6 +295,23 @@ impl AsyncOrderMessageHandler {
                     code,
                     message: message.to_owned(),
                 },
+            }),
+        );
+    }
+
+    fn queue_jsonrpc_result_to_state(
+        state: &Arc<Mutex<AsyncOrderState>>,
+        peer: PublicKey,
+        id: Value,
+        result: AsyncOrderNewResultWire,
+    ) {
+        Self::queue_jsonrpc_value_to_state(
+            state,
+            peer,
+            json!({
+                "jsonrpc": JSONRPC_VERSION,
+                "id": id,
+                "result": result,
             }),
         );
     }
@@ -184,18 +327,23 @@ impl AsyncOrderMessageHandler {
         );
     }
 
-    fn apply_async_order_new(
+    fn queue_jsonrpc_invalid_request(&self, peer: PublicKey) {
+        self.queue_jsonrpc_value(
+            peer,
+            json!({
+                "jsonrpc": JSONRPC_VERSION,
+                "id": Value::Null,
+                "error": JsonRpcErrorWire::invalid_request(),
+            }),
+        );
+    }
+
+    fn record_async_order_new(
         &self,
         sender_node_id: PublicKey,
         params: AsyncOrderNewParamsWire,
     ) -> Result<AsyncOrderNewResultWire, JsonRpcErrorWire> {
-        if params.protocol_version != PROTOCOL_VERSION {
-            return Err(JsonRpcErrorWire::unsupported_protocol_version());
-        }
-        if params.hashes.is_empty() {
-            return Err(JsonRpcErrorWire::invalid_hash_batch());
-        }
-
+        Self::validate_async_order_new_params(&params)?;
         let parsed_hashes = parse_hash_batch(params.hashes)?;
 
         let mut state = self.state.lock().unwrap();
@@ -219,11 +367,64 @@ impl AsyncOrderMessageHandler {
 
         Ok(order.snapshot_result())
     }
+
+    fn send_new_async_order_to_lsp(
+        &self,
+        sender_node_id: PublicKey,
+        id: Value,
+        params: AsyncOrderNewParamsWire,
+    ) -> bool {
+        let (Some(lsp_client), Some(runtime_handle)) =
+            (self.lsp_client.clone(), self.runtime_handle.clone())
+        else {
+            return false;
+        };
+
+        let state = Arc::clone(&self.state);
+        runtime_handle.spawn(async move {
+            match lsp_client.async_order_new(sender_node_id, params).await {
+                Ok(result) => {
+                    AsyncOrderMessageHandler::queue_jsonrpc_result_to_state(
+                        &state,
+                        sender_node_id,
+                        id,
+                        result,
+                    );
+                }
+                Err(err) => {
+                    AsyncOrderMessageHandler::queue_jsonrpc_error_to_state(
+                        &state,
+                        sender_node_id,
+                        id,
+                        err.code,
+                        &err.message,
+                    );
+                }
+            }
+        });
+        true
+    }
+
+    fn validate_async_order_new_params(
+        params: &AsyncOrderNewParamsWire,
+    ) -> Result<(), JsonRpcErrorWire> {
+        if params.protocol_version != PROTOCOL_VERSION {
+            return Err(JsonRpcErrorWire::unsupported_protocol_version());
+        }
+        if params.hashes.is_empty() {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+        if params.hashes.len() > ASYNC_ORDER_MAX_HASH_BATCH_SIZE {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+        parse_hash_batch(params.hashes.clone())?;
+        Ok(())
+    }
 }
 
 impl Default for AsyncOrderMessageHandler {
     fn default() -> Self {
-        Self::new()
+        Self::new(Arc::new(AllowFreeAccess))
     }
 }
 
@@ -251,8 +452,17 @@ impl CustomMessageHandler for AsyncOrderMessageHandler {
         msg: Self::CustomMessage,
         sender_node_id: PublicKey,
     ) -> Result<(), LightningError> {
+        if !self.access_control.allows_peer(&sender_node_id) {
+            warn!(peer = %sender_node_id, "rejected async_order peer message from untrusted peer");
+            return Ok(());
+        }
+
         if msg.payload.as_bytes().contains(&0) {
-            warn!(payload = %msg.payload, "async_order peer message contained a NUL byte");
+            warn!(
+                peer = %sender_node_id,
+                payload_len = msg.payload.len(),
+                "async_order peer message contained a NUL byte"
+            );
             self.queue_jsonrpc_parse_error(sender_node_id);
             return Ok(());
         }
@@ -260,29 +470,39 @@ impl CustomMessageHandler for AsyncOrderMessageHandler {
         let envelope: AsyncOrderEnvelope = match serde_json::from_str(&msg.payload) {
             Ok(envelope) => envelope,
             Err(err) => {
-                warn!(error = %err, payload = %msg.payload, "failed to decode async_order peer message");
+                warn!(
+                    error = %err,
+                    peer = %sender_node_id,
+                    payload_len = msg.payload.len(),
+                    "failed to decode async_order peer message"
+                );
                 self.queue_jsonrpc_parse_error(sender_node_id);
                 return Ok(());
             }
         };
 
         if envelope.jsonrpc != JSONRPC_VERSION {
-            self.queue_jsonrpc_parse_error(sender_node_id);
+            self.queue_jsonrpc_invalid_request(sender_node_id);
             return Ok(());
         }
 
         if envelope.result.is_some() || envelope.error.is_some() {
-            self.queue_jsonrpc_parse_error(sender_node_id);
+            if envelope.method.is_some() {
+                warn!(
+                    peer = %sender_node_id,
+                    "ignoring malformed async_order response envelope with method field"
+                );
+            }
             return Ok(());
         }
 
         let Some(method) = envelope.method else {
-            self.queue_jsonrpc_parse_error(sender_node_id);
+            self.queue_jsonrpc_invalid_request(sender_node_id);
             return Ok(());
         };
 
         let Some(id) = envelope.id else {
-            self.queue_jsonrpc_parse_error(sender_node_id);
+            self.queue_jsonrpc_invalid_request(sender_node_id);
             return Ok(());
         };
 
@@ -314,7 +534,26 @@ impl CustomMessageHandler for AsyncOrderMessageHandler {
                 }
             };
 
-            match self.apply_async_order_new(sender_node_id, params) {
+            if self.lsp_client.is_some() {
+                match Self::validate_async_order_new_params(&params) {
+                    Ok(()) => {
+                        if !self.send_new_async_order_to_lsp(sender_node_id, id.clone(), params) {
+                            self.queue_jsonrpc_error(
+                                sender_node_id,
+                                id,
+                                JSONRPC_INTERNAL_ERROR,
+                                "async_order_lsp_client_not_available",
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        self.queue_jsonrpc_error(sender_node_id, id, err.code, &err.message)
+                    }
+                }
+                return Ok(());
+            }
+
+            match self.record_async_order_new(sender_node_id, params) {
                 Ok(result) => self.queue_jsonrpc_result(sender_node_id, id, result),
                 Err(err) => self.queue_jsonrpc_error(sender_node_id, id, err.code, &err.message),
             }
@@ -409,6 +648,14 @@ impl AsyncOrderRecord {
             }
         }
 
+        let missing_count = hashes
+            .iter()
+            .filter(|(index, _)| !self.hashes.contains_key(index))
+            .count();
+        if self.hashes.len().saturating_add(missing_count) > ASYNC_ORDER_MAX_HASH_BATCH_SIZE {
+            return Err(JsonRpcErrorWire::invalid_hash_batch());
+        }
+
         if saw_existing && saw_missing {
             return Err(JsonRpcErrorWire::invalid_hash_batch());
         }
@@ -436,7 +683,7 @@ impl AsyncOrderRecord {
             accepted_through_index: self.highest_hash_index().to_string(),
             next_index_expected: self.next_hash_index().to_string(),
             unused_hashes: self.available_hashes().to_string(),
-            refill_batch_size: DEFAULT_REFILL_BATCH_SIZE.to_owned(),
+            refill_batch_size: ASYNC_ORDER_MAX_HASH_BATCH_SIZE.to_string(),
         }
     }
 }
@@ -463,10 +710,24 @@ impl JsonRpcErrorWire {
         }
     }
 
+    fn internal_error(message: String) -> Self {
+        Self {
+            code: JSONRPC_INTERNAL_ERROR,
+            message,
+        }
+    }
+
     fn invalid_hash_batch() -> Self {
         Self {
             code: ASYNC_ERROR_INVALID_HASH_BATCH,
             message: "invalid_hash_batch".to_owned(),
+        }
+    }
+
+    fn invalid_request() -> Self {
+        Self {
+            code: JSONRPC_INVALID_REQUEST,
+            message: "invalid request".to_owned(),
         }
     }
 
@@ -510,6 +771,15 @@ mod tests {
     use super::*;
     use crate::utils::new_jsonrpc_request_id;
     use bitcoin::secp256k1::{Secp256k1, SecretKey};
+    use std::sync::Arc;
+
+    struct DenyAllAccess;
+
+    impl AsyncOrderAccessControl for DenyAllAccess {
+        fn allows_peer(&self, _peer: &PublicKey) -> bool {
+            false
+        }
+    }
 
     fn test_peer_pubkey(tag: u8) -> PublicKey {
         let secp = Secp256k1::new();
@@ -519,7 +789,7 @@ mod tests {
         PublicKey::from_secret_key(&secp, &secret_key)
     }
 
-    fn new_request_payload(id: &str, hashes: &[(u64, &str)]) -> String {
+    fn new_order_request_payload(id: &str, hashes: &[(u64, &str)]) -> String {
         let hashes = hashes
             .iter()
             .map(|(hash_index, payment_hash)| {
@@ -548,12 +818,16 @@ mod tests {
         serde_json::from_str(&pending[0].1.payload).unwrap()
     }
 
+    fn payment_hash_for_index(index: u64) -> String {
+        format!("{index:064x}")
+    }
+
     #[test]
     fn async_order_new_creates_order_and_returns_state() {
-        let handler = AsyncOrderMessageHandler::new();
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
         let test_peer = test_peer_pubkey(1);
         let request_id = new_jsonrpc_request_id();
-        let request_payload = new_request_payload(
+        let request_payload = new_order_request_payload(
             &request_id,
             &[
                 (
@@ -588,18 +862,20 @@ mod tests {
         assert_eq!(response_value["result"]["accepted_through_index"], "2");
         assert_eq!(response_value["result"]["next_index_expected"], "3");
         assert_eq!(response_value["result"]["unused_hashes"], "2");
-        assert_eq!(
-            response_value["result"]["refill_batch_size"],
-            DEFAULT_REFILL_BATCH_SIZE
-        );
+        let refill_batch_size = response_value["result"]["refill_batch_size"]
+            .as_str()
+            .unwrap()
+            .parse::<usize>()
+            .unwrap();
+        assert_eq!(refill_batch_size, ASYNC_ORDER_MAX_HASH_BATCH_SIZE);
     }
 
     #[test]
     fn async_order_new_is_idempotent_for_identical_batch() {
-        let handler = AsyncOrderMessageHandler::new();
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
         let test_peer = test_peer_pubkey(2);
         let request_id = new_jsonrpc_request_id();
-        let request_payload = new_request_payload(
+        let request_payload = new_order_request_payload(
             &request_id,
             &[
                 (
@@ -639,10 +915,10 @@ mod tests {
 
     #[test]
     fn async_order_new_rejects_conflicting_index() {
-        let handler = AsyncOrderMessageHandler::new();
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
         let test_peer = test_peer_pubkey(3);
         let initial_request_id = new_jsonrpc_request_id();
-        let initial_request_payload = new_request_payload(
+        let initial_request_payload = new_order_request_payload(
             &initial_request_id,
             &[
                 (
@@ -666,7 +942,7 @@ mod tests {
         read_single_response(&handler);
 
         let conflicting_request_id = new_jsonrpc_request_id();
-        let conflicting_request_payload = new_request_payload(
+        let conflicting_request_payload = new_order_request_payload(
             &conflicting_request_id,
             &[(
                 1,
@@ -696,11 +972,11 @@ mod tests {
 
     #[test]
     fn async_order_new_rejects_repeated_payment_hash() {
-        let handler = AsyncOrderMessageHandler::new();
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
         let test_peer = test_peer_pubkey(6);
         let initial_request_id = new_jsonrpc_request_id();
 
-        let initial_request_payload = new_request_payload(
+        let initial_request_payload = new_order_request_payload(
             &initial_request_id,
             &[
                 (
@@ -724,7 +1000,7 @@ mod tests {
         read_single_response(&handler);
 
         let repeated_hash_request_id = new_jsonrpc_request_id();
-        let repeated_hash_payload = new_request_payload(
+        let repeated_hash_payload = new_order_request_payload(
             &repeated_hash_request_id,
             &[
                 (
@@ -760,7 +1036,7 @@ mod tests {
 
     #[test]
     fn async_order_new_rejects_malformed_json_with_parse_error() {
-        let handler = AsyncOrderMessageHandler::new();
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
         let test_peer = test_peer_pubkey(4);
 
         handler
@@ -780,8 +1056,8 @@ mod tests {
     }
 
     #[test]
-    fn async_order_new_rejects_notification_like_payload_with_parse_error() {
-        let handler = AsyncOrderMessageHandler::new();
+    fn async_order_new_rejects_notification_like_payload_with_invalid_request() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
         let test_peer = test_peer_pubkey(5);
 
         handler
@@ -809,7 +1085,87 @@ mod tests {
         let response_value = read_single_response(&handler);
         assert_eq!(response_value["jsonrpc"], JSONRPC_VERSION);
         assert_eq!(response_value["id"], Value::Null);
-        assert_eq!(response_value["error"]["code"], JSONRPC_PARSE_ERROR);
-        assert_eq!(response_value["error"]["message"], "parse error");
+        assert_eq!(response_value["error"]["code"], JSONRPC_INVALID_REQUEST);
+        assert_eq!(response_value["error"]["message"], "invalid request");
+    }
+
+    #[test]
+    fn async_order_ignores_response_payloads() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let test_peer = test_peer_pubkey(7);
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: json!({
+                        "jsonrpc": JSONRPC_VERSION,
+                        "id": new_jsonrpc_request_id(),
+                        "result": {
+                            "status": "active",
+                        },
+                    })
+                    .to_string(),
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        assert!(handler.get_and_clear_pending_msg().is_empty());
+    }
+
+    #[test]
+    fn async_order_new_rejects_hash_batches_over_200() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let test_peer = test_peer_pubkey(8);
+        let request_id = new_jsonrpc_request_id();
+        let hashes = (1..=201)
+            .map(|index| (index, payment_hash_for_index(index)))
+            .collect::<Vec<_>>();
+        let borrowed_hashes = hashes
+            .iter()
+            .map(|(index, hash)| (*index, hash.as_str()))
+            .collect::<Vec<_>>();
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: new_order_request_payload(&request_id, &borrowed_hashes),
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        let response_value = read_single_response(&handler);
+        assert_eq!(response_value["id"], request_id);
+        assert_eq!(
+            response_value["error"]["code"],
+            ASYNC_ERROR_INVALID_HASH_BATCH
+        );
+        assert_eq!(response_value["error"]["message"], "invalid_hash_batch");
+    }
+
+    #[test]
+    fn async_order_rejects_untrusted_peers_without_response() {
+        let handler = AsyncOrderMessageHandler::new(Arc::new(DenyAllAccess));
+        let test_peer = test_peer_pubkey(9);
+        let request_id = new_jsonrpc_request_id();
+        let request_payload = new_order_request_payload(
+            &request_id,
+            &[(
+                1,
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )],
+        );
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_payload,
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        assert!(handler.get_and_clear_pending_msg().is_empty());
     }
 }

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1,5 +1,5 @@
 use crate::kv_store::SeaOrmKvStore;
-use crate::async_order::AsyncOrderMessageHandler;
+use crate::async_order::{AsyncOrderAccessControl, AsyncOrderMessageHandler};
 use amplify::{map, s};
 use bitcoin::blockdata::locktime::absolute::LockTime;
 use bitcoin::hashes::{sha256, Hash as BitcoinHash};
@@ -973,6 +973,40 @@ pub(crate) type OutputSweeper = ldk_sweep::OutputSweeper<
     Arc<FilesystemLogger>,
     Arc<RgbOutputSpender>,
 >;
+
+struct VirtualChannelAccess {
+    trusted_no_broadcast: bool,
+    virtual_peer_pubkeys: Vec<PublicKey>,
+    channel_manager: Arc<ChannelManager>,
+}
+
+impl VirtualChannelAccess {
+    fn new(static_state: &StaticState, channel_manager: Arc<ChannelManager>) -> Self {
+        Self {
+            trusted_no_broadcast: static_state.enable_virtual_channels_v0,
+            virtual_peer_pubkeys: static_state.virtual_peer_pubkeys.clone(),
+            channel_manager,
+        }
+    }
+
+    fn is_virtual_peer(&self, peer: &PublicKey) -> bool {
+        self.virtual_peer_pubkeys.is_empty()
+            || self
+                .virtual_peer_pubkeys
+                .iter()
+                .any(|virtual_peer| virtual_peer == peer)
+    }
+}
+
+impl AsyncOrderAccessControl for VirtualChannelAccess {
+    fn allows_peer(&self, peer: &PublicKey) -> bool {
+        self.trusted_no_broadcast
+            && self.is_virtual_peer(peer)
+            && self.channel_manager.list_channels().iter().any(|channel| {
+                channel.counterparty.node_id == *peer && channel.trusted_no_broadcast
+            })
+    }
+}
 
 fn _safe_update_rgb_channel_amount(
     channel_id: &str,
@@ -3132,11 +3166,26 @@ pub(crate) async fn start_ldk(
         .unwrap()
         .as_secs();
     rand::thread_rng().fill_bytes(&mut ephemeral_bytes);
+
+    let virtual_channel_access = Arc::new(VirtualChannelAccess::new(
+        static_state,
+        channel_manager.clone(),
+    ));
+    let async_order_handler = match static_state.lsp_base_url.as_ref() {
+        Some(lsp_base_url) => Arc::new(AsyncOrderMessageHandler::new_with_lsp_client(
+            virtual_channel_access,
+            lsp_base_url.clone(),
+            static_state.lsp_bearer_token.clone(),
+            Handle::current(),
+        )),
+        None => Arc::new(AsyncOrderMessageHandler::new(virtual_channel_access)),
+    };
+
     let lightning_msg_handler = MessageHandler {
         chan_handler: channel_manager.clone(),
         route_handler: gossip_sync.clone(),
         onion_message_handler: onion_messenger.clone(),
-        custom_message_handler: Arc::new(AsyncOrderMessageHandler::new()),
+        custom_message_handler: async_order_handler,
         send_only_message_handler: Arc::clone(&chain_monitor),
     };
     let peer_manager: Arc<PeerManager> = Arc::new(PeerManager::new(

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1,5 +1,5 @@
-use crate::kv_store::SeaOrmKvStore;
 use crate::async_order::{AsyncOrderAccessControl, AsyncOrderMessageHandler};
+use crate::kv_store::SeaOrmKvStore;
 use amplify::{map, s};
 use bitcoin::blockdata::locktime::absolute::LockTime;
 use bitcoin::hashes::{sha256, Hash as BitcoinHash};

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1,4 +1,6 @@
-use crate::async_order::{AsyncOrderAccessControl, AsyncOrderMessageHandler};
+use crate::async_order::{
+    AsyncOrderAccessControl, AsyncOrderMessageHandler, AsyncPaymentsPreimageRoot,
+};
 use crate::kv_store::SeaOrmKvStore;
 use amplify::{map, s};
 use bitcoin::blockdata::locktime::absolute::LockTime;
@@ -3180,12 +3182,20 @@ pub(crate) async fn start_ldk(
         )),
         None => Arc::new(AsyncOrderMessageHandler::new(virtual_channel_access)),
     };
+    let async_payments_preimage_root = Arc::new(
+        AsyncPaymentsPreimageRoot::build_from_mnemonic(
+            &mnemonic,
+            network,
+            &channel_manager.get_our_node_id(),
+        )
+        .map_err(|err| APIError::Unexpected(err.message))?,
+    );
 
     let lightning_msg_handler = MessageHandler {
         chan_handler: channel_manager.clone(),
         route_handler: gossip_sync.clone(),
         onion_message_handler: onion_messenger.clone(),
-        custom_message_handler: async_order_handler,
+        custom_message_handler: Arc::clone(&async_order_handler),
         send_only_message_handler: Arc::clone(&chain_monitor),
     };
     let peer_manager: Arc<PeerManager> = Arc::new(PeerManager::new(
@@ -3381,6 +3391,8 @@ pub(crate) async fn start_ldk(
         onion_messenger: onion_messenger.clone(),
         outbound_payments,
         peer_manager: Arc::clone(&peer_manager),
+        async_order_handler,
+        async_payments_preimage_root,
         kv_store: Arc::clone(&kv_store),
         bump_tx_event_handler,
         rgb_wallet_wrapper,

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1,4 +1,5 @@
 use crate::kv_store::SeaOrmKvStore;
+use crate::async_order::AsyncOrderMessageHandler;
 use amplify::{map, s};
 use bitcoin::blockdata::locktime::absolute::LockTime;
 use bitcoin::hashes::{sha256, Hash as BitcoinHash};
@@ -912,7 +913,7 @@ pub(crate) type PeerManager = LdkPeerManager<
     Arc<P2PGossipSync<Arc<NetworkGraph>, Arc<GossipVerifier>, Arc<FilesystemLogger>>>,
     Arc<OnionMessenger>,
     Arc<FilesystemLogger>,
-    IgnoringMessageHandler,
+    Arc<AsyncOrderMessageHandler>,
     Arc<KeysManager>,
     Arc<ChainMonitor>,
 >;
@@ -3135,7 +3136,7 @@ pub(crate) async fn start_ldk(
         chan_handler: channel_manager.clone(),
         route_handler: gossip_sync.clone(),
         onion_message_handler: onion_messenger.clone(),
-        custom_message_handler: IgnoringMessageHandler {},
+        custom_message_handler: Arc::new(AsyncOrderMessageHandler::new()),
         send_only_message_handler: Arc::clone(&chain_monitor),
     };
     let peer_manager: Arc<PeerManager> = Arc::new(PeerManager::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(unused_imports)]
 
 mod args;
+mod async_order;
 mod auth;
 mod backup;
 mod bitcoind;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,16 +50,16 @@ use crate::auth::conditional_auth_middleware;
 use crate::error::AppError;
 use crate::ldk::stop_ldk;
 use crate::routes::{
-    address, asset_balance, asset_metadata, backup, btc_balance, cancel_hodl_invoice,
-    change_password, check_indexer_url, check_proxy_endpoint, claim_hodl_invoice, close_channel,
-    connect_peer, create_utxos, decode_ln_invoice, decode_rgb_invoice, disconnect_peer,
-    estimate_fee, fail_transfers, get_asset_media, get_channel_id, get_payment, get_swap, inflate,
-    init, invoice_status, issue_asset_cfa, issue_asset_ifa, issue_asset_nia, issue_asset_uda,
-    keysend, list_assets, list_channels, list_payments, list_peers, list_swaps, list_transactions,
-    list_transfers, list_unspents, ln_invoice, lock, maker_execute, maker_init, network_info,
-    node_info, open_channel, post_asset_media, refresh_transfers, restore, revoke_token,
-    rgb_invoice, send_btc, send_onion_message, send_payment, send_rgb, shutdown, sign_message,
-    sync, taker, unlock,
+    address, asset_balance, asset_metadata, async_order_new, backup, btc_balance,
+    cancel_hodl_invoice, change_password, check_indexer_url, check_proxy_endpoint,
+    claim_hodl_invoice, close_channel, connect_peer, create_utxos, decode_ln_invoice,
+    decode_rgb_invoice, disconnect_peer, estimate_fee, fail_transfers, get_asset_media,
+    get_channel_id, get_payment, get_swap, inflate, init, invoice_status, issue_asset_cfa,
+    issue_asset_ifa, issue_asset_nia, issue_asset_uda, keysend, list_assets, list_channels,
+    list_payments, list_peers, list_swaps, list_transactions, list_transfers, list_unspents,
+    ln_invoice, lock, maker_execute, maker_init, network_info, node_info, open_channel,
+    post_asset_media, refresh_transfers, restore, revoke_token, rgb_invoice, send_btc,
+    send_onion_message, send_payment, send_rgb, shutdown, sign_message, sync, taker, unlock,
 };
 use crate::utils::{start_daemon, AppState, LOGS_DIR};
 
@@ -114,6 +114,7 @@ pub(crate) async fn app(args: UserArgs) -> Result<(Router, Arc<AppState>), AppEr
         // all routes before this will have the default body limit disabled
         .layer(DefaultBodyLimit::disable())
         .route("/address", post(address))
+        .route("/apay/new", post(async_order_new))
         .route("/assetbalance", post(asset_balance))
         .route("/assetmetadata", post(asset_metadata))
         .route("/backup", post(backup))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod args;
+mod async_order;
 mod auth;
 mod backup;
 mod bitcoind;

--- a/src/node.rs
+++ b/src/node.rs
@@ -16,6 +16,8 @@ pub struct NodeConfig {
     pub root_public_key: Option<biscuit_auth::PublicKey>,
     pub enable_virtual_channels_v0: bool,
     pub virtual_peer_pubkeys: Vec<bitcoin::secp256k1::PublicKey>,
+    pub lsp_base_url: Option<String>,
+    pub lsp_bearer_token: Option<String>,
 }
 
 #[derive(Clone)]
@@ -44,6 +46,8 @@ impl NodeHandle {
             root_public_key: config.root_public_key,
             enable_virtual_channels_v0: config.enable_virtual_channels_v0,
             virtual_peer_pubkeys: config.virtual_peer_pubkeys,
+            lsp_base_url: config.lsp_base_url,
+            lsp_bearer_token: config.lsp_bearer_token,
         };
         let state = start_daemon(&args).await?;
         Ok(Self { state })

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -59,6 +59,7 @@ use rgb_lib::{
     BitcoinNetwork as RgbLibNetwork, ContractId, RgbTransport,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::{
     collections::HashMap, net::ToSocketAddrs, path::Path, str::FromStr, sync::Arc, time::Duration,
 };
@@ -66,8 +67,14 @@ use tokio::{
     fs::File,
     io::{AsyncReadExt, AsyncWriteExt, BufReader},
     sync::MutexGuard as TokioMutexGuard,
+    time::timeout,
 };
 
+use crate::async_order::{
+    read_async_payments_next_hash_index, write_async_payments_next_hash_index,
+    AsyncOrderNewHashWire, AsyncOrderNewResultWire, ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
+    ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
+};
 use crate::ldk::{
     clear_rgb_payment_pending, start_ldk, stop_ldk, LdkBackgroundServices,
     VirtualChannelSessionStatus,
@@ -76,9 +83,9 @@ use crate::swap::{SwapData, SwapInfo, SwapString};
 use crate::utils::{
     check_already_initialized, check_channel_id, check_password_strength, check_password_validity,
     encrypt_and_save_mnemonic, get_max_local_rgb_amount, get_route, hex_str,
-    hex_str_to_compressed_pubkey, hex_str_to_vec, validate_and_parse_description_hash,
-    validate_and_parse_payment_hash, validate_and_parse_payment_preimage, UnlockedAppState,
-    UserOnionMessageContents,
+    hex_str_to_compressed_pubkey, hex_str_to_vec, new_jsonrpc_request_id,
+    validate_and_parse_description_hash, validate_and_parse_payment_hash,
+    validate_and_parse_payment_preimage, UnlockedAppState, UserOnionMessageContents,
 };
 use crate::{
     backup::{do_backup, restore_backup},
@@ -342,6 +349,27 @@ impl From<Assignment> for RgbLibAssignment {
             Assignment::Any => Self::Any,
         }
     }
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct AsyncOrderNewRequest {
+    pub(crate) host_node_id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct AsyncOrderNewResponse {
+    pub(crate) request_id: String,
+    pub(crate) host_node_id: String,
+    pub(crate) protocol_version: u64,
+    pub(crate) order_id: String,
+    pub(crate) status: String,
+    pub(crate) accepted_through_index: u64,
+    pub(crate) next_index_expected: u64,
+    pub(crate) unused_hashes: u64,
+    pub(crate) refill_batch_size: u64,
+    pub(crate) first_hash_index: u64,
+    pub(crate) last_hash_index: u64,
+    pub(crate) hashes: Vec<AsyncOrderNewHashWire>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1370,6 +1398,101 @@ pub(crate) async fn address(
     let address = unlocked_state.rgb_get_address()?;
 
     Ok(Json(AddressResponse { address }))
+}
+
+pub(crate) async fn async_order_new(
+    State(state): State<Arc<AppState>>,
+    WithRejection(Json(payload), _): WithRejection<Json<AsyncOrderNewRequest>, APIError>,
+) -> Result<Json<AsyncOrderNewResponse>, APIError> {
+    let guard = state.check_unlocked().await?;
+    let unlocked_state = Arc::clone(guard.as_ref().unwrap());
+    drop(guard);
+
+    let host_node_id =
+        hex_str_to_compressed_pubkey(&payload.host_node_id).ok_or(APIError::InvalidPubkey)?;
+    if unlocked_state
+        .peer_manager
+        .peer_by_node_id(&host_node_id)
+        .is_none()
+    {
+        return Err(APIError::InvalidPeerInfo(s!(
+            "/apay/new requires a connected host peer"
+        )));
+    }
+
+    let params = unlocked_state
+        .async_payments_preimage_root
+        .prepare_async_order_new_params(
+            read_async_payments_next_hash_index(unlocked_state.kv_store.as_ref(), &host_node_id)
+                .map_err(|err| APIError::Unexpected(err.message))?,
+            ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
+        )
+        .map_err(|err| APIError::InvalidRequest(err.message))?;
+    let hashes = params.hashes.clone();
+    let first_hash_index = hashes
+        .first()
+        .map(|entry| entry.hash_index)
+        .expect("validated async_order.new hash batch is non-empty");
+    let last_hash_index = hashes
+        .last()
+        .map(|entry| entry.hash_index)
+        .expect("validated async_order.new hash batch is non-empty");
+    let request_id = new_jsonrpc_request_id();
+
+    let response_rx = unlocked_state
+        .async_order_handler
+        .queue_async_order_new_request(host_node_id, Value::String(request_id.clone()), params)
+        .map_err(|err| APIError::InvalidRequest(err.message))?;
+    unlocked_state.peer_manager.process_events();
+    let order_state: AsyncOrderNewResultWire = match timeout(
+        Duration::from_secs(ASYNC_ORDER_RESPONSE_TIMEOUT_SECS),
+        response_rx,
+    )
+    .await
+    {
+        Ok(Ok(Ok(result))) => result,
+        Ok(Ok(Err(err))) => {
+            return Err(APIError::InvalidRequest(format!(
+                "async_order host error {}: {}",
+                err.code, err.message
+            )));
+        }
+        Ok(Err(_)) => {
+            return Err(APIError::Network(s!(
+                "/apay/new response channel closed before host replied"
+            )))
+        }
+        Err(_) => {
+            unlocked_state
+                .async_order_handler
+                .forget_async_order_response(host_node_id, &request_id);
+            return Err(APIError::Network(s!(
+                "/apay/new timed out waiting for host response"
+            )));
+        }
+    };
+    let next_hash_index = order_state.next_index_expected;
+    write_async_payments_next_hash_index(
+        unlocked_state.kv_store.as_ref(),
+        &host_node_id,
+        next_hash_index,
+    )
+    .map_err(|err| APIError::Unexpected(err.message))?;
+
+    Ok(Json(AsyncOrderNewResponse {
+        request_id,
+        host_node_id: hex_str(&host_node_id.serialize()),
+        protocol_version: order_state.protocol_version,
+        order_id: order_state.order_id,
+        status: order_state.status,
+        accepted_through_index: order_state.accepted_through_index,
+        next_index_expected: order_state.next_index_expected,
+        unused_hashes: order_state.unused_hashes,
+        refill_batch_size: order_state.refill_batch_size,
+        first_hash_index,
+        last_hash_index,
+        hashes,
+    }))
 }
 
 pub(crate) async fn asset_balance(

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1,6 +1,11 @@
 // NOTE: This module mirrors core behavior from `src/routes.rs` for SDK consumers.
 // If route-level business logic changes, keep SDK equivalents in sync.
 
+use crate::async_order::{
+    read_async_payments_next_hash_index, write_async_payments_next_hash_index,
+    AsyncOrderNewHashWire, AsyncOrderNewResultWire, JsonRpcErrorWire,
+    ASYNC_ORDER_MAX_HASH_BATCH_SIZE, ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
+};
 use crate::core_types::{FEE_RATE, MIN_CHANNEL_CONFIRMATIONS};
 use crate::disk;
 use crate::error::APIError;
@@ -10,9 +15,10 @@ use crate::swap::{SwapData, SwapInfo, SwapString};
 use crate::utils::{
     check_already_initialized, check_channel_id, check_password_strength, check_password_validity,
     connect_peer_if_necessary, encrypt_and_save_mnemonic, get_current_timestamp,
-    get_max_local_rgb_amount, get_route, hex_str, hex_str_to_vec, parse_peer_info,
-    validate_and_parse_description_hash, validate_and_parse_payment_hash,
-    validate_and_parse_payment_preimage, AppState, UserOnionMessageContents,
+    get_max_local_rgb_amount, get_route, hex_str, hex_str_to_compressed_pubkey, hex_str_to_vec,
+    new_jsonrpc_request_id, parse_peer_info, validate_and_parse_description_hash,
+    validate_and_parse_payment_hash, validate_and_parse_payment_preimage, AppState,
+    UserOnionMessageContents,
 };
 use amplify::{map, s};
 use bitcoin::hashes::sha256::Hash as Sha256;
@@ -63,6 +69,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::time::timeout;
 
 use rgb_lib::wallet::rust_only::IndexerProtocol as RgbLibIndexerProtocol;
 use rgb_lib::wallet::RecipientType as RgbLibRecipientType;
@@ -73,6 +80,7 @@ use rgb_lib::wallet::{
 };
 use rgb_lib::BitcoinNetwork as RgbBitcoinNetwork;
 use rgb_lib::{AssetSchema as RgbLibAssetSchema, Assignment as RgbLibAssignment};
+use serde_json::Value;
 
 const SDK_HTLC_MIN_MSAT: u64 = 3_000_000;
 const SDK_OPENRGBCHANNEL_MIN_SAT: u64 = SDK_HTLC_MIN_MSAT / 1000 * 10 + 10;
@@ -218,6 +226,25 @@ pub(crate) struct AssetMetadataData {
     pub(crate) ticker: Option<String>,
     pub(crate) details: Option<String>,
     pub(crate) token: Option<Token>,
+}
+
+pub(crate) struct AsyncOrderNewRequestData {
+    pub(crate) host_node_id: String,
+}
+
+pub(crate) struct AsyncOrderNewData {
+    pub(crate) request_id: String,
+    pub(crate) host_node_id: String,
+    pub(crate) protocol_version: u64,
+    pub(crate) order_id: String,
+    pub(crate) status: String,
+    pub(crate) accepted_through_index: u64,
+    pub(crate) next_index_expected: u64,
+    pub(crate) unused_hashes: u64,
+    pub(crate) refill_batch_size: u64,
+    pub(crate) first_hash_index: u64,
+    pub(crate) last_hash_index: u64,
+    pub(crate) hashes: Vec<AsyncOrderNewHashWire>,
 }
 
 pub(crate) struct BtcBalance {
@@ -1096,6 +1123,101 @@ pub(crate) async fn address(state: Arc<AppState>) -> Result<AddressData, APIErro
 
     Ok(AddressData {
         address: unlocked_state.rgb_get_address()?,
+    })
+}
+
+pub(crate) async fn async_order_new(
+    state: Arc<AppState>,
+    request: AsyncOrderNewRequestData,
+) -> Result<AsyncOrderNewData, APIError> {
+    let guard = check_unlocked(&state).await?;
+    let unlocked_state = Arc::clone(guard.as_ref().unwrap());
+    drop(guard);
+
+    let host_node_id =
+        hex_str_to_compressed_pubkey(&request.host_node_id).ok_or(APIError::InvalidPubkey)?;
+    if unlocked_state
+        .peer_manager
+        .peer_by_node_id(&host_node_id)
+        .is_none()
+    {
+        return Err(APIError::InvalidPeerInfo(s!(
+            "/apay/new requires a connected host peer"
+        )));
+    }
+
+    let params = unlocked_state
+        .async_payments_preimage_root
+        .prepare_async_order_new_params(
+            read_async_payments_next_hash_index(unlocked_state.kv_store.as_ref(), &host_node_id)
+                .map_err(|err| APIError::Unexpected(err.message))?,
+            ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
+        )
+        .map_err(|err| APIError::InvalidRequest(err.message))?;
+    let hashes = params.hashes.clone();
+    let first_hash_index = hashes
+        .first()
+        .map(|entry| entry.hash_index)
+        .expect("validated async_order.new hash batch is non-empty");
+    let last_hash_index = hashes
+        .last()
+        .map(|entry| entry.hash_index)
+        .expect("validated async_order.new hash batch is non-empty");
+    let request_id = new_jsonrpc_request_id();
+
+    let response_rx = unlocked_state
+        .async_order_handler
+        .queue_async_order_new_request(host_node_id, Value::String(request_id.clone()), params)
+        .map_err(|err| APIError::InvalidRequest(err.message))?;
+    unlocked_state.peer_manager.process_events();
+    let order_state: AsyncOrderNewResultWire = match timeout(
+        Duration::from_secs(ASYNC_ORDER_RESPONSE_TIMEOUT_SECS),
+        response_rx,
+    )
+    .await
+    {
+        Ok(Ok(Ok(result))) => result,
+        Ok(Ok(Err(err))) => {
+            return Err(APIError::InvalidRequest(format!(
+                "async_order host error {}: {}",
+                err.code, err.message
+            )));
+        }
+        Ok(Err(_)) => {
+            return Err(APIError::Network(s!(
+                "/apay/new response channel closed before host replied"
+            )))
+        }
+        Err(_) => {
+            unlocked_state
+                .async_order_handler
+                .forget_async_order_response(host_node_id, &request_id);
+            return Err(APIError::Network(s!(
+                "/apay/new timed out waiting for host response"
+            )));
+        }
+    };
+    let next_hash_index = order_state.next_index_expected;
+    write_async_payments_next_hash_index(
+        unlocked_state.kv_store.as_ref(),
+        &host_node_id,
+        next_hash_index,
+    )
+    .map_err(|err| APIError::Unexpected(err.message))?;
+
+    Ok(AsyncOrderNewData {
+        request_id,
+        host_node_id: hex_str(&host_node_id.serialize()),
+        protocol_version: order_state.protocol_version,
+        order_id: order_state.order_id,
+        status: order_state.status,
+        accepted_through_index: order_state.accepted_through_index,
+        next_index_expected: order_state.next_index_expected,
+        unused_hashes: order_state.unused_hashes,
+        refill_batch_size: order_state.refill_batch_size,
+        first_hash_index,
+        last_hash_index,
+        hashes,
     })
 }
 

--- a/src/test/auth_db_persistence.rs
+++ b/src/test/auth_db_persistence.rs
@@ -27,6 +27,8 @@ fn build_state(storage_dir_path: PathBuf, database: DatabaseConnection) -> AppSt
             enable_virtual_channels_v0: false,
             virtual_peer_pubkeys: vec![],
             database: Arc::new(database),
+            lsp_base_url: None,
+            lsp_bearer_token: None,
         }),
         cancel_token: CancellationToken::new(),
         unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/test/lib_sdk/helpers.rs
+++ b/src/test/lib_sdk/helpers.rs
@@ -231,6 +231,8 @@ pub(crate) fn make_node(
         max_media_upload_size_mb: 20,
         enable_virtual_channels_v0: Some(false),
         virtual_peer_pubkeys: None,
+        lsp_base_url: None,
+        lsp_bearer_token: None,
     })
     .expect("create SDK node")
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -94,6 +94,8 @@ impl Default for UserArgs {
             root_public_key: None,
             enable_virtual_channels_v0: false,
             virtual_peer_pubkeys: vec![],
+            lsp_base_url: None,
+            lsp_bearer_token: None,
         }
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -33,6 +33,8 @@ pub fn mock_locked_app_state() -> TestAppState {
             enable_virtual_channels_v0: false,
             virtual_peer_pubkeys: vec![],
             database: Arc::new(database),
+            lsp_base_url: None,
+            lsp_bearer_token: None,
         }),
         cancel_token: CancellationToken::new(),
         unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/uniffi_api/examples/python-interop/manual_py_full_n2n.py
+++ b/src/uniffi_api/examples/python-interop/manual_py_full_n2n.py
@@ -68,6 +68,8 @@ def make_node(storage: Path, daemon_port: int, peer_port: int) -> rln.SdkNode:
         max_media_upload_size_mb=20,
         enable_virtual_channels_v0=False,
         virtual_peer_pubkeys=None,
+        lsp_base_url=None,
+        lsp_bearer_token=None,
     )
     return rln.SdkNode.create(req)
 

--- a/src/uniffi_api/examples/python-interop/manual_py_virtual_channels_sdk.py
+++ b/src/uniffi_api/examples/python-interop/manual_py_virtual_channels_sdk.py
@@ -62,6 +62,8 @@ def make_node(storage: Path, daemon_port: int, peer_port: int) -> rln.SdkNode:
         max_media_upload_size_mb=20,
         enable_virtual_channels_v0=True,
         virtual_peer_pubkeys=None,
+        lsp_base_url=None,
+        lsp_bearer_token=None,
     )
     return rln.SdkNode.create(req)
 

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -44,6 +44,8 @@ fn handle_from_request(request: SdkInitRequest) -> Result<NodeHandle, RlnError> 
         root_public_key: None,
         enable_virtual_channels_v0: request.enable_virtual_channels_v0.unwrap_or(false),
         virtual_peer_pubkeys: request.virtual_peer_pubkeys.unwrap_or_default(),
+        lsp_base_url: request.lsp_base_url,
+        lsp_bearer_token: request.lsp_bearer_token,
     };
     block_on_app(NodeHandle::new(config))
 }

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -8,6 +8,7 @@ mod uniffi_smoke_tests {
     use bitcoin::hex::DisplayHex;
     use rgb_lib::BitcoinNetwork;
     use sea_orm::{ConnectOptions, Database};
+    use serial_test::serial;
     use std::collections::HashSet;
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
@@ -15,6 +16,7 @@ mod uniffi_smoke_tests {
     use tokio_util::sync::CancellationToken;
 
     #[test]
+    #[serial(uniffi_state)]
     fn uniffi_entrypoints_require_initialized_state() {
         clear_uniffi_app_state();
         assert!(!uniffi_is_initialized());
@@ -106,6 +108,7 @@ mod uniffi_smoke_tests {
     }
 
     #[test]
+    #[serial(uniffi_state)]
     fn uniffi_entrypoints_use_registered_state() {
         set_uniffi_app_state(mock_locked_state());
         assert!(uniffi_is_initialized());
@@ -137,6 +140,7 @@ mod uniffi_smoke_tests {
     }
 
     #[test]
+    #[serial(uniffi_state)]
     fn uniffi_instance_entrypoints_work_without_global_registration() {
         clear_uniffi_app_state();
         assert!(!uniffi_is_initialized());

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -93,6 +93,8 @@ mod uniffi_smoke_tests {
                 enable_virtual_channels_v0: false,
                 virtual_peer_pubkeys: vec![],
                 database: Arc::new(database),
+                lsp_base_url: None,
+                lsp_bearer_token: None,
             }),
             cancel_token: CancellationToken::new(),
             unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -621,6 +621,8 @@ pub struct SdkInitRequest {
     pub max_media_upload_size_mb: u16,
     pub enable_virtual_channels_v0: Option<bool>,
     pub virtual_peer_pubkeys: Option<Vec<PublicKey>>,
+    pub lsp_base_url: Option<String>,
+    pub lsp_bearer_token: Option<String>,
 }
 
 pub struct SendRgbRequest {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,6 +36,7 @@ use std::{
 use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
 use tokio_util::sync::CancellationToken;
 
+use crate::async_order::{AsyncOrderMessageHandler, AsyncPaymentsPreimageRoot};
 use crate::core_types::{DEFAULT_FINAL_CLTV_EXPIRY_DELTA, HTLC_MIN_MSAT};
 use crate::ldk::{ChannelIdsMap, Router, VirtualChannelDraftStore, VirtualChannelSessionStore};
 use crate::rgb::{get_rgb_channel_info_optional, RgbLibWalletWrapper};
@@ -116,6 +117,8 @@ pub(crate) struct UnlockedAppState {
     pub(crate) onion_messenger: Arc<OnionMessenger>,
     pub(crate) outbound_payments: Arc<Mutex<OutboundPaymentInfoStorage>>,
     pub(crate) peer_manager: Arc<PeerManager>,
+    pub(crate) async_order_handler: Arc<AsyncOrderMessageHandler>,
+    pub(crate) async_payments_preimage_root: Arc<AsyncPaymentsPreimageRoot>,
     pub(crate) kv_store: Arc<SeaOrmKvStore>,
     pub(crate) bump_tx_event_handler: Arc<BumpTxEventHandler>,
     pub(crate) maker_swaps: Arc<Mutex<SwapMap>>,
@@ -299,7 +302,6 @@ pub(crate) fn hex_str(value: &[u8]) -> String {
     res
 }
 
-#[cfg(test)]
 pub(crate) fn new_jsonrpc_request_id() -> String {
     uuid::Uuid::new_v4().to_string()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,8 +102,9 @@ pub(crate) struct StaticState {
     pub(crate) logger: Arc<FilesystemLogger>,
     pub(crate) max_media_upload_size_mb: u16,
     pub(crate) virtual_peer_pubkeys: Vec<PublicKey>,
-    /// Shared database connection for mnemonic storage and LDK KVStore
     pub(crate) database: Arc<DatabaseConnection>,
+    pub(crate) lsp_base_url: Option<String>,
+    pub(crate) lsp_bearer_token: Option<String>,
 }
 
 pub(crate) struct UnlockedAppState {
@@ -412,6 +413,8 @@ pub(crate) async fn start_daemon(args: &UserArgs) -> Result<Arc<AppState>, AppEr
         max_media_upload_size_mb: args.max_media_upload_size_mb,
         virtual_peer_pubkeys: args.virtual_peer_pubkeys.clone(),
         database: Arc::new(database),
+        lsp_base_url: args.lsp_base_url.clone(),
+        lsp_bearer_token: args.lsp_bearer_token.clone(),
     });
 
     let app_state = Arc::new(AppState {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -298,6 +298,11 @@ pub(crate) fn hex_str(value: &[u8]) -> String {
     res
 }
 
+#[cfg(test)]
+pub(crate) fn new_jsonrpc_request_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
 pub(crate) fn hex_str_to_compressed_pubkey(hex: &str) -> Option<PublicKey> {
     if hex.len() != 33 * 2 {
         return None;

--- a/test/kotlin-e2e/KotlinUniffiE2e.kt
+++ b/test/kotlin-e2e/KotlinUniffiE2e.kt
@@ -97,17 +97,19 @@ private fun ensureDir(path: Path) {
 
 private fun makeNode(storageDir: Path, daemonPort: UShort, peerPort: UShort): SdkNode {
     return SdkNode.create(
-        SdkInitRequest(
-            storageDirPath = storageDir.pathString,
-            daemonListeningPort = daemonPort,
-            ldkPeerListeningPort = peerPort,
-            network = "regtest",
-            maxMediaUploadSizeMb = 20u,
-            enableVirtualChannelsV0 = false,
-            virtualPeerPubkeys = null,
+            SdkInitRequest(
+                storageDirPath = storageDir.pathString,
+                daemonListeningPort = daemonPort,
+                ldkPeerListeningPort = peerPort,
+                network = "regtest",
+                maxMediaUploadSizeMb = 20u,
+                enableVirtualChannelsV0 = false,
+                virtualPeerPubkeys = null,
+                lspBaseUrl = null,
+                lspBearerToken = null,
+            )
         )
-    )
-}
+    }
 
 private fun unlockRequest(password: String): SdkUnlockRequest {
     return SdkUnlockRequest(

--- a/test/python-e2e/PythonUniffiE2e.py
+++ b/test/python-e2e/PythonUniffiE2e.py
@@ -86,6 +86,8 @@ def make_node(storage_dir: Path, daemon_port: int, peer_port: int) -> rln.SdkNod
         max_media_upload_size_mb=20,
         enable_virtual_channels_v0=False,
         virtual_peer_pubkeys=None,
+        lsp_base_url=None,
+        lsp_bearer_token=None,
     )
     return rln.SdkNode.create(req)
 

--- a/test/swift-e2e/Package.swift
+++ b/test/swift-e2e/Package.swift
@@ -5,8 +5,13 @@ import PackageDescription
 // Original macOS-only: let libraryPath = "Libraries/macos"
 #if os(macOS)
 let libraryPath = "Libraries/macos"
+let openSslLinkerSettings: [LinkerSetting] = []
 #else
 let libraryPath = "Libraries/linux"
+let openSslLinkerSettings: [LinkerSetting] = [
+    .linkedLibrary("crypto"),
+    .linkedLibrary("ssl"),
+]
 #endif
 
 let package = Package(
@@ -33,7 +38,7 @@ let package = Package(
                     libraryPath,  // [TEST: Linux runner] was: "Libraries/macos"
                 ]),
                 .linkedLibrary("rgb_lightning_node"),
-            ]
+            ] + openSslLinkerSettings
         ),
         .testTarget(
             name: "SwiftUniffiE2ETests",

--- a/test/swift-e2e/Tests/SwiftUniffiE2ETests/SwiftUniffiE2ESmokeTests.swift
+++ b/test/swift-e2e/Tests/SwiftUniffiE2ETests/SwiftUniffiE2ESmokeTests.swift
@@ -25,7 +25,9 @@ final class SwiftUniffiE2ESmokeTests: XCTestCase {
                 network: "regtest",
                 maxMediaUploadSizeMb: 5,
                 enableVirtualChannelsV0: false,
-                virtualPeerPubkeys: nil
+                virtualPeerPubkeys: nil,
+                lspBaseUrl: nil,
+                lspBearerToken: nil
             )
         )
         defer { node.shutdown() }


### PR DESCRIPTION
This is the first phase of the async-payments control plane, which only supports virtual channels.

- adds async-order JSON-RPC handling over the custom peer message path
- gates the control plane to trusted virtual peers with `trusted_no_broadcast`
- forwards async-order requests to `utexo-lsp` when `--lsp-base-url` / `--lsp-bearer-token` are set
- enforces a hard 200-hash batch limit
- ignores JSON-RPC responses instead of re-answering them
- keeps a local fallback path for test/dev mode when no LSP backend is configured

`cargo test async_order`