### PR TITLE
Feat/UniFFI apay new

### DIFF
--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -116,6 +116,8 @@ interface SdkNode {
     InflateResponse inflate(InflateRequest request);
     [Throws=RlnError]
     SendRgbResponse send_rgb(SendRgbRequest request);
+    [Throws=RlnError]
+    AsyncOrderNewResponse apay_new(string host_node_id);
 };
 
 [Error]
@@ -770,6 +772,26 @@ enum AssignmentKind {
     "InflationRight",
     "ReplaceRight",
     "Any",
+};
+
+dictionary AsyncOrderNewHashWire {
+    u64 hash_index;
+    string payment_hash;
+};
+
+dictionary AsyncOrderNewResponse {
+    string request_id;
+    string host_node_id;
+    u64 protocol_version;
+    string order_id;
+    string status;
+    u64 accepted_through_index;
+    u64 next_index_expected;
+    u64 unused_hashes;
+    u64 refill_batch_size;
+    u64 first_hash_index;
+    u64 last_hash_index;
+    sequence<AsyncOrderNewHashWire> hashes;
 };
 
 [Custom]

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -99,9 +99,9 @@ struct AsyncOrderEnvelope {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct AsyncOrderNewHashWire {
-    pub(crate) hash_index: u64,
-    pub(crate) payment_hash: String,
+pub struct AsyncOrderNewHashWire {
+    pub hash_index: u64,
+    pub payment_hash: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/core_types.rs
+++ b/src/core_types.rs
@@ -9,7 +9,7 @@ pub(crate) const HTLC_MIN_MSAT: u64 = 3_000_000;
 pub(crate) const MAX_SWAP_FEE_MSAT: u64 = HTLC_MIN_MSAT;
 pub(crate) const DEFAULT_FINAL_CLTV_EXPIRY_DELTA: u32 = 14;
 
-pub(crate) mod async_order {
+pub mod async_order {
     use crate::async_order::{AsyncOrderNewHashWire, AsyncOrderRequestInvoiceParamsWire};
     use serde::{Deserialize, Serialize};
 
@@ -19,19 +19,19 @@ pub(crate) mod async_order {
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
-    pub(crate) struct AsyncOrderNewResponse {
-        pub(crate) request_id: String,
-        pub(crate) host_node_id: String,
-        pub(crate) protocol_version: u64,
-        pub(crate) order_id: String,
-        pub(crate) status: String,
-        pub(crate) accepted_through_index: u64,
-        pub(crate) next_index_expected: u64,
-        pub(crate) unused_hashes: u64,
-        pub(crate) refill_batch_size: u64,
-        pub(crate) first_hash_index: u64,
-        pub(crate) last_hash_index: u64,
-        pub(crate) hashes: Vec<AsyncOrderNewHashWire>,
+    pub struct AsyncOrderNewResponse {
+        pub request_id: String,
+        pub host_node_id: String,
+        pub protocol_version: u64,
+        pub order_id: String,
+        pub status: String,
+        pub accepted_through_index: u64,
+        pub next_index_expected: u64,
+        pub unused_hashes: u64,
+        pub refill_batch_size: u64,
+        pub first_hash_index: u64,
+        pub last_hash_index: u64,
+        pub hashes: Vec<AsyncOrderNewHashWire>,
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod state;
 mod types;
 
-use std::str::FromStr;
-
+use crate::async_order::AsyncOrderNewHashWire;
+use crate::core_types::async_order::{AsyncOrderNewRequest, AsyncOrderNewResponse};
 use crate::sdk;
 use crate::{NodeConfig, NodeHandle};
 use bitcoin::hex::DisplayHex;
@@ -12,6 +12,7 @@ use state::{
     is_uniffi_app_state_initialized, set_uniffi_node_handle,
 };
 pub(crate) use state::{clear_uniffi_app_state, set_uniffi_app_state};
+use std::str::FromStr;
 pub use types::*;
 
 pub fn uniffi_healthcheck() -> String {
@@ -1335,6 +1336,15 @@ impl SdkNode {
     pub fn send_rgb(&self, request: SendRgbRequest) -> Result<SendRgbResponse, RlnError> {
         send_rgb_from_state(self.handle.app_state(), request)
     }
+
+    pub fn apay_new(&self, host_node_id: String) -> Result<AsyncOrderNewResponse, RlnError> {
+        let state = self.handle.app_state();
+        let response = block_on_sdk(sdk::async_order_new(
+            state,
+            AsyncOrderNewRequest { host_node_id },
+        ))?;
+        Ok(response)
+    }
 }
 
 pub fn sdk_initialize(request: SdkInitRequest) -> Result<(), RlnError> {
@@ -1508,6 +1518,11 @@ pub fn sdk_inflate(request: InflateRequest) -> Result<InflateResponse, RlnError>
 pub fn sdk_send_rgb(request: SendRgbRequest) -> Result<SendRgbResponse, RlnError> {
     let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
     SdkNode { handle }.send_rgb(request)
+}
+
+pub fn sdk_apay_new(host_node_id: String) -> Result<AsyncOrderNewResponse, RlnError> {
+    let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
+    SdkNode { handle }.apay_new(host_node_id)
 }
 
 uniffi::include_scaffolding!("rgb_lightning_node");


### PR DESCRIPTION
Add UniFFI `apay_new` support for creating new async payment orders from mobile integrations.