### PR TITLE
adjust dockerfile and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,8 @@
 !regtest.sh
 !rust-lightning/
 !src/
+!migration/
+!build.rs
 
 # but still ignore these
 rust-lightning/.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 FROM rust:1.91-slim-trixie AS builder
 
+WORKDIR /app
 COPY . .
 
-RUN cargo build --release
+RUN apt-get update && apt install -y --no-install-recommends \
+    pkg-config libssl-dev ca-certificates \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN cargo build --release --locked
 
 
 FROM debian:trixie-slim
 
-COPY --from=builder ./target/release/rgb-lightning-node /usr/bin/rgb-lightning-node
+COPY --from=builder /app/target/release/rgb-lightning-node /usr/bin/rgb-lightning-node
 
 RUN apt-get update && apt install -y --no-install-recommends \
     ca-certificates openssl \


### PR DESCRIPTION
1. Update `.dockerignore` to whitelist `migration/` and `build.rs`.
2. In the `Dockerfile` build phase, we need to add `apt install pkg-config libssl-dev ca-certificates`.
Note: I verified that it builds successfully with these packages, but we might be able to trim them down later.