### PR TITLE
Expose VSS config in UniFFI SDK init and build SDK artifacts with vss

### DIFF
--- a/.github/workflows/release-sdk.yaml
+++ b/.github/workflows/release-sdk.yaml
@@ -110,7 +110,7 @@ jobs:
           bindgen --version
 
       - name: Build host cdylib with external signer API
-        run: cargo build --release --features "uniffi,vls" --lib
+        run: cargo build --release --features "uniffi,vls,vss" --lib
 
       - name: Generate Kotlin Android bindings
         run: ./scripts/ci/uniffi_generate_from_library.sh kotlin target/uniffi/kotlin-android target/release/librgb_lightning_node.so uniffi-android.toml
@@ -215,10 +215,10 @@ jobs:
           export BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_ios="--sysroot=${IOS_SYSROOT}"
           export BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_ios_sim="--sysroot=${SIM_SYSROOT}"
           export BINDGEN_EXTRA_CLANG_ARGS_x86_64_apple_ios="--sysroot=${SIM_SYSROOT}"
-          cargo build --release --features "uniffi,vls" --lib
-          cargo build --release --features "uniffi,vls" --lib --target aarch64-apple-ios
-          cargo build --release --features "uniffi,vls" --lib --target aarch64-apple-ios-sim
-          cargo build --release --features "uniffi,vls" --lib --target x86_64-apple-ios
+          cargo build --release --features "uniffi,vls,vss" --lib
+          cargo build --release --features "uniffi,vls,vss" --lib --target aarch64-apple-ios
+          cargo build --release --features "uniffi,vls,vss" --lib --target aarch64-apple-ios-sim
+          cargo build --release --features "uniffi,vls,vss" --lib --target x86_64-apple-ios
 
       - name: Generate Swift bindings
         run: ./scripts/ci/uniffi_generate_from_library.sh swift target/uniffi/swift target/release/librgb_lightning_node.dylib

--- a/.github/workflows/sdk-e2e.yaml
+++ b/.github/workflows/sdk-e2e.yaml
@@ -36,7 +36,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build Python UniFFI library
-        run: cargo build --release --features uniffi --lib
+        run: cargo build --release --features uniffi,vss --lib
 
       - name: Generate Python bindings
         run: ./scripts/ci/uniffi_generate_python.sh

--- a/.github/workflows/uniffi-artifacts.yaml
+++ b/.github/workflows/uniffi-artifacts.yaml
@@ -28,7 +28,7 @@ jobs:
           rustflags: ""
 
       - name: Run library-only test suite
-        run: cargo test --features "uniffi,test-utils" --test lib_core
+        run: cargo test --features "uniffi,vss,test-utils" --test lib_core
 
   kotlin-jvm:
     name: Kotlin JVM (Linux host)
@@ -47,7 +47,7 @@ jobs:
           rustflags: ""
 
       - name: Build host cdylib
-        run: cargo build --release --features uniffi --lib
+        run: cargo build --release --features uniffi,vss --lib
 
       - name: Generate Kotlin bindings
         run: ./scripts/ci/uniffi_generate_kotlin.sh
@@ -195,9 +195,9 @@ jobs:
           export BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_ios="--sysroot=${IOS_SYSROOT}"
           export BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_ios_sim="--sysroot=${SIM_SYSROOT}"
           export BINDGEN_EXTRA_CLANG_ARGS_x86_64_apple_ios="--sysroot=${SIM_SYSROOT}"
