### PR TITLE
780 Implement async payment outbound invoice lifecycle

### DIFF
--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/ConcurrentBtcPaymentsTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/ConcurrentBtcPaymentsTest.kt
@@ -503,6 +503,7 @@ class ConcurrentBtcPaymentsTest {
                     assetAmount = null,
                     descriptionHash = null,
                     paymentHash = null,
+                    minFinalCltvExpiryDelta = null,
                 )
             ).invoice
 
@@ -514,6 +515,7 @@ class ConcurrentBtcPaymentsTest {
                     assetAmount = null,
                     descriptionHash = null,
                     paymentHash = null,
+                    minFinalCltvExpiryDelta = null,
                 )
             ).invoice
             val decoded1 = nodeA.decodeLnInvoice(invoice1)

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
@@ -546,6 +546,7 @@ class PaymentTest {
                     assetAmount = 100u,
                     descriptionHash = null,
                     paymentHash = null,
+                    minFinalCltvExpiryDelta = null,
                 )
             ).invoice
             sendPaymentWithLnBalance(nodeA, nodeB, invoice1, assetId, 100u, 600u, 0u)
@@ -607,6 +608,7 @@ class PaymentTest {
                     assetAmount = 50u,
                     descriptionHash = null,
                     paymentHash = null,
+                    minFinalCltvExpiryDelta = null,
                 )
             ).invoice
             sendPaymentWithLnBalance(nodeB, nodeA, invoice2, assetId, 50u, 100u, 500u)
