### PR TITLE
Enable stable Android concurrent BTC payments e2e test

### DIFF
--- a/.github/workflows/sdk-e2e.yaml
+++ b/.github/workflows/sdk-e2e.yaml
@@ -306,7 +306,7 @@ jobs:
           # Temporarily disabled: repeated CI failures and local flaky repros.
           # - org.rgblightningnode.RestartTest
           # - org.rgblightningnode.MultiOpenCloseTest
-          # - org.rgblightningnode.ConcurrentBtcPaymentsTest
+          - org.rgblightningnode.ConcurrentBtcPaymentsTest
           # - org.rgblightningnode.SwapRoundtripBuyTest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Re-enables `org.rgblightningnode.ConcurrentBtcPaymentsTest` in the Android E2E CI matrix.

## Validation

- Ran `ConcurrentBtcPaymentsTest` locally on Android emulator `Pixel_API_34`.
- Repeated 10 runs with clean regtest restart before each run.
- Result: 10/10 passed.

## Notes

Other disabled Android E2E tests remain disabled:
- `RestartTest`: tracked separately as a restart/unlock persistence issue #771 https://github.com/UTEXO-Protocol/project-tasks/issues/771
- `MultiOpenCloseTest` and `SwapRoundtripBuyTest`:  blocked by https://github.com/UTEXO-Protocol/rgb-lightning-node/issues/28