-          cargo build --release --features uniffi --lib --target aarch64-apple-ios
-          cargo build --release --features uniffi --lib --target aarch64-apple-ios-sim
-          cargo build --release --features uniffi --lib --target x86_64-apple-ios
+          cargo build --release --features uniffi,vss --lib --target aarch64-apple-ios
+          cargo build --release --features uniffi,vss --lib --target aarch64-apple-ios-sim
+          cargo build --release --features uniffi,vss --lib --target x86_64-apple-ios
 
       - name: Generate Swift bindings
         run: ./scripts/ci/uniffi_generate_swift.sh

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -531,6 +531,9 @@ dictionary SdkInitRequest {
     sequence<PublicKey>? virtual_peer_pubkeys;
     string? lsp_base_url;
     string? lsp_bearer_token;
+    string? vss_url = null;
+    boolean vss_allow_http = false;
+    boolean vss_allow_empty_restore = false;
 };
 
 dictionary SdkUnlockRequest {

--- a/src/test/lib_sdk/helpers.rs
+++ b/src/test/lib_sdk/helpers.rs
@@ -233,6 +233,9 @@ pub(crate) fn make_node(
         virtual_peer_pubkeys: None,
         lsp_base_url: None,
         lsp_bearer_token: None,
+        vss_url: None,
+        vss_allow_http: false,
+        vss_allow_empty_restore: false,
     })
     .expect("create SDK node")
 }

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -35,6 +35,16 @@ fn network_from_str(network: &str) -> Result<rgb_lib::BitcoinNetwork, RlnError> 
 
 fn handle_from_request(request: SdkInitRequest) -> Result<NodeHandle, RlnError> {
     let network = network_from_str(&request.network)?;
+    if let Some(url) = &request.vss_url {
+        #[cfg(feature = "vss")]
+        crate::utils::validate_vss_url(url, request.vss_allow_http)
+            .map_err(|_| RlnError::InvalidRequest)?;
+        #[cfg(not(feature = "vss"))]
+        {
+            let _ = url;
+            return Err(RlnError::InvalidRequest);
+        }
+    }
     let config = NodeConfig {
         storage_dir_path: std::path::PathBuf::from(request.storage_dir_path),
         daemon_listening_port: request.daemon_listening_port,
@@ -46,8 +56,8 @@ fn handle_from_request(request: SdkInitRequest) -> Result<NodeHandle, RlnError> 
         virtual_peer_pubkeys: request.virtual_peer_pubkeys.unwrap_or_default(),
         lsp_base_url: request.lsp_base_url,
         lsp_bearer_token: request.lsp_bearer_token,
-        vss_url: None,
-        vss_allow_empty_restore: false,
+        vss_url: request.vss_url,
+        vss_allow_empty_restore: request.vss_allow_empty_restore,
     };
     block_on_app(NodeHandle::new(config))
 }

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -309,4 +309,23 @@ mod uniffi_smoke_tests {
         assert_eq!(mapped.preimage, expected_preimage);
         assert!(matches!(mapped.payment_type, PaymentType::InboundHodl));
     }
+
+    #[test]
+    fn sdk_create_rejects_invalid_vss_url() {
+        let res = SdkNode::create(SdkInitRequest {
+            storage_dir_path: "/tmp/rln_vss_validation_test".to_string(),
+            daemon_listening_port: 3001,
+            ldk_peer_listening_port: 9735,
+            network: "regtest".to_string(),
+            max_media_upload_size_mb: 1,
+            enable_virtual_channels_v0: None,
+            virtual_peer_pubkeys: None,
+            lsp_base_url: None,
+            lsp_bearer_token: None,
+            vss_url: Some("http://example.com/vss".to_string()),
+            vss_allow_http: false,
+            vss_allow_empty_restore: false,
+        });
+        assert!(matches!(res, Err(RlnError::InvalidRequest)));
+    }
 }

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -624,6 +624,9 @@ pub struct SdkInitRequest {
     pub virtual_peer_pubkeys: Option<Vec<PublicKey>>,
     pub lsp_base_url: Option<String>,
     pub lsp_bearer_token: Option<String>,
+    pub vss_url: Option<String>,
+    pub vss_allow_http: bool,
+    pub vss_allow_empty_restore: bool,
 }
 
 pub struct SendRgbRequest {


### PR DESCRIPTION
# Expose VSS cloud backup through the UniFFI SDK

VSS cloud backup already works on the node, but only via the standalone binary's CLI flags. The UniFFI SDK hard-coded VSS to "off", so apps embedding the node could never enable it.

This PR lets the SDK init accept the VSS settings (server URL plus the existing safety options) and passes them to the node. The new fields are optional with defaults, so current callers are unaffected. If a VSS URL is given but the build lacks VSS support, the SDK now fails with a clear error instead of silently ignoring it. The SDK artifacts are also built with the VSS feature so the shipped SDK actually includes the backup functionality.

Standalone-binary behavior is unchanged. Surfacing the option in the downstream Node bindings and TypeScript SDK is follow-up work.