@@ -641,6 +643,7 @@ class PaymentTest {
                     assetAmount = 50u,
                     descriptionHash = null,
                     paymentHash = null,
+                    minFinalCltvExpiryDelta = null,
                 )
             ).invoice
             nodeA.sendpayment(
@@ -681,6 +684,7 @@ class PaymentTest {
                     assetAmount = 50u,
                     descriptionHash = null,
                     paymentHash = null,
+                    minFinalCltvExpiryDelta = null,
                 )
             ).invoice
             nodeB.sendpayment(

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
@@ -505,6 +505,7 @@ class RestartTest {
                     assetAmount = 100u,
                     descriptionHash = null,
                     paymentHash = null,
+                    minFinalCltvExpiryDelta = null,
                 )
             ).invoice
             val sendPayment = requireNotNull(nodeA).sendpayment(

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -421,6 +421,7 @@ dictionary DecodeLnInvoiceResponse {
     PaymentHash payment_hash;
     string payment_secret;
     PublicKey? payee_pubkey;
+    u64 min_final_cltv_expiry_delta;
     string network;
 };
 

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -491,6 +491,7 @@ dictionary LnInvoiceRequest {
     u64? asset_amount;
     PaymentHash? payment_hash;
     string? description_hash;
+    u16? min_final_cltv_expiry_delta;
 };
 
 dictionary LnInvoiceResponse {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1265,7 +1265,6 @@ components:
     AsyncOrderRequestInvoiceParams:
       type: object
       required:
-        - claim_session_id
         - hash_index
         - payment_hash
         - amount_msat
@@ -1273,9 +1272,6 @@ components:
         - invoice_expiry_sec
         - min_final_cltv_expiry_delta
       properties:
-        claim_session_id:
-          type: string
-          example: claim-session-1
         hash_index:
           type: string
           example: '42'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19,6 +19,8 @@ tags:
     description: APIs to perform operations related to LN peers
   - name: Payments
     description: APIs to perform operations related to LN payments
+  - name: Async Payments
+    description: APIs to perform async payment lifecycle operations
   - name: Invoices
     description: APIs to perform operations related to LN invoices
   - name: On-chain
@@ -46,7 +48,7 @@ paths:
   /apay/new:
     post:
       tags:
-        - Payments
+        - Async Payments
       summary: Send a new order with async-payment hashes
       description: Derive deterministic payment hashes for async payments from the unlocked wallet. Send an async_order.new JSON-RPC request to the connected invoice-host peer so it can track those hashes and process asynchronous payments.
       requestBody:
@@ -61,6 +63,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AsyncOrderNewResponse'
+  /apay/outboundinvoice:
+    post:
+      tags:
+        - Async Payments
+      summary: Request an outbound LN invoice
+      description: Request an outbound invoice from the connected recipient peer for an async payment claim session.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AsyncOrderOutboundInvoiceRequest'
+      responses:
+        '200':
+          description: Recipient peer returned an outbound invoice
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AsyncOrderOutboundInvoiceResponse'
   /assetbalance:
     post:
       tags:
@@ -1219,6 +1239,71 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AsyncOrderNewHash'
+    AsyncOrderOutboundInvoiceRequest:
+      type: object
+      required:
+        - client_node_id
+        - params
+      properties:
+        client_node_id:
+          type: string
+          example: 02270dadcd6e7ba0ef707dac72acccae1a3607453a8dd2aef36ff3be4e0d31f043
+        params:
+          $ref: '#/components/schemas/AsyncOrderRequestInvoiceParams'
+    AsyncOrderOutboundInvoiceResponse:
+      type: object
+      required:
+        - payment_hash
+        - bolt11
+      properties:
+        payment_hash:
+          type: string
+          example: abababababababababababababababababababababababababababababababab
+        bolt11:
+          type: string
+          example: lnbc1test
+    AsyncOrderRequestInvoiceParams:
+      type: object
+      required:
+        - claim_session_id
+        - hash_index
+        - payment_hash
+        - amount_msat
+        - description_hash
+        - invoice_expiry_sec
+        - min_final_cltv_expiry_delta
+      properties:
+        claim_session_id:
+          type: string
+          example: claim-session-1
+        hash_index:
+          type: string
+          example: '42'
+        payment_hash:
+          type: string
+          example: abababababababababababababababababababababababababababababababab
+        amount_msat:
+          type: integer
+          example: 99000
+        asset_id:
+          type:
+            - string
+            - 'null'
+          example: rgb:EIkAVQvq-WbAb5JG-CYxbUER-oqDNwne-ZNxBDID-p0cpf9U
+        asset_amount:
+          type:
+            - integer
+            - 'null'
+          example: 10
+        description_hash:
+          type: string
+          example: 5ca5d81b482b4015e7b14df7a27fe0a38c226273604ffd3b008b752571811938
+        invoice_expiry_sec:
+          type: integer
+          example: 900
+        min_final_cltv_expiry_delta:
+          type: integer
+          example: 18
     AssetBalanceRequest:
       type: object
       required:
@@ -1831,6 +1916,7 @@ components:
         - timestamp
         - payment_hash
         - payment_secret
+        - min_final_cltv_expiry_delta
         - network
       properties:
         amt_msat:
@@ -1854,6 +1940,11 @@ components:
             - integer
             - 'null'
           example: 42
+        description_hash:
+          type:
+            - string
+            - 'null'
+          example: 5ca5d81b482b4015e7b14df7a27fe0a38c226273604ffd3b008b752571811938
         payment_hash:
           type: string
           example: 5ca5d81b482b4015e7b14df7a27fe0a38c226273604ffd3b008b752571811938
@@ -1865,6 +1956,9 @@ components:
             - string
             - 'null'
           example: 0343851df9e0e8aff0c10b3498ce723ff4c9b4a855e6c8819adcafbbb3e24ea2af
+        min_final_cltv_expiry_delta:
+          type: integer
+          example: 144
         network:
           $ref: '#/components/schemas/BitcoinNetwork'
     DecodeRGBInvoiceRequest:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -731,6 +731,7 @@ paths:
       description: >-
         Get a LN invoice to receive a payment. Provide `payment_hash` to create a HODL invoice.
         Provide `description_hash` to include an out-of-band BOLT11 description hash.
+        Provide `min_final_cltv_expiry_delta` to request an explicit inbound final CLTV policy.
       requestBody:
         content:
           application/json:
@@ -2482,6 +2483,10 @@ components:
           type: string
           description: Optional. When provided, the invoice includes a BOLT11 description hash.
           example: 5ca5d81b482b4015e7b14df7a27fe0a38c226273604ffd3b008b752571811938
+        min_final_cltv_expiry_delta:
+          type: integer
+          description: Optional. Requested inbound final CLTV policy in blocks.
+          example: 144
     LNInvoiceResponse:
       type: object
       required:

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -25,7 +25,7 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tracing::warn;
 
-use crate::utils::{hex_str, validate_and_parse_payment_hash};
+use crate::utils::{hex_str, validate_and_parse_description_hash, validate_and_parse_payment_hash};
 
 pub(crate) const ASYNC_ORDER_MESSAGE_TYPE_ID: u16 = 37915;
 pub(crate) const ASYNC_ORDER_MAX_HASH_BATCH_SIZE: usize = 200;
@@ -278,6 +278,31 @@ struct AsyncOrderRequestInvoiceCacheEntry {
     params: AsyncOrderRequestInvoiceParamsWire,
     result: AsyncOrderOutboundInvoiceResultWire,
     expires_at: Instant,
+}
+
+fn canonicalize_request_invoice_params(
+    params: &AsyncOrderRequestInvoiceParamsWire,
+) -> Result<AsyncOrderRequestInvoiceParamsWire, JsonRpcErrorWire> {
+    let hash_index = params
+        .hash_index
+        .parse::<u64>()
+        .map_err(|_| JsonRpcErrorWire::invalid_params("invalid_hash_index"))?;
+    let payment_hash = validate_and_parse_payment_hash(&params.payment_hash)
+        .map_err(|_| JsonRpcErrorWire::invalid_params("invalid_payment_hash"))?;
+    let description_hash = validate_and_parse_description_hash(params.description_hash.trim())
+        .map_err(|_| JsonRpcErrorWire::invalid_params("invalid_description_hash"))?;
+
+    Ok(AsyncOrderRequestInvoiceParamsWire {
+        claim_session_id: params.claim_session_id.clone(),
+        hash_index: hash_index.to_string(),
+        payment_hash: hex_str(&payment_hash.0),
+        amount_msat: params.amount_msat,
+        asset_id: params.asset_id.clone(),
+        asset_amount: params.asset_amount,
+        description_hash: hex_str(&description_hash.0.to_byte_array()),
+        invoice_expiry_sec: params.invoice_expiry_sec,
+        min_final_cltv_expiry_delta: params.min_final_cltv_expiry_delta,
+    })
 }
 
 #[derive(Clone)]
@@ -863,6 +888,7 @@ impl AsyncOrderMessageHandler {
         sender_node_id: PublicKey,
         params: AsyncOrderRequestInvoiceParamsWire,
     ) -> Result<AsyncOrderOutboundInvoiceResultWire, JsonRpcErrorWire> {
+        let canonical_params = canonicalize_request_invoice_params(&params)?;
         let Some(invoice_provider) = self.invoice_provider.lock().unwrap().clone() else {
             return Err(JsonRpcErrorWire::internal_error(
                 "async_order_invoice_provider_not_available".to_owned(),
@@ -872,7 +898,7 @@ impl AsyncOrderMessageHandler {
         let cache_key = (sender_node_id, params.claim_session_id.clone());
         let mut state = self.state.lock().unwrap();
         if let Some(cached) = state.request_invoice_cache.get(&cache_key) {
-            if cached.params == params {
+            if cached.params == canonical_params {
                 if Instant::now() >= cached.expires_at {
                     return Err(JsonRpcErrorWire::stale_flow());
                 }
@@ -890,7 +916,7 @@ impl AsyncOrderMessageHandler {
         state.request_invoice_cache.insert(
             cache_key,
             AsyncOrderRequestInvoiceCacheEntry {
-                params,
+                params: canonical_params,
                 result: result.clone(),
                 expires_at,
             },
@@ -2017,6 +2043,54 @@ mod tests {
             response_value["error"]["message"],
             "async_order_invoice_provider_not_available"
         );
+    }
+
+    #[test]
+    fn async_order_request_invoice_replays_canonicalized_params() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let provider = Arc::new(TestInvoiceProvider::new(test_request_invoice_result()));
+        handler.set_invoice_provider(provider.clone());
+        let test_peer = test_peer_pubkey(39);
+        let first_request_id = new_jsonrpc_request_id();
+        let second_request_id = new_jsonrpc_request_id();
+        let params = test_request_invoice_params();
+        let mut replay_params = params.clone();
+        replay_params.hash_index = "0042".to_owned();
+        replay_params.payment_hash = replay_params.payment_hash.to_uppercase();
+        replay_params.description_hash = replay_params.description_hash.to_uppercase();
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_invoice_payload(
+                        &first_request_id,
+                        ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                        &params,
+                    ),
+                },
+                test_peer,
+            )
+            .unwrap();
+        let first_response = read_single_response(&handler);
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_invoice_payload(
+                        &second_request_id,
+                        ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                        &replay_params,
+                    ),
+                },
+                test_peer,
+            )
+            .unwrap();
+        let second_response = read_single_response(&handler);
+
+        assert_eq!(first_response["result"], second_response["result"]);
+        assert_eq!(first_response["id"], first_request_id);
+        assert_eq!(second_response["id"], second_request_id);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -123,9 +123,14 @@ pub(crate) struct AsyncOrderNewResultWire {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct AsyncOrderOutboundInvoiceResultWire {
+    pub(crate) payment_hash: String,
+    pub(crate) bolt11: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AsyncOrderRequestInvoiceParamsWire {
-    pub(crate) claim_session_id: String,
     pub(crate) hash_index: String,
     pub(crate) payment_hash: String,
     pub(crate) amount_msat: u64,
@@ -134,12 +139,6 @@ pub(crate) struct AsyncOrderRequestInvoiceParamsWire {
     pub(crate) description_hash: String,
     pub(crate) invoice_expiry_sec: u32,
     pub(crate) min_final_cltv_expiry_delta: u16,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub(crate) struct AsyncOrderOutboundInvoiceResultWire {
-    pub(crate) payment_hash: String,
-    pub(crate) bolt11: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -293,7 +292,6 @@ fn canonicalize_request_invoice_params(
         .map_err(|_| JsonRpcErrorWire::invalid_params("invalid_description_hash"))?;
 
     Ok(AsyncOrderRequestInvoiceParamsWire {
-        claim_session_id: params.claim_session_id.clone(),
         hash_index: hash_index.to_string(),
         payment_hash: hex_str(&payment_hash.0),
         amount_msat: params.amount_msat,
@@ -320,17 +318,17 @@ struct AsyncOrderClaimableRequest {
 }
 
 #[derive(Clone, Debug, Serialize)]
-struct AsyncOrderPaymentSentRequest {
-    payment_hash: String,
-    payment_preimage: String,
-}
-
-#[derive(Clone, Debug, Serialize)]
-struct AsyncOrderNewRequest {
+struct AsyncOrderNewLspRequest {
     id: Value,
     peer_pubkey: String,
     protocol_version: u64,
     hashes: Vec<AsyncOrderNewHashWire>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct AsyncOrderPaymentSentRequest {
+    payment_hash: String,
+    payment_preimage: String,
 }
 
 impl Default for AsyncOrderState {
@@ -454,7 +452,7 @@ impl AsyncOrderLspClient {
         request_id: Value,
         params: AsyncOrderNewParamsWire,
     ) -> Result<AsyncOrderNewResultWire, JsonRpcErrorWire> {
-        let request = AsyncOrderNewRequest {
+        let request = AsyncOrderNewLspRequest {
             id: request_id.clone(),
             peer_pubkey: hex_str(&sender_node_id.serialize()),
             protocol_version: params.protocol_version,
@@ -767,9 +765,6 @@ impl AsyncOrderMessageHandler {
         id: Value,
         params: AsyncOrderRequestInvoiceParamsWire,
     ) -> Result<AsyncOrderResponseReceiver, JsonRpcErrorWire> {
-        if params.claim_session_id.trim().is_empty() || params.claim_session_id.len() > 128 {
-            return Err(JsonRpcErrorWire::invalid_request());
-        }
         self.queue_async_order_request(peer_node_id, id, ASYNC_ORDER_REQUEST_INVOICE_METHOD, params)
     }
 
@@ -895,16 +890,17 @@ impl AsyncOrderMessageHandler {
             ));
         };
 
-        let cache_key = (sender_node_id, params.claim_session_id.clone());
+        let cache_key = (sender_node_id, canonical_params.payment_hash.clone());
+        let now = Instant::now();
         let mut state = self.state.lock().unwrap();
-        if let Some(cached) = state.request_invoice_cache.get(&cache_key) {
-            if cached.params == canonical_params {
-                if Instant::now() >= cached.expires_at {
-                    return Err(JsonRpcErrorWire::stale_flow());
+        if let Some(cached) = state.request_invoice_cache.get(&cache_key).cloned() {
+            if now < cached.expires_at {
+                if cached.params == canonical_params {
+                    return Ok(cached.result);
                 }
-                return Ok(cached.result.clone());
+                return Err(JsonRpcErrorWire::stale_flow());
             }
-            return Err(JsonRpcErrorWire::stale_flow());
+            state.request_invoice_cache.remove(&cache_key);
         }
 
         let result = invoice_provider.request_outbound_invoice(sender_node_id, params.clone())?;
@@ -1712,7 +1708,6 @@ mod tests {
 
     fn test_request_invoice_params() -> AsyncOrderRequestInvoiceParamsWire {
         AsyncOrderRequestInvoiceParamsWire {
-            claim_session_id: "claim-session-1".to_owned(),
             hash_index: "42".to_owned(),
             payment_hash: "abababababababababababababababababababababababababababababababab"
                 .to_owned(),
@@ -1927,7 +1922,7 @@ mod tests {
     }
 
     #[test]
-    fn async_order_request_invoice_is_idempotent_by_claim_session_id() {
+    fn async_order_request_invoice_is_idempotent_by_payment_hash() {
         let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
         let provider = Arc::new(TestInvoiceProvider::new(test_request_invoice_result()));
         handler.set_invoice_provider(provider.clone());
@@ -1971,7 +1966,7 @@ mod tests {
     }
 
     #[test]
-    fn async_order_request_invoice_rejects_conflicting_claim_session_replay() {
+    fn async_order_request_invoice_rejects_conflicting_payment_hash_replay() {
         let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
         let provider = Arc::new(TestInvoiceProvider::new(test_request_invoice_result()));
         handler.set_invoice_provider(provider.clone());
@@ -2017,9 +2012,54 @@ mod tests {
     }
 
     #[test]
+    fn async_order_request_invoice_allows_reissue_after_expiry() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let provider = Arc::new(TestInvoiceProvider::new(test_request_invoice_result()));
+        handler.set_invoice_provider(provider.clone());
+        let test_peer = test_peer_pubkey(38);
+        let first_request_id = new_jsonrpc_request_id();
+        let second_request_id = new_jsonrpc_request_id();
+        let mut params = test_request_invoice_params();
+        params.invoice_expiry_sec = 0;
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_invoice_payload(
+                        &first_request_id,
+                        ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                        &params,
+                    ),
+                },
+                test_peer,
+            )
+            .unwrap();
+        let first_response = read_single_response(&handler);
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_invoice_payload(
+                        &second_request_id,
+                        ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                        &params,
+                    ),
+                },
+                test_peer,
+            )
+            .unwrap();
+        let second_response = read_single_response(&handler);
+
+        assert_eq!(first_response["result"], second_response["result"]);
+        assert_eq!(first_response["id"], first_request_id);
+        assert_eq!(second_response["id"], second_request_id);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
     fn async_order_request_invoice_requires_provider() {
         let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
-        let test_peer = test_peer_pubkey(38);
+        let test_peer = test_peer_pubkey(39);
         let request_id = new_jsonrpc_request_id();
         let params = test_request_invoice_params();
 
@@ -2050,7 +2090,7 @@ mod tests {
         let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
         let provider = Arc::new(TestInvoiceProvider::new(test_request_invoice_result()));
         handler.set_invoice_provider(provider.clone());
-        let test_peer = test_peer_pubkey(39);
+        let test_peer = test_peer_pubkey(40);
         let first_request_id = new_jsonrpc_request_id();
         let second_request_id = new_jsonrpc_request_id();
         let params = test_request_invoice_params();

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tracing::warn;
@@ -33,6 +33,11 @@ pub(crate) const ASYNC_ORDER_RESPONSE_TIMEOUT_SECS: u64 = 30;
 const ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT: i64 = 1004;
 const ASYNC_ERROR_DUPLICATE_HASH_CONFLICT: i64 = 1005;
 const ASYNC_ERROR_INVALID_HASH_BATCH: i64 = 1003;
+pub(crate) const ASYNC_ERROR_INVOICE_HASH_MISMATCH: i64 = 1104;
+pub(crate) const ASYNC_ERROR_STALE_FLOW: i64 = 1105;
+const ASYNC_ORDER_NEW_METHOD: &str = "async_order.new";
+const ASYNC_ORDER_REQUEST_INVOICE_METHOD: &str = "async_order.request_invoice";
+const ASYNC_ORDER_PAYMENT_SENT_PATH: &str = "/internal/async_order/payment_sent";
 const ASYNC_ERROR_UNSUPPORTED_PROTOCOL_VERSION: i64 = 1000;
 const JSONRPC_INVALID_REQUEST: i64 = -32600;
 const JSONRPC_INVALID_PARAMS: i64 = -32602;
@@ -115,6 +120,26 @@ pub(crate) struct AsyncOrderNewResultWire {
     pub(crate) next_index_expected: u64,
     pub(crate) unused_hashes: u64,
     pub(crate) refill_batch_size: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AsyncOrderRequestInvoiceParamsWire {
+    pub(crate) claim_session_id: String,
+    pub(crate) hash_index: String,
+    pub(crate) payment_hash: String,
+    pub(crate) amount_msat: u64,
+    pub(crate) asset_id: Option<String>,
+    pub(crate) asset_amount: Option<u64>,
+    pub(crate) description_hash: String,
+    pub(crate) invoice_expiry_sec: u32,
+    pub(crate) min_final_cltv_expiry_delta: u16,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct AsyncOrderOutboundInvoiceResultWire {
+    pub(crate) payment_hash: String,
+    pub(crate) bolt11: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -200,6 +225,14 @@ pub(crate) trait AsyncOrderAccessControl: Send + Sync {
     fn allows_peer(&self, peer: &PublicKey) -> bool;
 }
 
+pub(crate) trait AsyncOrderInvoiceProvider: Send + Sync {
+    fn request_outbound_invoice(
+        &self,
+        sender_node_id: PublicKey,
+        params: AsyncOrderRequestInvoiceParamsWire,
+    ) -> Result<AsyncOrderOutboundInvoiceResultWire, JsonRpcErrorWire>;
+}
+
 #[derive(Debug)]
 struct AllowFreeAccess;
 
@@ -211,6 +244,7 @@ impl AsyncOrderAccessControl for AllowFreeAccess {
 
 pub(crate) struct AsyncOrderMessageHandler {
     access_control: Arc<dyn AsyncOrderAccessControl>,
+    invoice_provider: Arc<Mutex<Option<Arc<dyn AsyncOrderInvoiceProvider>>>>,
     lsp_client: Option<AsyncOrderLspClient>,
     runtime_handle: Option<Handle>,
     state: Arc<Mutex<AsyncOrderState>>,
@@ -221,9 +255,10 @@ struct AsyncOrderState {
     peers: HashMap<PublicKey, PeerOrderState>,
     pending: Vec<(PublicKey, AsyncOrderMessage)>,
     pending_responses: HashMap<(PublicKey, String), AsyncOrderResponseSender>,
+    request_invoice_cache: HashMap<(PublicKey, String), AsyncOrderRequestInvoiceCacheEntry>,
 }
 
-type AsyncOrderResponse = Result<AsyncOrderNewResultWire, JsonRpcErrorWire>;
+type AsyncOrderResponse = Result<Value, JsonRpcErrorWire>;
 type AsyncOrderResponseSender = oneshot::Sender<AsyncOrderResponse>;
 pub(crate) type AsyncOrderResponseReceiver = oneshot::Receiver<AsyncOrderResponse>;
 
@@ -238,6 +273,13 @@ struct AsyncOrderRecord {
     hashes: BTreeMap<u64, String>,
 }
 
+#[derive(Clone, Debug)]
+struct AsyncOrderRequestInvoiceCacheEntry {
+    params: AsyncOrderRequestInvoiceParamsWire,
+    result: AsyncOrderOutboundInvoiceResultWire,
+    expires_at: Instant,
+}
+
 #[derive(Clone)]
 struct AsyncOrderLspClient {
     base_url: String,
@@ -246,7 +288,20 @@ struct AsyncOrderLspClient {
 }
 
 #[derive(Clone, Debug, Serialize)]
-struct AsyncOrderNewStoreRequest {
+struct AsyncOrderClaimableRequest {
+    amount_msat: u64,
+    claim_deadline_height: Option<u32>,
+    payment_hash: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct AsyncOrderPaymentSentRequest {
+    payment_hash: String,
+    payment_preimage: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct AsyncOrderNewRequest {
     id: Value,
     peer_pubkey: String,
     protocol_version: u64,
@@ -260,6 +315,7 @@ impl Default for AsyncOrderState {
             peers: HashMap::new(),
             pending: Vec::new(),
             pending_responses: HashMap::new(),
+            request_invoice_cache: HashMap::new(),
         }
     }
 }
@@ -277,13 +333,103 @@ impl AsyncOrderLspClient {
         }
     }
 
+    async fn async_order_claimable(
+        &self,
+        payment_hash: PaymentHash,
+        amount_msat: u64,
+        claim_deadline_height: Option<u32>,
+    ) -> Result<(), JsonRpcErrorWire> {
+        let request = AsyncOrderClaimableRequest {
+            amount_msat,
+            claim_deadline_height,
+            payment_hash: hex_str(&payment_hash.0),
+        };
+        let mut builder = self
+            .client
+            .post(format!("{}/internal/async_order/claimable", self.base_url))
+            .json(&request);
+        if let Some(token) = self
+            .lsp_bearer_token
+            .as_deref()
+            .filter(|token| !token.is_empty())
+        {
+            builder = builder.bearer_auth(token);
+        }
+
+        let response = builder.send().await.map_err(|err| {
+            if err.is_timeout() {
+                JsonRpcErrorWire::internal_error(
+                    "async_order_lsp_request_failed: POST /internal/async_order/claimable timed out"
+                        .to_owned(),
+                )
+            } else {
+                JsonRpcErrorWire::internal_error(format!(
+                    "async_order_lsp_request_failed: POST /internal/async_order/claimable failed: {err}"
+                ))
+            }
+        })?;
+        if !response.status().is_success() {
+            return Err(JsonRpcErrorWire::internal_error(format!(
+                "async_order_lsp_request_failed: POST /internal/async_order/claimable returned {}",
+                response.status()
+            )));
+        }
+        Ok(())
+    }
+
+    async fn async_order_payment_sent(
+        &self,
+        payment_hash: String,
+        payment_preimage: String,
+    ) -> Result<(), JsonRpcErrorWire> {
+        let request = AsyncOrderPaymentSentRequest {
+            payment_hash,
+            payment_preimage,
+        };
+        let mut builder = self
+            .client
+            .post(format!(
+                "{}/{}",
+                self.base_url,
+                ASYNC_ORDER_PAYMENT_SENT_PATH.trim_start_matches('/')
+            ))
+            .json(&request);
+        if let Some(token) = self
+            .lsp_bearer_token
+            .as_deref()
+            .filter(|token| !token.is_empty())
+        {
+            builder = builder.bearer_auth(token);
+        }
+
+        let response = builder.send().await.map_err(|err| {
+            if err.is_timeout() {
+                JsonRpcErrorWire::internal_error(
+                    "async_order_lsp_request_failed: POST /internal/async_order/payment_sent timed out"
+                        .to_owned(),
+                )
+            } else {
+                JsonRpcErrorWire::internal_error(format!(
+                    "async_order_lsp_request_failed: POST /internal/async_order/payment_sent failed: {err}"
+                ))
+            }
+        })?;
+        if !response.status().is_success() {
+            return Err(JsonRpcErrorWire::internal_error(format!(
+                "async_order_lsp_request_failed: POST /internal/async_order/payment_sent returned {}",
+                response.status()
+            )));
+        }
+        Ok(())
+    }
+
     async fn async_order_new(
         &self,
         sender_node_id: PublicKey,
         request_id: Value,
         params: AsyncOrderNewParamsWire,
     ) -> Result<AsyncOrderNewResultWire, JsonRpcErrorWire> {
-        let request = AsyncOrderNewStoreRequest {
+        let request = AsyncOrderNewRequest {
             id: request_id.clone(),
             peer_pubkey: hex_str(&sender_node_id.serialize()),
             protocol_version: params.protocol_version,
@@ -478,6 +624,7 @@ impl AsyncOrderMessageHandler {
     pub(crate) fn new(access_control: Arc<dyn AsyncOrderAccessControl>) -> Self {
         Self {
             access_control,
+            invoice_provider: Arc::new(Mutex::new(None)),
             lsp_client: None,
             runtime_handle: None,
             state: Arc::new(Mutex::new(AsyncOrderState::default())),
@@ -492,6 +639,7 @@ impl AsyncOrderMessageHandler {
     ) -> Self {
         Self {
             access_control,
+            invoice_provider: Arc::new(Mutex::new(None)),
             lsp_client: Some(AsyncOrderLspClient::new(
                 lsp_base_url,
                 lsp_bearer_token,
@@ -505,6 +653,48 @@ impl AsyncOrderMessageHandler {
     #[cfg(test)]
     fn new_allowing_all_peers() -> Self {
         Self::new(Arc::new(AllowFreeAccess))
+    }
+
+    pub(crate) fn set_invoice_provider(&self, provider: Arc<dyn AsyncOrderInvoiceProvider>) {
+        *self.invoice_provider.lock().unwrap() = Some(provider);
+    }
+
+    fn queue_async_order_request(
+        &self,
+        sender_node_id: PublicKey,
+        id: Value,
+        method: &'static str,
+        params: impl Serialize,
+    ) -> Result<AsyncOrderResponseReceiver, JsonRpcErrorWire> {
+        let Some(request_id) = id.as_str().map(str::to_owned) else {
+            return Err(JsonRpcErrorWire::invalid_request());
+        };
+
+        let (response_sender, response_receiver) = oneshot::channel();
+        let mut state = self.state.lock().unwrap();
+        let response_key = (sender_node_id, request_id);
+        if state.pending_responses.contains_key(&response_key) {
+            return Err(JsonRpcErrorWire::internal_error(
+                "async_order_request_id_already_pending".to_owned(),
+            ));
+        }
+        state
+            .pending_responses
+            .insert(response_key, response_sender);
+        state.pending.push((
+            sender_node_id,
+            AsyncOrderMessage {
+                payload: json!({
+                    "jsonrpc": JSONRPC_VERSION,
+                    "id": id,
+                    "method": method,
+                    "params": params,
+                })
+                .to_string(),
+            },
+        ));
+
+        Ok(response_receiver)
     }
 
     fn queue_jsonrpc_value_to_state(
@@ -525,7 +715,7 @@ impl AsyncOrderMessageHandler {
         Self::queue_jsonrpc_value_to_state(&self.state, peer, value);
     }
 
-    fn queue_jsonrpc_result(&self, peer: PublicKey, id: Value, result: AsyncOrderNewResultWire) {
+    fn queue_jsonrpc_result<T: Serialize>(&self, peer: PublicKey, id: Value, result: T) {
         self.queue_jsonrpc_value(
             peer,
             json!({
@@ -536,42 +726,26 @@ impl AsyncOrderMessageHandler {
         );
     }
 
-    pub(crate) fn queue_async_order_new_request(
+    pub(crate) fn queue_async_order_new(
         &self,
         host_node_id: PublicKey,
         id: Value,
         params: AsyncOrderNewParamsWire,
     ) -> Result<AsyncOrderResponseReceiver, JsonRpcErrorWire> {
         Self::validate_async_order_new_params(&params)?;
-        let Some(request_id) = id.as_str().map(str::to_owned) else {
+        self.queue_async_order_request(host_node_id, id, ASYNC_ORDER_NEW_METHOD, params)
+    }
+
+    pub(crate) fn queue_async_order_request_invoice(
+        &self,
+        peer_node_id: PublicKey,
+        id: Value,
+        params: AsyncOrderRequestInvoiceParamsWire,
+    ) -> Result<AsyncOrderResponseReceiver, JsonRpcErrorWire> {
+        if params.claim_session_id.trim().is_empty() || params.claim_session_id.len() > 128 {
             return Err(JsonRpcErrorWire::invalid_request());
-        };
-
-        let (response_sender, response_receiver) = oneshot::channel();
-        let mut state = self.state.lock().unwrap();
-        let response_key = (host_node_id, request_id);
-        if state.pending_responses.contains_key(&response_key) {
-            return Err(JsonRpcErrorWire::internal_error(
-                "async_order_request_id_already_pending".to_owned(),
-            ));
         }
-        state
-            .pending_responses
-            .insert(response_key, response_sender);
-        state.pending.push((
-            host_node_id,
-            AsyncOrderMessage {
-                payload: json!({
-                    "jsonrpc": JSONRPC_VERSION,
-                    "id": id,
-                    "method": "async_order.new",
-                    "params": params,
-                })
-                .to_string(),
-            },
-        ));
-
-        Ok(response_receiver)
+        self.queue_async_order_request(peer_node_id, id, ASYNC_ORDER_REQUEST_INVOICE_METHOD, params)
     }
 
     pub(crate) fn forget_async_order_response(&self, host_node_id: PublicKey, request_id: &str) {
@@ -610,7 +784,7 @@ impl AsyncOrderMessageHandler {
         state: &Arc<Mutex<AsyncOrderState>>,
         peer: PublicKey,
         id: Value,
-        result: AsyncOrderNewResultWire,
+        result: impl Serialize,
     ) {
         Self::queue_jsonrpc_value_to_state(
             state,
@@ -658,12 +832,7 @@ impl AsyncOrderMessageHandler {
         };
 
         let response = match (result, error) {
-            (Some(result), None) => serde_json::from_value::<AsyncOrderNewResultWire>(result)
-                .map_err(|err| {
-                    JsonRpcErrorWire::internal_error(format!(
-                        "invalid_async_order_response_result: {err}"
-                    ))
-                }),
+            (Some(result), None) => Ok(result),
             (None, Some(error)) => match serde_json::from_value::<JsonRpcErrorWire>(error) {
                 Ok(err) => Err(err),
                 Err(err) => Err(JsonRpcErrorWire::internal_error(format!(
@@ -687,6 +856,46 @@ impl AsyncOrderMessageHandler {
         if let Some(response_sender) = response_sender {
             let _ = response_sender.send(response);
         }
+    }
+
+    fn receive_async_order_request_invoice(
+        &self,
+        sender_node_id: PublicKey,
+        params: AsyncOrderRequestInvoiceParamsWire,
+    ) -> Result<AsyncOrderOutboundInvoiceResultWire, JsonRpcErrorWire> {
+        let Some(invoice_provider) = self.invoice_provider.lock().unwrap().clone() else {
+            return Err(JsonRpcErrorWire::internal_error(
+                "async_order_invoice_provider_not_available".to_owned(),
+            ));
+        };
+
+        let cache_key = (sender_node_id, params.claim_session_id.clone());
+        let mut state = self.state.lock().unwrap();
+        if let Some(cached) = state.request_invoice_cache.get(&cache_key) {
+            if cached.params == params {
+                if Instant::now() >= cached.expires_at {
+                    return Err(JsonRpcErrorWire::stale_flow());
+                }
+                return Ok(cached.result.clone());
+            }
+            return Err(JsonRpcErrorWire::stale_flow());
+        }
+
+        let result = invoice_provider.request_outbound_invoice(sender_node_id, params.clone())?;
+        let expires_at = Instant::now()
+            .checked_add(Duration::from_secs(params.invoice_expiry_sec as u64))
+            .ok_or_else(|| {
+                JsonRpcErrorWire::internal_error("async_order_invoice_expiry_overflow".to_owned())
+            })?;
+        state.request_invoice_cache.insert(
+            cache_key,
+            AsyncOrderRequestInvoiceCacheEntry {
+                params,
+                result: result.clone(),
+                expires_at,
+            },
+        );
+        Ok(result)
     }
 
     fn record_async_order_new(
@@ -759,6 +968,53 @@ impl AsyncOrderMessageHandler {
             }
         });
         Ok(())
+    }
+
+    pub(crate) fn notify_claimable_hodl_invoice(
+        &self,
+        payment_hash: PaymentHash,
+        amount_msat: u64,
+        claim_deadline_height: Option<u32>,
+    ) {
+        let (Some(lsp_client), Some(runtime_handle)) =
+            (self.lsp_client.clone(), self.runtime_handle.clone())
+        else {
+            return;
+        };
+
+        runtime_handle.spawn(async move {
+            if let Err(err) = lsp_client
+                .async_order_claimable(
+                    payment_hash,
+                    amount_msat,
+                    claim_deadline_height,
+                )
+                .await
+            {
+                warn!(code = err.code, message = %err.message, "async_order claimable notification failed");
+            }
+        });
+    }
+
+    pub(crate) fn notify_payment_sent(
+        &self,
+        payment_hash: PaymentHash,
+        payment_preimage: PaymentPreimage,
+    ) {
+        let (Some(lsp_client), Some(runtime_handle)) =
+            (self.lsp_client.clone(), self.runtime_handle.clone())
+        else {
+            return;
+        };
+
+        runtime_handle.spawn(async move {
+            if let Err(err) = lsp_client
+                .async_order_payment_sent(hex_str(&payment_hash.0), hex_str(&payment_preimage.0))
+                .await
+            {
+                warn!(code = err.code, message = %err.message, "async_order payment_sent notification failed");
+            }
+        });
     }
 
     fn validate_async_order_new_params(
@@ -872,7 +1128,7 @@ impl CustomMessageHandler for AsyncOrderMessageHandler {
             return Ok(());
         };
 
-        if method == "async_order.new" {
+        if method == ASYNC_ORDER_NEW_METHOD {
             let params_value = match envelope.params {
                 Some(params) => params,
                 None => {
@@ -917,6 +1173,45 @@ impl CustomMessageHandler for AsyncOrderMessageHandler {
             }
 
             match self.record_async_order_new(sender_node_id, params) {
+                Ok(result) => self.queue_jsonrpc_result(sender_node_id, id, result),
+                Err(err) => self.queue_jsonrpc_error(sender_node_id, id, err.code, &err.message),
+            }
+            return Ok(());
+        }
+
+        if method == ASYNC_ORDER_REQUEST_INVOICE_METHOD {
+            let params_value = match envelope.params {
+                Some(params) => params,
+                None => {
+                    self.queue_jsonrpc_error(
+                        sender_node_id,
+                        id,
+                        JSONRPC_INVALID_PARAMS,
+                        "missing params",
+                    );
+                    return Ok(());
+                }
+            };
+
+            let params: AsyncOrderRequestInvoiceParamsWire =
+                match serde_json::from_value(params_value) {
+                    Ok(params) => params,
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            "invalid async_order.request_invoice params from {sender_node_id}"
+                        );
+                        self.queue_jsonrpc_error(
+                            sender_node_id,
+                            id,
+                            JSONRPC_INVALID_PARAMS,
+                            "invalid_request_invoice_params",
+                        );
+                        return Ok(());
+                    }
+                };
+
+            match self.receive_async_order_request_invoice(sender_node_id, params) {
                 Ok(result) => self.queue_jsonrpc_result(sender_node_id, id, result),
                 Err(err) => self.queue_jsonrpc_error(sender_node_id, id, err.code, &err.message),
             }
@@ -1073,7 +1368,14 @@ impl JsonRpcErrorWire {
         }
     }
 
-    fn internal_error(message: String) -> Self {
+    pub(crate) fn application_error(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn internal_error(message: String) -> Self {
         Self {
             code: JSONRPC_INTERNAL_ERROR,
             message,
@@ -1087,10 +1389,24 @@ impl JsonRpcErrorWire {
         }
     }
 
+    pub(crate) fn invalid_params(message: impl Into<String>) -> Self {
+        Self {
+            code: JSONRPC_INVALID_PARAMS,
+            message: message.into(),
+        }
+    }
+
     fn invalid_request() -> Self {
         Self {
             code: JSONRPC_INVALID_REQUEST,
             message: "invalid request".to_owned(),
+        }
+    }
+
+    fn stale_flow() -> Self {
+        Self {
+            code: ASYNC_ERROR_STALE_FLOW,
+            message: "stale_flow".to_owned(),
         }
     }
 
@@ -1158,12 +1474,38 @@ mod tests {
     use bitcoin::secp256k1::{Secp256k1, SecretKey};
     use std::collections::HashMap as StdHashMap;
     use std::str::FromStr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex as StdMutex};
     use std::time::Duration;
     use tokio::net::TcpListener;
     use tokio::time::sleep;
 
     struct DenyAllAccess;
+
+    struct TestInvoiceProvider {
+        calls: AtomicUsize,
+        result: AsyncOrderOutboundInvoiceResultWire,
+    }
+
+    impl TestInvoiceProvider {
+        fn new(result: AsyncOrderOutboundInvoiceResultWire) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                result,
+            }
+        }
+    }
+
+    impl AsyncOrderInvoiceProvider for TestInvoiceProvider {
+        fn request_outbound_invoice(
+            &self,
+            _sender_node_id: PublicKey,
+            _params: AsyncOrderRequestInvoiceParamsWire,
+        ) -> Result<AsyncOrderOutboundInvoiceResultWire, JsonRpcErrorWire> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.result.clone())
+        }
+    }
 
     #[derive(Default)]
     struct MemoryKvStore {
@@ -1342,6 +1684,45 @@ mod tests {
         }
     }
 
+    fn test_request_invoice_params() -> AsyncOrderRequestInvoiceParamsWire {
+        AsyncOrderRequestInvoiceParamsWire {
+            claim_session_id: "claim-session-1".to_owned(),
+            hash_index: "42".to_owned(),
+            payment_hash: "abababababababababababababababababababababababababababababababab"
+                .to_owned(),
+            amount_msat: 99000,
+            asset_id: Some("rgb:EIkAVQvq-WbAb5JG-CYxbUER-oqDNwne-ZNxBDID-p0cpf9U".to_owned()),
+            asset_amount: Some(10),
+            description_hash: hex_str(
+                &sha256::Hash::hash(b"test request invoice description").to_byte_array(),
+            ),
+            invoice_expiry_sec: 900,
+            min_final_cltv_expiry_delta: 18,
+        }
+    }
+
+    fn test_request_invoice_result() -> AsyncOrderOutboundInvoiceResultWire {
+        AsyncOrderOutboundInvoiceResultWire {
+            payment_hash: "abababababababababababababababababababababababababababababababab"
+                .to_owned(),
+            bolt11: "lnbc1test".to_owned(),
+        }
+    }
+
+    fn request_invoice_payload(
+        id: &str,
+        method: &str,
+        params: &AsyncOrderRequestInvoiceParamsWire,
+    ) -> String {
+        json!({
+            "jsonrpc": JSONRPC_VERSION,
+            "id": id,
+            "method": method,
+            "params": params,
+        })
+        .to_string()
+    }
+
     fn test_mnemonic() -> Mnemonic {
         Mnemonic::from_str(
             "legal winner thank year wave sausage worth useful legal winner thank yellow",
@@ -1430,7 +1811,7 @@ mod tests {
         let request_id = Value::String(new_jsonrpc_request_id());
 
         let _response_rx = handler
-            .queue_async_order_new_request(
+            .queue_async_order_new(
                 host_node_id,
                 request_id.clone(),
                 test_async_order_new_params(),
@@ -1459,7 +1840,7 @@ mod tests {
         let host_node_id = test_peer_pubkey(26);
         let request_id = Value::String(new_jsonrpc_request_id());
         let response_rx = handler
-            .queue_async_order_new_request(
+            .queue_async_order_new(
                 host_node_id,
                 request_id.clone(),
                 test_async_order_new_params(),
@@ -1482,7 +1863,160 @@ mod tests {
             .unwrap();
 
         let response = response_rx.await.unwrap().unwrap();
+        let response: AsyncOrderNewResultWire = serde_json::from_value(response).unwrap();
         assert_eq!(response, test_async_order_new_result());
+    }
+
+    #[test]
+    fn async_order_request_invoice_returns_provider_invoice() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let provider = Arc::new(TestInvoiceProvider::new(test_request_invoice_result()));
+        handler.set_invoice_provider(provider.clone());
+        let test_peer = test_peer_pubkey(34);
+        let request_id = new_jsonrpc_request_id();
+        let params = test_request_invoice_params();
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_invoice_payload(
+                        &request_id,
+                        ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                        &params,
+                    ),
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        let response_value = read_single_response(&handler);
+        assert_eq!(response_value["jsonrpc"], JSONRPC_VERSION);
+        assert_eq!(response_value["id"], request_id);
+        assert_eq!(
+            response_value["result"]["payment_hash"],
+            "abababababababababababababababababababababababababababababababab"
+        );
+        assert_eq!(response_value["result"]["bolt11"], "lnbc1test");
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn async_order_request_invoice_is_idempotent_by_claim_session_id() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let provider = Arc::new(TestInvoiceProvider::new(test_request_invoice_result()));
+        handler.set_invoice_provider(provider.clone());
+        let test_peer = test_peer_pubkey(36);
+        let first_request_id = new_jsonrpc_request_id();
+        let second_request_id = new_jsonrpc_request_id();
+        let params = test_request_invoice_params();
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_invoice_payload(
+                        &first_request_id,
+                        ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                        &params,
+                    ),
+                },
+                test_peer,
+            )
+            .unwrap();
+        let first_response = read_single_response(&handler);
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_invoice_payload(
+                        &second_request_id,
+                        ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                        &params,
+                    ),
+                },
+                test_peer,
+            )
+            .unwrap();
+        let second_response = read_single_response(&handler);
+
+        assert_eq!(first_response["result"], second_response["result"]);
+        assert_eq!(first_response["id"], first_request_id);
+        assert_eq!(second_response["id"], second_request_id);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn async_order_request_invoice_rejects_conflicting_claim_session_replay() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let provider = Arc::new(TestInvoiceProvider::new(test_request_invoice_result()));
+        handler.set_invoice_provider(provider.clone());
+        let test_peer = test_peer_pubkey(37);
+        let first_request_id = new_jsonrpc_request_id();
+        let second_request_id = new_jsonrpc_request_id();
+        let params = test_request_invoice_params();
+        let mut conflicting_params = params.clone();
+        conflicting_params.amount_msat = 98000;
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_invoice_payload(
+                        &first_request_id,
+                        ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                        &params,
+                    ),
+                },
+                test_peer,
+            )
+            .unwrap();
+        read_single_response(&handler);
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_invoice_payload(
+                        &second_request_id,
+                        ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                        &conflicting_params,
+                    ),
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        let response_value = read_single_response(&handler);
+        assert_eq!(response_value["id"], second_request_id);
+        assert_eq!(response_value["error"]["code"], ASYNC_ERROR_STALE_FLOW);
+        assert_eq!(response_value["error"]["message"], "stale_flow");
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn async_order_request_invoice_requires_provider() {
+        let handler = AsyncOrderMessageHandler::new_allowing_all_peers();
+        let test_peer = test_peer_pubkey(38);
+        let request_id = new_jsonrpc_request_id();
+        let params = test_request_invoice_params();
+
+        handler
+            .handle_custom_message(
+                AsyncOrderMessage {
+                    payload: request_invoice_payload(
+                        &request_id,
+                        ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                        &params,
+                    ),
+                },
+                test_peer,
+            )
+            .unwrap();
+
+        let response_value = read_single_response(&handler);
+        assert_eq!(response_value["id"], request_id);
+        assert_eq!(response_value["error"]["code"], JSONRPC_INTERNAL_ERROR);
+        assert_eq!(
+            response_value["error"]["message"],
+            "async_order_invoice_provider_not_available"
+        );
     }
 
     #[test]

--- a/src/core_types.rs
+++ b/src/core_types.rs
@@ -9,6 +9,44 @@ pub(crate) const HTLC_MIN_MSAT: u64 = 3_000_000;
 pub(crate) const MAX_SWAP_FEE_MSAT: u64 = HTLC_MIN_MSAT;
 pub(crate) const DEFAULT_FINAL_CLTV_EXPIRY_DELTA: u32 = 14;
 
+pub(crate) mod async_order {
+    use crate::async_order::{AsyncOrderNewHashWire, AsyncOrderRequestInvoiceParamsWire};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub(crate) struct AsyncOrderNewRequest {
+        pub(crate) host_node_id: String,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub(crate) struct AsyncOrderNewResponse {
+        pub(crate) request_id: String,
+        pub(crate) host_node_id: String,
+        pub(crate) protocol_version: u64,
+        pub(crate) order_id: String,
+        pub(crate) status: String,
+        pub(crate) accepted_through_index: u64,
+        pub(crate) next_index_expected: u64,
+        pub(crate) unused_hashes: u64,
+        pub(crate) refill_batch_size: u64,
+        pub(crate) first_hash_index: u64,
+        pub(crate) last_hash_index: u64,
+        pub(crate) hashes: Vec<AsyncOrderNewHashWire>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub(crate) struct AsyncOrderOutboundInvoiceRequest {
+        pub(crate) client_node_id: String,
+        pub(crate) params: AsyncOrderRequestInvoiceParamsWire,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub(crate) struct AsyncOrderOutboundInvoiceResponse {
+        pub(crate) payment_hash: String,
+        pub(crate) bolt11: String,
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 pub(crate) enum HTLCStatus {
     Pending,

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1044,7 +1044,7 @@ struct AsyncOrderRecipientInvoiceProvider {
     channel_manager: Arc<ChannelManager>,
     inbound_payments: Arc<Mutex<InboundPaymentInfoStorage>>,
     async_payments_preimage_root: Arc<AsyncPaymentsPreimageRoot>,
-    kv_store: Arc<SeaOrmKvStore>,
+    kv_store: Arc<SyncedKvStore>,
 }
 
 impl AsyncOrderRecipientInvoiceProvider {
@@ -1065,9 +1065,6 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
         _sender_node_id: PublicKey,
         params: AsyncOrderRequestInvoiceParamsWire,
     ) -> Result<AsyncOrderOutboundInvoiceResultWire, JsonRpcErrorWire> {
-        if params.claim_session_id.trim().is_empty() || params.claim_session_id.len() > 128 {
-            return Err(JsonRpcErrorWire::invalid_params("invalid_claim_session_id"));
-        }
         let hash_index = Self::parse_u64_field(&params.hash_index, "hash_index")?;
         let amount_msat = params.amount_msat;
         if amount_msat < HTLC_MIN_MSAT {
@@ -1112,8 +1109,16 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
         }
 
         let mut inbound = self.inbound_payments.lock().unwrap();
-        if inbound.payments.contains_key(&requested_payment_hash) {
-            return Err(Self::stale_flow_error());
+        if let Some(existing) = inbound.payments.get(&requested_payment_hash) {
+            let expired = existing
+                .expires_at
+                .map(|expires_at| get_current_timestamp() >= expires_at)
+                .unwrap_or(false);
+            let reusable = matches!(existing.status, HTLCStatus::Failed | HTLCStatus::Cancelled)
+                || (matches!(existing.status, HTLCStatus::Pending) && expired);
+            if !reusable {
+                return Err(Self::stale_flow_error());
+            }
         }
 
         let description_hash = lightning_invoice::Sha256(
@@ -1142,7 +1147,7 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
         let created_at = get_current_timestamp();
         let expires_at = created_at + params.invoice_expiry_sec as u64;
         let result = AsyncOrderOutboundInvoiceResultWire {
-            payment_hash: params.payment_hash.clone(),
+            payment_hash: hex_str(&requested_payment_hash.0),
             bolt11: invoice.to_string(),
         };
         persist_staged_inbound_payment(

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1,5 +1,8 @@
 use crate::async_order::{
-    AsyncOrderAccessControl, AsyncOrderMessageHandler, AsyncPaymentsPreimageRoot,
+    AsyncOrderAccessControl, AsyncOrderInvoiceProvider, AsyncOrderMessageHandler,
+    AsyncOrderOutboundInvoiceResultWire, AsyncOrderRequestInvoiceParamsWire,
+    AsyncPaymentsPreimageRoot, JsonRpcErrorWire, ASYNC_ERROR_INVOICE_HASH_MISMATCH,
+    ASYNC_ERROR_STALE_FLOW,
 };
 use crate::synced_kv_store::SyncedKvStore;
 use amplify::{map, s};
@@ -16,7 +19,9 @@ use lightning::chain::{BestBlock, Filter};
 use lightning::events::bump_transaction::{BumpTransactionEventHandler, Wallet};
 use lightning::events::{Event, PaymentFailureReason, PaymentPurpose, ReplayEvent};
 use lightning::ln::channel_state::ChannelDetails;
-use lightning::ln::channelmanager::{self, ChannelFundingType, PaymentId, RecentPaymentDetails};
+use lightning::ln::channelmanager::{
+    self, Bolt11InvoiceParameters, ChannelFundingType, PaymentId, RecentPaymentDetails,
+};
 use lightning::ln::channelmanager::{
     ChainParameters, ChannelManagerReadArgs, SimpleArcChannelManager,
 };
@@ -61,7 +66,7 @@ use lightning_block_sync::poll;
 use lightning_block_sync::SpvClient;
 use lightning_block_sync::UnboundedCache;
 use lightning_dns_resolver::OMDomainResolver;
-use lightning_invoice::PaymentSecret;
+use lightning_invoice::{Bolt11InvoiceDescription, PaymentSecret};
 use lightning_net_tokio::SocketDescriptor;
 use rand::RngCore;
 use rgb_lib::{
@@ -100,7 +105,8 @@ use tokio::task::JoinHandle;
 
 use crate::bitcoind::BitcoindClient;
 use crate::core_types::{
-    HTLCStatus, SwapStatus, UnlockRequest, DUST_LIMIT_MSAT, FEE_RATE, MIN_CHANNEL_CONFIRMATIONS,
+    HTLCStatus, SwapStatus, UnlockRequest, DUST_LIMIT_MSAT, FEE_RATE, HTLC_MIN_MSAT,
+    MIN_CHANNEL_CONFIRMATIONS,
 };
 use crate::database::RlnDatabase;
 use crate::disk::{self, FilesystemLogger};
@@ -125,9 +131,9 @@ use crate::rgb::{check_rgb_proxy_endpoint, get_rgb_channel_info_optional, RgbLib
 use crate::swap::SwapData;
 use crate::utils::{
     check_port_is_available, connect_peer_if_necessary, do_connect_peer, get_current_timestamp,
-    hex_str, AppState, StaticState, UnlockedAppState, ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST,
-    ELECTRUM_URL_SIGNET, ELECTRUM_URL_TESTNET, ELECTRUM_URL_TESTNET4, PROXY_ENDPOINT_LOCAL,
-    PROXY_ENDPOINT_PUBLIC,
+    hex_str, validate_and_parse_payment_hash, AppState, StaticState, UnlockedAppState,
+    ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST, ELECTRUM_URL_SIGNET, ELECTRUM_URL_TESTNET,
+    ELECTRUM_URL_TESTNET4, PROXY_ENDPOINT_LOCAL, PROXY_ENDPOINT_PUBLIC,
 };
 
 const VIRTUAL_CHANNEL_DOMAIN_SEPARATOR: &[u8] = b"rln_virtual_channels_v0";
@@ -164,12 +170,14 @@ pub(crate) fn virtual_channel_synthetic_outpoint(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum InvoiceType {
     AutoClaim,
-    Hodl,
+    Hodl { async_payment_recipient: bool },
 }
 
 impl_writeable_tlv_based_enum!(InvoiceType,
     (0, AutoClaim) => {},
-    (1, Hodl) => {},
+    (1, Hodl) => {
+        (0, async_payment_recipient, (default_value, false)),
+    },
 );
 
 /// Save config to database (source of truth) and sync to KVStore for rust-lightning.
@@ -1011,6 +1019,141 @@ impl AsyncOrderAccessControl for VirtualChannelAccess {
     }
 }
 
+struct AsyncOrderRecipientInvoiceProvider {
+    channel_manager: Arc<ChannelManager>,
+    inbound_payments: Arc<Mutex<InboundPaymentInfoStorage>>,
+    async_payments_preimage_root: Arc<AsyncPaymentsPreimageRoot>,
+    kv_store: Arc<SeaOrmKvStore>,
+}
+
+impl AsyncOrderRecipientInvoiceProvider {
+    fn parse_u64_field(value: &str, field: &str) -> Result<u64, JsonRpcErrorWire> {
+        value
+            .parse::<u64>()
+            .map_err(|_| JsonRpcErrorWire::invalid_params(format!("invalid_{field}")))
+    }
+
+    fn stale_flow_error() -> JsonRpcErrorWire {
+        JsonRpcErrorWire::application_error(ASYNC_ERROR_STALE_FLOW, "stale_flow")
+    }
+}
+
+impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
+    fn request_outbound_invoice(
+        &self,
+        _sender_node_id: PublicKey,
+        params: AsyncOrderRequestInvoiceParamsWire,
+    ) -> Result<AsyncOrderOutboundInvoiceResultWire, JsonRpcErrorWire> {
+        if params.claim_session_id.trim().is_empty() || params.claim_session_id.len() > 128 {
+            return Err(JsonRpcErrorWire::invalid_params("invalid_claim_session_id"));
+        }
+        let hash_index = Self::parse_u64_field(&params.hash_index, "hash_index")?;
+        let amount_msat = params.amount_msat;
+        if amount_msat < HTLC_MIN_MSAT {
+            return Err(JsonRpcErrorWire::invalid_params(format!(
+                "amt_msat cannot be less than {HTLC_MIN_MSAT}"
+            )));
+        }
+        if matches!(params.asset_amount, Some(0)) {
+            return Err(JsonRpcErrorWire::invalid_params("invalid_asset_amount"));
+        }
+        if params.description_hash.trim().is_empty() {
+            return Err(JsonRpcErrorWire::invalid_params("invalid_description_hash"));
+        }
+
+        let (contract_id, asset_amount) = match (&params.asset_id, params.asset_amount) {
+            (Some(asset_id), Some(asset_amount)) => (
+                Some(
+                    ContractId::from_str(asset_id)
+                        .map_err(|_| JsonRpcErrorWire::invalid_params("invalid_asset_id"))?,
+                ),
+                Some(asset_amount),
+            ),
+            (None, None) => (None, None),
+            _ => return Err(JsonRpcErrorWire::invalid_params("incomplete_rgb_info")),
+        };
+
+        let requested_payment_hash = validate_and_parse_payment_hash(&params.payment_hash)
+            .map_err(|_| {
+                JsonRpcErrorWire::application_error(
+                    ASYNC_ERROR_INVOICE_HASH_MISMATCH,
+                    "invoice_hash_mismatch",
+                )
+            })?;
+        let material = self
+            .async_payments_preimage_root
+            .derive_hash_material(hash_index)?;
+        if material.payment_hash != requested_payment_hash {
+            return Err(JsonRpcErrorWire::application_error(
+                ASYNC_ERROR_INVOICE_HASH_MISMATCH,
+                "invoice_hash_mismatch",
+            ));
+        }
+
+        let mut inbound = self.inbound_payments.lock().unwrap();
+        if inbound.payments.contains_key(&requested_payment_hash) {
+            return Err(Self::stale_flow_error());
+        }
+
+        let description_hash = lightning_invoice::Sha256(
+            sha256::Hash::from_str(params.description_hash.trim())
+                .map_err(|_| JsonRpcErrorWire::invalid_params("invalid_description_hash"))?,
+        );
+
+        let invoice_params = Bolt11InvoiceParameters {
+            amount_msats: Some(amount_msat),
+            description: Bolt11InvoiceDescription::Hash(description_hash),
+            invoice_expiry_delta_secs: Some(params.invoice_expiry_sec),
+            min_final_cltv_expiry_delta: Some(params.min_final_cltv_expiry_delta),
+            payment_hash: Some(requested_payment_hash),
+            contract_id,
+            asset_amount,
+        };
+        let invoice = self
+            .channel_manager
+            .create_bolt11_invoice(invoice_params)
+            .map_err(|err| {
+                JsonRpcErrorWire::internal_error(format!(
+                    "async_order_request_outbound_invoice_failed: {err}"
+                ))
+            })?;
+
+        let created_at = get_current_timestamp();
+        let expires_at = created_at + params.invoice_expiry_sec as u64;
+        let result = AsyncOrderOutboundInvoiceResultWire {
+            payment_hash: params.payment_hash.clone(),
+            bolt11: invoice.to_string(),
+        };
+        inbound.payments.insert(
+            requested_payment_hash,
+            PaymentInfo {
+                preimage: Some(material.payment_preimage),
+                secret: Some(*invoice.payment_secret()),
+                status: HTLCStatus::Pending,
+                amt_msat: Some(amount_msat),
+                created_at,
+                updated_at: created_at,
+                payee_pubkey: self.channel_manager.get_our_node_id(),
+                expires_at: Some(expires_at),
+                claim_deadline_height: None,
+                invoice_type: Some(InvoiceType::Hodl {
+                    async_payment_recipient: true,
+                }),
+            },
+        );
+        self.kv_store
+            .write("", "", INBOUND_PAYMENTS_KEY, inbound.encode())
+            .map_err(|err| {
+                JsonRpcErrorWire::internal_error(format!(
+                    "async_order_request_outbound_invoice_persist_failed: {err}"
+                ))
+            })?;
+        drop(inbound);
+
+        Ok(result)
+    }
+}
+
 fn _safe_update_rgb_channel_amount(
     channel_id: &str,
     rgb_offered_htlc: u64,
@@ -1689,17 +1832,32 @@ async fn handle_ldk_events(
                         .channel_manager
                         .claim_funds(payment_preimage.unwrap());
                 }
-                InvoiceType::Hodl => {
-                    unlocked_state.upsert_inbound_payment(
-                        payment_hash,
-                        HTLCStatus::Claimable,
-                        payment_preimage,
-                        payment_secret,
-                        Some(amount_msat),
-                        unlocked_state.channel_manager.get_our_node_id(),
-                        claim_deadline,
-                        None,
-                    );
+                InvoiceType::Hodl {
+                    async_payment_recipient,
+                } => {
+                    if async_payment_recipient {
+                        unlocked_state
+                            .channel_manager
+                            .claim_funds(payment_preimage.unwrap());
+                    } else {
+                        unlocked_state.upsert_inbound_payment(
+                            payment_hash,
+                            HTLCStatus::Claimable,
+                            payment_preimage,
+                            payment_secret,
+                            Some(amount_msat),
+                            unlocked_state.channel_manager.get_our_node_id(),
+                            claim_deadline,
+                            None,
+                        );
+                        unlocked_state
+                            .async_order_handler
+                            .notify_claimable_hodl_invoice(
+                                payment_hash,
+                                amount_msat,
+                                claim_deadline,
+                            );
+                    }
                 }
             }
         }
@@ -1811,6 +1969,9 @@ async fn handle_ldk_events(
                     HTLCStatus::Succeeded,
                     Some(payment_preimage),
                 );
+                unlocked_state
+                    .async_order_handler
+                    .notify_payment_sent(payment_hash, payment_preimage);
                 tracing::info!(
                     "EVENT: successfully sent payment of {:?} millisatoshis{} from \
                             payment hash {} with preimage {}",
@@ -3547,6 +3708,13 @@ pub(crate) async fn start_ldk(
             }
         }
     }
+
+    async_order_handler.set_invoice_provider(Arc::new(AsyncOrderRecipientInvoiceProvider {
+        channel_manager: Arc::clone(&channel_manager),
+        inbound_payments: Arc::clone(&inbound_payments),
+        async_payments_preimage_root: Arc::clone(&async_payments_preimage_root),
+        kv_store: Arc::clone(&kv_store),
+    }));
 
     let unlocked_state = Arc::new(UnlockedAppState {
         channel_manager: Arc::clone(&channel_manager),

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -353,6 +353,27 @@ impl VirtualChannelSessionStore {
     }
 }
 
+fn persist_staged_inbound_payment(
+    kv_store: &dyn KVStoreSync,
+    inbound: &mut InboundPaymentInfoStorage,
+    payment_hash: PaymentHash,
+    payment_info: PaymentInfo,
+) -> Result<(), JsonRpcErrorWire> {
+    let mut staged_inbound = InboundPaymentInfoStorage {
+        payments: inbound.payments.clone(),
+    };
+    staged_inbound.payments.insert(payment_hash, payment_info);
+    kv_store
+        .write("", "", INBOUND_PAYMENTS_KEY, staged_inbound.encode())
+        .map_err(|err| {
+            JsonRpcErrorWire::internal_error(format!(
+                "async_order_request_outbound_invoice_persist_failed: {err}"
+            ))
+        })?;
+    inbound.payments = staged_inbound.payments;
+    Ok(())
+}
+
 impl UnlockedAppState {
     pub(crate) fn add_maker_swap(&self, payment_hash: PaymentHash, swap: SwapData) {
         let mut maker_swaps = self.get_maker_swaps();
@@ -1124,7 +1145,9 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
             payment_hash: params.payment_hash.clone(),
             bolt11: invoice.to_string(),
         };
-        inbound.payments.insert(
+        persist_staged_inbound_payment(
+            self.kv_store.as_ref(),
+            &mut inbound,
             requested_payment_hash,
             PaymentInfo {
                 preimage: Some(material.payment_preimage),
@@ -1140,15 +1163,7 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
                     async_payment_recipient: true,
                 }),
             },
-        );
-        self.kv_store
-            .write("", "", INBOUND_PAYMENTS_KEY, inbound.encode())
-            .map_err(|err| {
-                JsonRpcErrorWire::internal_error(format!(
-                    "async_order_request_outbound_invoice_persist_failed: {err}"
-                ))
-            })?;
-        drop(inbound);
+        )?;
 
         Ok(result)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,8 @@ use crate::auth::conditional_auth_middleware;
 use crate::error::AppError;
 use crate::ldk::stop_ldk;
 use crate::routes::{
-    address, asset_balance, asset_metadata, async_order_new, backup, btc_balance,
-    cancel_hodl_invoice, change_password, check_indexer_url, check_proxy_endpoint,
+    address, asset_balance, asset_metadata, async_order_new, async_order_outbound_invoice, backup,
+    btc_balance, cancel_hodl_invoice, change_password, check_indexer_url, check_proxy_endpoint,
     claim_hodl_invoice, close_channel, connect_peer, create_utxos, decode_ln_invoice,
     decode_rgb_invoice, disconnect_peer, estimate_fee, fail_transfers, get_asset_media,
     get_channel_id, get_payment, get_swap, inflate, init, invoice_status, issue_asset_cfa,
@@ -120,6 +120,7 @@ pub(crate) async fn app(args: UserArgs) -> Result<(Router, Arc<AppState>), AppEr
         .layer(DefaultBodyLimit::disable())
         .route("/address", post(address))
         .route("/apay/new", post(async_order_new))
+        .route("/apay/outboundinvoice", post(async_order_outbound_invoice))
         .route("/assetbalance", post(asset_balance))
         .route("/assetmetadata", post(asset_metadata))
         .route("/backup", post(backup))

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -851,6 +851,7 @@ pub(crate) struct LNInvoiceRequest {
     pub(crate) asset_amount: Option<u64>,
     pub(crate) payment_hash: Option<String>,
     pub(crate) description_hash: Option<String>,
+    pub(crate) min_final_cltv_expiry_delta: Option<u16>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1985,6 +1986,7 @@ pub(crate) async fn create_utxos(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn decode_ln_invoice(
     State(state): State<Arc<AppState>>,
     WithRejection(Json(payload), _): WithRejection<Json<DecodeLNInvoiceRequest>, APIError>,
@@ -3078,10 +3080,10 @@ pub(crate) async fn ln_invoice(
             amount_msats: payload.amt_msat,
             description,
             invoice_expiry_delta_secs: Some(payload.expiry_sec),
+            min_final_cltv_expiry_delta: payload.min_final_cltv_expiry_delta,
             payment_hash: requested_payment_hash,
             contract_id,
             asset_amount: payload.asset_amount,
-            ..Default::default()
         };
 
         let invoice = unlocked_state

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -72,7 +72,8 @@ use tokio::{
 
 use crate::async_order::{
     read_async_payments_next_hash_index, write_async_payments_next_hash_index,
-    AsyncOrderNewHashWire, AsyncOrderNewResultWire, ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
+    AsyncOrderNewHashWire, AsyncOrderNewResultWire, AsyncOrderOutboundInvoiceResultWire,
+    AsyncOrderRequestInvoiceParamsWire, ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
     ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
 };
 use crate::ldk::{
@@ -357,6 +358,12 @@ pub(crate) struct AsyncOrderNewRequest {
 }
 
 #[derive(Deserialize, Serialize)]
+pub(crate) struct AsyncOrderOutboundInvoiceRequest {
+    pub(crate) client_node_id: String,
+    pub(crate) params: AsyncOrderRequestInvoiceParamsWire,
+}
+
+#[derive(Deserialize, Serialize)]
 pub(crate) struct AsyncOrderNewResponse {
     pub(crate) request_id: String,
     pub(crate) host_node_id: String,
@@ -537,9 +544,11 @@ pub(crate) struct DecodeLNInvoiceResponse {
     pub(crate) timestamp: u64,
     pub(crate) asset_id: Option<String>,
     pub(crate) asset_amount: Option<u64>,
+    pub(crate) description_hash: Option<String>,
     pub(crate) payment_hash: String,
     pub(crate) payment_secret: String,
     pub(crate) payee_pubkey: Option<String>,
+    pub(crate) min_final_cltv_expiry_delta: u64,
     pub(crate) network: BitcoinNetwork,
 }
 
@@ -976,7 +985,7 @@ pub(crate) struct Payment {
 fn payment_type_from_invoice(invoice_type: Option<InvoiceType>) -> PaymentType {
     match invoice_type.unwrap_or(InvoiceType::AutoClaim) {
         InvoiceType::AutoClaim => PaymentType::InboundAutoClaim,
-        InvoiceType::Hodl => PaymentType::InboundHodl,
+        InvoiceType::Hodl { .. } => PaymentType::InboundHodl,
     }
 }
 
@@ -1444,10 +1453,10 @@ pub(crate) async fn async_order_new(
 
     let response_rx = unlocked_state
         .async_order_handler
-        .queue_async_order_new_request(host_node_id, Value::String(request_id.clone()), params)
+        .queue_async_order_new(host_node_id, Value::String(request_id.clone()), params)
         .map_err(|err| APIError::InvalidRequest(err.message))?;
     unlocked_state.peer_manager.process_events();
-    let order_state: AsyncOrderNewResultWire = match timeout(
+    let order_state_value = match timeout(
         Duration::from_secs(ASYNC_ORDER_RESPONSE_TIMEOUT_SECS),
         response_rx,
     )
@@ -1474,6 +1483,10 @@ pub(crate) async fn async_order_new(
             )));
         }
     };
+    let order_state: AsyncOrderNewResultWire =
+        serde_json::from_value(order_state_value).map_err(|err| {
+            APIError::InvalidRequest(format!("invalid async_order.new response: {err}"))
+        })?;
     let next_hash_index = order_state.next_index_expected;
     write_async_payments_next_hash_index(
         unlocked_state.kv_store.as_ref(),
@@ -1496,6 +1509,76 @@ pub(crate) async fn async_order_new(
         last_hash_index,
         hashes,
     }))
+}
+
+pub(crate) async fn async_order_outbound_invoice(
+    State(state): State<Arc<AppState>>,
+    WithRejection(Json(payload), _): WithRejection<
+        Json<AsyncOrderOutboundInvoiceRequest>,
+        APIError,
+    >,
+) -> Result<Json<AsyncOrderOutboundInvoiceResultWire>, APIError> {
+    let guard = state.check_unlocked().await?;
+    let unlocked_state = Arc::clone(guard.as_ref().unwrap());
+    drop(guard);
+
+    let peer_node_id =
+        hex_str_to_compressed_pubkey(&payload.client_node_id).ok_or(APIError::InvalidPubkey)?;
+    if unlocked_state
+        .peer_manager
+        .peer_by_node_id(&peer_node_id)
+        .is_none()
+    {
+        return Err(APIError::InvalidPeerInfo(s!(
+            "/apay/outboundinvoice requires a connected recipient peer"
+        )));
+    }
+
+    let request_id = payload.params.claim_session_id.clone();
+    let response_rx = unlocked_state
+        .async_order_handler
+        .queue_async_order_request_invoice(
+            peer_node_id,
+            Value::String(request_id.clone()),
+            payload.params,
+        )
+        .map_err(|err| APIError::InvalidRequest(err.message))?;
+    unlocked_state.peer_manager.process_events();
+
+    let response_value = match timeout(
+        Duration::from_secs(ASYNC_ORDER_RESPONSE_TIMEOUT_SECS),
+        response_rx,
+    )
+    .await
+    {
+        Ok(Ok(Ok(result))) => result,
+        Ok(Ok(Err(err))) => {
+            return Err(APIError::InvalidRequest(format!(
+                "async_order host error {}: {}",
+                err.code, err.message
+            )));
+        }
+        Ok(Err(_)) => {
+            return Err(APIError::Network(s!(
+                "/apay/outboundinvoice response channel closed before peer replied"
+            )))
+        }
+        Err(_) => {
+            unlocked_state
+                .async_order_handler
+                .forget_async_order_response(peer_node_id, &request_id);
+            return Err(APIError::Network(s!(
+                "/apay/outboundinvoice timed out waiting for peer response"
+            )));
+        }
+    };
+
+    let response: AsyncOrderOutboundInvoiceResultWire = serde_json::from_value(response_value)
+        .map_err(|err| {
+            APIError::InvalidRequest(format!("invalid request_invoice response: {err}"))
+        })?;
+
+    Ok(Json(response))
 }
 
 pub(crate) async fn asset_balance(
@@ -1625,7 +1708,7 @@ pub(crate) async fn cancel_hodl_invoice(
             .get(&payment_hash)
             .cloned()
             .ok_or(APIError::UnknownLNInvoice)?;
-        if !matches!(payment_info.invoice_type, Some(InvoiceType::Hodl)) {
+        if !matches!(payment_info.invoice_type, Some(InvoiceType::Hodl { .. })) {
             return Err(APIError::InvoiceNotHodl);
         }
         match payment_info.status {
@@ -1702,7 +1785,10 @@ pub(crate) async fn claim_hodl_invoice(
                 return Err(APIError::UnknownLNInvoice);
             };
 
-            if !matches!(existing_payment_mut.invoice_type, Some(InvoiceType::Hodl)) {
+            if !matches!(
+                existing_payment_mut.invoice_type,
+                Some(InvoiceType::Hodl { .. })
+            ) {
                 return Err(APIError::InvoiceNotHodl);
             }
 
@@ -2004,9 +2090,16 @@ pub(crate) async fn decode_ln_invoice(
         timestamp: invoice.duration_since_epoch().as_secs(),
         asset_id: invoice.rgb_contract_id().map(|c| c.to_string()),
         asset_amount: invoice.rgb_amount(),
+        description_hash: match invoice.description() {
+            lightning_invoice::Bolt11InvoiceDescriptionRef::Hash(hash) => {
+                Some(hex_str(&hash.0.to_byte_array()))
+            }
+            _ => None,
+        },
         payment_hash: hex_str(&invoice.payment_hash().to_byte_array()),
         payment_secret: hex_str(&invoice.payment_secret().0),
-        payee_pubkey: invoice.payee_pub_key().map(|p| p.to_string()),
+        payee_pubkey: Some(invoice.get_payee_pub_key().to_string()),
+        min_final_cltv_expiry_delta: invoice.min_final_cltv_expiry_delta(),
         network: invoice.network().into(),
     }))
 }
@@ -3092,7 +3185,12 @@ pub(crate) async fn ln_invoice(
             .map_err(|e| APIError::FailedInvoiceCreation(e.to_string()))?;
 
         let (payment_hash, invoice_type) = match requested_payment_hash {
-            Some(payment_hash) => (payment_hash, InvoiceType::Hodl),
+            Some(payment_hash) => (
+                payment_hash,
+                InvoiceType::Hodl {
+                    async_payment_recipient: false,
+                },
+            ),
             None => (
                 PaymentHash((*invoice.payment_hash()).to_byte_array()),
                 InvoiceType::AutoClaim,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -72,9 +72,12 @@ use tokio::{
 
 use crate::async_order::{
     read_async_payments_next_hash_index, write_async_payments_next_hash_index,
-    AsyncOrderNewHashWire, AsyncOrderNewResultWire, AsyncOrderOutboundInvoiceResultWire,
-    AsyncOrderRequestInvoiceParamsWire, ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
+    AsyncOrderNewResultWire, AsyncOrderOutboundInvoiceResultWire, ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
     ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
+};
+use crate::core_types::async_order::{
+    AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
+    AsyncOrderOutboundInvoiceResponse,
 };
 use crate::ldk::{
     clear_rgb_payment_pending, start_ldk, stop_ldk, LdkBackgroundServices,
@@ -350,33 +353,6 @@ impl From<Assignment> for RgbLibAssignment {
             Assignment::Any => Self::Any,
         }
     }
-}
-
-#[derive(Deserialize, Serialize)]
-pub(crate) struct AsyncOrderNewRequest {
-    pub(crate) host_node_id: String,
-}
-
-#[derive(Deserialize, Serialize)]
-pub(crate) struct AsyncOrderOutboundInvoiceRequest {
-    pub(crate) client_node_id: String,
-    pub(crate) params: AsyncOrderRequestInvoiceParamsWire,
-}
-
-#[derive(Deserialize, Serialize)]
-pub(crate) struct AsyncOrderNewResponse {
-    pub(crate) request_id: String,
-    pub(crate) host_node_id: String,
-    pub(crate) protocol_version: u64,
-    pub(crate) order_id: String,
-    pub(crate) status: String,
-    pub(crate) accepted_through_index: u64,
-    pub(crate) next_index_expected: u64,
-    pub(crate) unused_hashes: u64,
-    pub(crate) refill_batch_size: u64,
-    pub(crate) first_hash_index: u64,
-    pub(crate) last_hash_index: u64,
-    pub(crate) hashes: Vec<AsyncOrderNewHashWire>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1517,7 +1493,7 @@ pub(crate) async fn async_order_outbound_invoice(
         Json<AsyncOrderOutboundInvoiceRequest>,
         APIError,
     >,
-) -> Result<Json<AsyncOrderOutboundInvoiceResultWire>, APIError> {
+) -> Result<Json<AsyncOrderOutboundInvoiceResponse>, APIError> {
     let guard = state.check_unlocked().await?;
     let unlocked_state = Arc::clone(guard.as_ref().unwrap());
     drop(guard);
@@ -1534,7 +1510,7 @@ pub(crate) async fn async_order_outbound_invoice(
         )));
     }
 
-    let request_id = payload.params.claim_session_id.clone();
+    let request_id = new_jsonrpc_request_id();
     let response_rx = unlocked_state
         .async_order_handler
         .queue_async_order_request_invoice(
@@ -1578,7 +1554,10 @@ pub(crate) async fn async_order_outbound_invoice(
             APIError::InvalidRequest(format!("invalid request_invoice response: {err}"))
         })?;
 
-    Ok(Json(response))
+    Ok(Json(AsyncOrderOutboundInvoiceResponse {
+        payment_hash: response.payment_hash,
+        bolt11: response.bolt11,
+    }))
 }
 
 pub(crate) async fn asset_balance(

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -3248,6 +3248,7 @@ pub(crate) async fn invoice_status(
  * This method is an SDK-facing adapter corresponding to `routes::ln_invoice`.
  * It keeps route-equivalent semantics while using SDK-native parameter shape.
  */
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn create_ln_invoice(
     state: Arc<AppState>,
     amt_msat: Option<u64>,
@@ -3256,6 +3257,7 @@ pub(crate) async fn create_ln_invoice(
     asset_amount: Option<u64>,
     payment_hash: Option<String>,
     description_hash: Option<String>,
+    min_final_cltv_expiry_delta: Option<u16>,
 ) -> Result<LnInvoiceData, APIError> {
     let guard = check_unlocked(&state).await?;
     let unlocked_state = guard.as_ref().unwrap();
@@ -3298,10 +3300,10 @@ pub(crate) async fn create_ln_invoice(
         amount_msats: amt_msat,
         description,
         invoice_expiry_delta_secs: Some(expiry_sec),
+        min_final_cltv_expiry_delta,
         payment_hash: requested_payment_hash,
         contract_id,
         asset_amount,
-        ..Default::default()
     };
 
     let invoice = match unlocked_state

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -3,8 +3,12 @@
 
 use crate::async_order::{
     read_async_payments_next_hash_index, write_async_payments_next_hash_index,
-    AsyncOrderNewHashWire, AsyncOrderNewResultWire, JsonRpcErrorWire,
-    ASYNC_ORDER_MAX_HASH_BATCH_SIZE, ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
+    AsyncOrderNewResultWire, AsyncOrderOutboundInvoiceResultWire, ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
+    ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
+};
+use crate::core_types::async_order::{
+    AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
+    AsyncOrderOutboundInvoiceResponse,
 };
 use crate::core_types::{FEE_RATE, MIN_CHANNEL_CONFIRMATIONS};
 use crate::disk;
@@ -226,25 +230,6 @@ pub(crate) struct AssetMetadataData {
     pub(crate) ticker: Option<String>,
     pub(crate) details: Option<String>,
     pub(crate) token: Option<Token>,
-}
-
-pub(crate) struct AsyncOrderNewRequestData {
-    pub(crate) host_node_id: String,
-}
-
-pub(crate) struct AsyncOrderNewData {
-    pub(crate) request_id: String,
-    pub(crate) host_node_id: String,
-    pub(crate) protocol_version: u64,
-    pub(crate) order_id: String,
-    pub(crate) status: String,
-    pub(crate) accepted_through_index: u64,
-    pub(crate) next_index_expected: u64,
-    pub(crate) unused_hashes: u64,
-    pub(crate) refill_batch_size: u64,
-    pub(crate) first_hash_index: u64,
-    pub(crate) last_hash_index: u64,
-    pub(crate) hashes: Vec<AsyncOrderNewHashWire>,
 }
 
 pub(crate) struct BtcBalance {
@@ -1131,8 +1116,8 @@ pub(crate) async fn address(state: Arc<AppState>) -> Result<AddressData, APIErro
 
 pub(crate) async fn async_order_new(
     state: Arc<AppState>,
-    request: AsyncOrderNewRequestData,
-) -> Result<AsyncOrderNewData, APIError> {
+    request: AsyncOrderNewRequest,
+) -> Result<AsyncOrderNewResponse, APIError> {
     let guard = check_unlocked(&state).await?;
     let unlocked_state = Arc::clone(guard.as_ref().unwrap());
     drop(guard);
@@ -1212,7 +1197,7 @@ pub(crate) async fn async_order_new(
     )
     .map_err(|err| APIError::Unexpected(err.message))?;
 
-    Ok(AsyncOrderNewData {
+    Ok(AsyncOrderNewResponse {
         request_id,
         host_node_id: hex_str(&host_node_id.serialize()),
         protocol_version: order_state.protocol_version,
@@ -1225,6 +1210,76 @@ pub(crate) async fn async_order_new(
         first_hash_index,
         last_hash_index,
         hashes,
+    })
+}
+
+pub(crate) async fn async_order_outbound_invoice(
+    state: Arc<AppState>,
+    request: AsyncOrderOutboundInvoiceRequest,
+) -> Result<AsyncOrderOutboundInvoiceResponse, APIError> {
+    let guard = check_unlocked(&state).await?;
+    let unlocked_state = Arc::clone(guard.as_ref().unwrap());
+    drop(guard);
+
+    let peer_node_id =
+        hex_str_to_compressed_pubkey(&request.client_node_id).ok_or(APIError::InvalidPubkey)?;
+    if unlocked_state
+        .peer_manager
+        .peer_by_node_id(&peer_node_id)
+        .is_none()
+    {
+        return Err(APIError::InvalidPeerInfo(s!(
+            "/apay/outboundinvoice requires a connected recipient peer"
+        )));
+    }
+
+    let request_id = new_jsonrpc_request_id();
+    let response_rx = unlocked_state
+        .async_order_handler
+        .queue_async_order_request_invoice(
+            peer_node_id,
+            Value::String(request_id.clone()),
+            request.params,
+        )
+        .map_err(|err| APIError::InvalidRequest(err.message))?;
+    unlocked_state.peer_manager.process_events();
+
+    let response_value = match timeout(
+        Duration::from_secs(ASYNC_ORDER_RESPONSE_TIMEOUT_SECS),
+        response_rx,
+    )
+    .await
+    {
+        Ok(Ok(Ok(result))) => result,
+        Ok(Ok(Err(err))) => {
+            return Err(APIError::InvalidRequest(format!(
+                "async_order host error {}: {}",
+                err.code, err.message
+            )));
+        }
+        Ok(Err(_)) => {
+            return Err(APIError::Network(s!(
+                "/apay/outboundinvoice response channel closed before peer replied"
+            )))
+        }
+        Err(_) => {
+            unlocked_state
+                .async_order_handler
+                .forget_async_order_response(peer_node_id, &request_id);
+            return Err(APIError::Network(s!(
+                "/apay/outboundinvoice timed out waiting for peer response"
+            )));
+        }
+    };
+
+    let response: AsyncOrderOutboundInvoiceResultWire = serde_json::from_value(response_value)
+        .map_err(|err| {
+            APIError::InvalidRequest(format!("invalid request_invoice response: {err}"))
+        })?;
+
+    Ok(AsyncOrderOutboundInvoiceResponse {
+        payment_hash: response.payment_hash,
+        bolt11: response.bolt11,
     })
 }
 

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -267,6 +267,7 @@ pub(crate) struct DecodeLnInvoiceData {
     pub(crate) payment_hash: String,
     pub(crate) payment_secret: String,
     pub(crate) payee_pubkey: Option<String>,
+    pub(crate) min_final_cltv_expiry_delta: u64,
     pub(crate) network: RgbBitcoinNetwork,
 }
 
@@ -1169,10 +1170,10 @@ pub(crate) async fn async_order_new(
 
     let response_rx = unlocked_state
         .async_order_handler
-        .queue_async_order_new_request(host_node_id, Value::String(request_id.clone()), params)
+        .queue_async_order_new(host_node_id, Value::String(request_id.clone()), params)
         .map_err(|err| APIError::InvalidRequest(err.message))?;
     unlocked_state.peer_manager.process_events();
-    let order_state: AsyncOrderNewResultWire = match timeout(
+    let order_state_value = match timeout(
         Duration::from_secs(ASYNC_ORDER_RESPONSE_TIMEOUT_SECS),
         response_rx,
     )
@@ -1199,6 +1200,10 @@ pub(crate) async fn async_order_new(
             )));
         }
     };
+    let order_state: AsyncOrderNewResultWire =
+        serde_json::from_value(order_state_value).map_err(|err| {
+            APIError::InvalidRequest(format!("invalid async_order.new response: {err}"))
+        })?;
     let next_hash_index = order_state.next_index_expected;
     write_async_payments_next_hash_index(
         unlocked_state.kv_store.as_ref(),
@@ -3184,7 +3189,8 @@ pub(crate) async fn decode_ln_invoice(
         asset_amount: invoice.rgb_amount(),
         payment_hash: hex_str(&invoice.payment_hash().to_byte_array()),
         payment_secret: hex_str(&invoice.payment_secret().0),
-        payee_pubkey: invoice.payee_pub_key().map(|p| p.to_string()),
+        payee_pubkey: Some(invoice.get_payee_pub_key().to_string()),
+        min_final_cltv_expiry_delta: invoice.min_final_cltv_expiry_delta(),
         network: match invoice.network() {
             bitcoin::Network::Bitcoin => rgb_lib::BitcoinNetwork::Mainnet,
             bitcoin::Network::Testnet => rgb_lib::BitcoinNetwork::Testnet,
@@ -3315,7 +3321,12 @@ pub(crate) async fn create_ln_invoice(
     };
 
     let (payment_hash, invoice_type) = match requested_payment_hash {
-        Some(payment_hash) => (payment_hash, InvoiceType::Hodl),
+        Some(payment_hash) => (
+            payment_hash,
+            InvoiceType::Hodl {
+                async_payment_recipient: false,
+            },
+        ),
         None => (
             PaymentHash((*invoice.payment_hash()).to_byte_array()),
             InvoiceType::AutoClaim,
@@ -3345,7 +3356,7 @@ pub(crate) async fn create_ln_invoice(
 fn payment_type_from_invoice(invoice_type: Option<InvoiceType>) -> PaymentType {
     match invoice_type.unwrap_or(InvoiceType::AutoClaim) {
         InvoiceType::AutoClaim => PaymentType::InboundAutoClaim,
-        InvoiceType::Hodl => PaymentType::InboundHodl,
+        InvoiceType::Hodl { .. } => PaymentType::InboundHodl,
     }
 }
 
@@ -3496,7 +3507,7 @@ pub(crate) async fn cancel_hodl_invoice(
         .get(&payment_hash)
         .cloned()
         .ok_or(APIError::UnknownLNInvoice)?;
-    if !matches!(payment_info.invoice_type, Some(InvoiceType::Hodl)) {
+    if !matches!(payment_info.invoice_type, Some(InvoiceType::Hodl { .. })) {
         return Err(APIError::InvoiceNotHodl);
     }
     match payment_info.status {
@@ -3527,7 +3538,10 @@ pub(crate) async fn claim_hodl_invoice(
             return Err(APIError::UnknownLNInvoice);
         };
 
-        if !matches!(existing_payment_mut.invoice_type, Some(InvoiceType::Hodl)) {
+        if !matches!(
+            existing_payment_mut.invoice_type,
+            Some(InvoiceType::Hodl { .. })
+        ) {
             return Err(APIError::InvoiceNotHodl);
         }
 

--- a/src/test/hodl_invoice.rs
+++ b/src/test/hodl_invoice.rs
@@ -561,6 +561,7 @@ async fn claim_hodl_invoice_btc_rgb() {
         asset_amount: None,
         payment_hash: Some(payment_hash.clone()),
         description_hash: None,
+        min_final_cltv_expiry_delta: None,
     };
     let duplicate_hash_res = reqwest::Client::new()
         .post(format!("http://{node2_addr}/lninvoice"))

--- a/src/test/invoice.rs
+++ b/src/test/invoice.rs
@@ -25,6 +25,7 @@ async fn invoice() {
         asset_amount: Some(1),
         payment_hash: None,
         description_hash: None,
+        min_final_cltv_expiry_delta: None,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node1_addr}/lninvoice"))
@@ -42,6 +43,7 @@ async fn invoice() {
         asset_amount: Some(1),
         payment_hash: None,
         description_hash: None,
+        min_final_cltv_expiry_delta: None,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node1_addr}/lninvoice"))
@@ -59,6 +61,7 @@ async fn invoice() {
         asset_amount: None,
         payment_hash: None,
         description_hash: None,
+        min_final_cltv_expiry_delta: None,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node1_addr}/lninvoice"))
@@ -83,6 +86,7 @@ async fn description_hash_invoice() {
     fund_and_create_utxos(node1_addr, None).await;
 
     let description_hash = lightning_invoice::Sha256(Sha256::hash(b"out-of-band description"));
+    let inbound_min_final_cltv = 144;
     let payload = LNInvoiceRequest {
         amt_msat: None,
         expiry_sec: 900,
@@ -90,6 +94,7 @@ async fn description_hash_invoice() {
         asset_amount: None,
         payment_hash: None,
         description_hash: Some(description_hash.0.to_string()),
+        min_final_cltv_expiry_delta: Some(inbound_min_final_cltv),
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node1_addr}/lninvoice"))
@@ -106,6 +111,10 @@ async fn description_hash_invoice() {
         invoice.description(),
         lightning_invoice::Bolt11InvoiceDescriptionRef::Hash(hash) if *hash == description_hash
     ));
+    assert_eq!(
+        invoice.min_final_cltv_expiry_delta(),
+        u64::from(inbound_min_final_cltv) + 3
+    );
 }
 
 #[serial_test::serial]
@@ -181,6 +190,7 @@ async fn zero_amount_invoice() {
         asset_amount: None,
         payment_hash: None,
         description_hash: None,
+        min_final_cltv_expiry_delta: None,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node2_addr}/lninvoice"))
@@ -269,6 +279,7 @@ async fn zero_amount_invoice() {
         asset_amount: None,
         payment_hash: None,
         description_hash: None,
+        min_final_cltv_expiry_delta: None,
     };
     let invoice_without_amount = reqwest::Client::new()
         .post(format!("http://{node2_addr}/lninvoice"))
@@ -293,6 +304,7 @@ async fn zero_amount_invoice() {
         asset_amount: Some(50),
         payment_hash: None,
         description_hash: None,
+        min_final_cltv_expiry_delta: None,
     };
     let invoice_with_amount = reqwest::Client::new()
         .post(format!("http://{node2_addr}/lninvoice"))

--- a/src/test/invoice.rs
+++ b/src/test/invoice.rs
@@ -135,6 +135,7 @@ async fn invalid_description_hash_invoice() {
         asset_amount: None,
         payment_hash: None,
         description_hash: Some("not-a-valid-description-hash".to_string()),
+        min_final_cltv_expiry_delta: None,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node1_addr}/lninvoice"))

--- a/src/test/lib_core.rs
+++ b/src/test/lib_core.rs
@@ -62,6 +62,7 @@ fn locked_state_does_not_bypass_unlock_guards() {
         asset_amount: None,
         payment_hash: None,
         description_hash: None,
+        min_final_cltv_expiry_delta: None,
     });
     assert!(matches!(invoice, Err(RlnError::NotInitialized)));
 

--- a/src/test/lib_sdk/close_coop_vanilla.rs
+++ b/src/test/lib_sdk/close_coop_vanilla.rs
@@ -196,6 +196,7 @@ fn run_close_coop_vanilla(name: &str, port_offset: u16, with_anchors: bool) {
                 asset_amount: None,
                 payment_hash: None,
                 description_hash: None,
+                min_final_cltv_expiry_delta: None,
             })
             .expect("node A vanilla ln_invoice")
             .invoice;

--- a/src/test/lib_sdk/invoice.rs
+++ b/src/test/lib_sdk/invoice.rs
@@ -33,6 +33,7 @@ fn description_hash_survives_sdk_path() {
                 asset_amount: None,
                 payment_hash: None,
                 description_hash: Some(description_hash.0.to_string()),
+                min_final_cltv_expiry_delta: None,
             })
             .expect("node ln_invoice with description_hash")
             .invoice;

--- a/src/test/lib_sdk/multi_hop.rs
+++ b/src/test/lib_sdk/multi_hop.rs
@@ -243,6 +243,7 @@ fn multi_hop() {
                 asset_amount: Some(50),
                 payment_hash: None,
                 description_hash: None,
+                min_final_cltv_expiry_delta: None,
             })
             .expect("node C ln_invoice")
             .invoice;

--- a/src/test/lib_sdk/payment.rs
+++ b/src/test/lib_sdk/payment.rs
@@ -172,6 +172,7 @@ fn success() {
                 asset_amount: Some(asset_amount),
                 payment_hash: None,
                 description_hash: None,
+                min_final_cltv_expiry_delta: None,
             })
             .expect("node B ln_invoice")
             .invoice;
@@ -238,6 +239,7 @@ fn success() {
                 asset_amount: Some(asset_amount),
                 payment_hash: None,
                 description_hash: None,
+                min_final_cltv_expiry_delta: None,
             })
             .expect("node A ln_invoice second")
             .invoice;
@@ -273,6 +275,7 @@ fn success() {
                 asset_amount: Some(asset_amount),
                 payment_hash: None,
                 description_hash: None,
+                min_final_cltv_expiry_delta: None,
             })
             .expect("node B ln_invoice third")
             .invoice;
@@ -306,6 +309,7 @@ fn success() {
                 asset_amount: Some(asset_amount),
                 payment_hash: None,
                 description_hash: None,
+                min_final_cltv_expiry_delta: None,
             })
             .expect("node A ln_invoice fourth")
             .invoice;

--- a/src/test/lib_sdk/restart.rs
+++ b/src/test/lib_sdk/restart.rs
@@ -159,6 +159,7 @@ fn restart() {
                 asset_amount: Some(100),
                 payment_hash: None,
                 description_hash: None,
+                min_final_cltv_expiry_delta: None,
             })
             .expect("node B ln_invoice")
             .invoice;

--- a/src/test/lib_sdk/vanilla_payment_on_rgb_channel.rs
+++ b/src/test/lib_sdk/vanilla_payment_on_rgb_channel.rs
@@ -103,6 +103,7 @@ fn vanilla_payment_on_rgb_channel() {
                 asset_amount: None,
                 payment_hash: None,
                 description_hash: None,
+                min_final_cltv_expiry_delta: None,
             })
             .expect("node B vanilla ln_invoice")
             .invoice;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1172,6 +1172,7 @@ async fn ln_invoice_with_type(
         asset_amount,
         payment_hash,
         description_hash: None,
+        min_final_cltv_expiry_delta: None,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node_address}/lninvoice"))

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1148,7 +1148,9 @@ async fn ln_invoice_hodl(
         asset_amount,
         expiry_sec,
         payment_hash,
-        InvoiceType::Hodl,
+        InvoiceType::Hodl {
+            async_payment_recipient: false,
+        },
     )
     .await
 }

--- a/src/uniffi_api/examples/python-interop/manual_py_full_n2n.py
+++ b/src/uniffi_api/examples/python-interop/manual_py_full_n2n.py
@@ -371,6 +371,7 @@ def main():
             asset_id=asset_id,
             asset_amount=PAYMENT_ASSET_AMOUNT,
             description_hash=None,
+            min_final_cltv_expiry_delta=None,
         )
         invoice = node_b.ln_invoice(inv_req).invoice
         print("invoice:", invoice)

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -1130,6 +1130,7 @@ impl SdkNode {
             payment_hash,
             payment_secret: resp.payment_secret,
             payee_pubkey,
+            min_final_cltv_expiry_delta: resp.min_final_cltv_expiry_delta,
             network: format!("{:?}", resp.network),
         })
     }
@@ -1246,6 +1247,7 @@ impl SdkNode {
         let asset_id = request.asset_id.map(|a| a.to_string());
         let payment_hash = request.payment_hash.map(|h| h.0.as_hex().to_string());
         let description_hash = request.description_hash;
+        let min_final_cltv_expiry_delta = request.min_final_cltv_expiry_delta;
         let data = block_on_sdk(sdk::create_ln_invoice(
             state,
             request.amt_msat,
@@ -1254,6 +1256,7 @@ impl SdkNode {
             request.asset_amount,
             payment_hash,
             description_hash,
+            min_final_cltv_expiry_delta,
         ))?;
         let invoice = Bolt11Invoice::from_str(&data.invoice).map_err(|_| RlnError::Internal)?;
         Ok(LnInvoiceResponse { invoice })

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -38,6 +38,7 @@ mod uniffi_smoke_tests {
             asset_amount: None,
             payment_hash: None,
             description_hash: None,
+            min_final_cltv_expiry_delta: None,
         });
         assert!(matches!(invoice, Err(RlnError::NotInitialized)));
 

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -326,6 +326,7 @@ pub struct DecodeLnInvoiceResponse {
     pub payment_hash: PaymentHash,
     pub payment_secret: String,
     pub payee_pubkey: Option<PublicKey>,
+    pub min_final_cltv_expiry_delta: u64,
     pub network: String,
 }
 
@@ -396,6 +397,7 @@ pub struct LnInvoiceRequest {
     pub asset_amount: Option<u64>,
     pub payment_hash: Option<PaymentHash>,
     pub description_hash: Option<String>,
+    pub min_final_cltv_expiry_delta: Option<u16>,
 }
 
 pub struct CancelHodlInvoiceRequest {

--- a/test/kotlin-e2e/KotlinUniffiE2e.kt
+++ b/test/kotlin-e2e/KotlinUniffiE2e.kt
@@ -660,6 +660,7 @@ private fun paymentScenario() {
                 assetAmount = PAYMENT_ASSET_AMOUNT,
                 descriptionHash = null,
                 paymentHash = null,
+                minFinalCltvExpiryDelta = null,
             )
         ).invoice
         println("invoice: $invoice")
@@ -1019,6 +1020,7 @@ private fun closeCoopVanillaScenario(name: String, portOffset: UInt, withAnchors
                 assetAmount = null,
                 descriptionHash = null,
                 paymentHash = null,
+                minFinalCltvExpiryDelta = null,
             )
         ).invoice
         val sendPayment = nodeB.sendpayment(

--- a/test/python-e2e/hodl.py
+++ b/test/python-e2e/hodl.py
@@ -444,6 +444,7 @@ def run_hodl_claim_phase(
             asset_amount=PAYMENT_ASSET_AMOUNT,
             payment_hash=payment_hash_hex,
             description_hash=None,
+            min_final_cltv_expiry_delta=None,
         )
     ).invoice
     print(f"hodl claim invoice: {invoice}")
@@ -565,6 +566,7 @@ def run_hodl_cancel_phase(
             asset_amount=PAYMENT_ASSET_AMOUNT,
             payment_hash=payment_hash_hex,
             description_hash=None,
+            min_final_cltv_expiry_delta=None,
         )
     ).invoice
     print(f"hodl cancel invoice: {invoice}")
@@ -702,6 +704,7 @@ def run_hodl_to_claimable(sender: rln.SdkNode, receiver: rln.SdkNode, asset_id, 
             asset_amount=PAYMENT_ASSET_AMOUNT,
             payment_hash=payment_hash_hex,
             description_hash=None,
+            min_final_cltv_expiry_delta=None,
         )
     ).invoice
     print(f"hodl expiry invoice: {invoice}")

--- a/test/python-e2e/payment.py
+++ b/test/python-e2e/payment.py
@@ -131,6 +131,7 @@ def payment_scenario():
                 asset_amount=PAYMENT_ASSET_AMOUNT,
                 description_hash=None,
                 payment_hash=None,
+                min_final_cltv_expiry_delta=None,
             )
         ).invoice
         print(f"invoice: {invoice}")


### PR DESCRIPTION
Adds `async_order.request_invoice` control plane support:
- peer-message request/response handling through `/apay/outboundinvoice`
- recipient invoice provider
- deterministic async payment preimage use
- HODL invoice marking with `async_payment_recipient`
- `claimable`/`payment_sent` notifications to utexo-lsp
- additional invoice decode fields.
- explicit inbound final CLTV policy support to LN invoice creation across HTTP, SDK, UniFFI, OpenAPI, and tests. This lets callers request a specific `min_final_cltv_expiry_delta` instead of relying on LDK defaults.




