### PR TITLE
Support Async Payment Hash Substitution Resistance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,7 +5150,7 @@ dependencies = [
 [[package]]
 name = "signer-external"
 version = "0.1.0-alpha"
-source = "git+https://github.com/UTEXO-Protocol/rln-external-signer.git?branch=main#780e881711499e6717c7b6ab0408ab3c641c86d2"
+source = "git+https://github.com/UTEXO-Protocol/rln-external-signer.git?branch=main#168faab43779f944d1b7e9ed85b47d463cf44ab0"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -120,6 +120,8 @@ interface SdkNode {
     SendRgbResponse send_rgb(SendRgbRequest request);
     [Throws=RlnError]
     AsyncOrderNewResponse apay_new(string host_node_id);
+    [Throws=RlnError]
+    AsyncOrderNewResponse apay_new_with_address(string host_node_id, string username, string domain);
 };
 
 [Error]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1243,10 +1243,27 @@ components:
       type: object
       required:
         - host_node_id
+      dependentRequired:
+        username:
+          - domain
+        domain:
+          - username
       properties:
         host_node_id:
           type: string
           example: 02123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0
+        username:
+          type: string
+          description: >-
+            Optional. LSP-assigned Lightning Address localpart. When supplied together with `domain`,
+            the recipient signs a `recipient_pubkey <-> username@domain` address attestation and includes it with the order.
+            Source it from the LSP's `GET /lightning_address/by_pubkey/{pubkey}` so it matches what the LSP serves.
+          example: xalkan
+        domain:
+          type: string
+          description: >-
+            Optional. Lightning Address domain; required together with `username` to produce the address attestation.
+          example: utexo.com
     AsyncOrderNewResponse:
       type: object
       required:

--- a/src/apay_merkle.rs
+++ b/src/apay_merkle.rs
@@ -1,0 +1,191 @@
+#![allow(dead_code)]
+
+use bitcoin::hashes::{sha256, Hash};
+
+pub(crate) const APAY_HASH_LEAF_TAG: &[u8] = b"UTEXO_APAY_HASH_V1";
+pub(crate) const MERKLE_LEAF_PREFIX: u8 = 0x00;
+pub(crate) const MERKLE_NODE_PREFIX: u8 = 0x01;
+
+pub(crate) type Hash32 = [u8; 32];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum MerkleSide {
+    Left,
+    Right,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct MerkleProofElement {
+    pub(crate) sibling: Hash32,
+    pub(crate) side: MerkleSide,
+}
+
+fn digest(data: &[u8]) -> Hash32 {
+    sha256::Hash::hash(data).to_byte_array()
+}
+
+pub(crate) fn leaf_hash(
+    recipient_pubkey: &[u8; 33],
+    batch_id: &[u8; 16],
+    hash_index: u64,
+    payment_hash: &[u8; 32],
+) -> Hash32 {
+    let mut data = Vec::with_capacity(1 + APAY_HASH_LEAF_TAG.len() + 33 + 16 + 8 + 32);
+    data.push(MERKLE_LEAF_PREFIX);
+    data.extend_from_slice(APAY_HASH_LEAF_TAG);
+    data.extend_from_slice(recipient_pubkey);
+    data.extend_from_slice(batch_id);
+    data.extend_from_slice(&hash_index.to_be_bytes());
+    data.extend_from_slice(payment_hash);
+    digest(&data)
+}
+
+pub(crate) fn node_hash(left: &Hash32, right: &Hash32) -> Hash32 {
+    let mut data = Vec::with_capacity(1 + 32 + 32);
+    data.push(MERKLE_NODE_PREFIX);
+    data.extend_from_slice(left);
+    data.extend_from_slice(right);
+    digest(&data)
+}
+
+fn next_level(level: &[Hash32]) -> Vec<Hash32> {
+    let mut next = Vec::with_capacity(level.len().div_ceil(2));
+    let mut i = 0;
+    while i < level.len() {
+        let left = &level[i];
+        let right = if i + 1 < level.len() {
+            &level[i + 1]
+        } else {
+            &level[i]
+        };
+        next.push(node_hash(left, right));
+        i += 2;
+    }
+    next
+}
+
+pub(crate) fn root(leaves: &[Hash32]) -> Hash32 {
+    assert!(!leaves.is_empty(), "merkle root over empty leaf set");
+    let mut level = leaves.to_vec();
+    while level.len() > 1 {
+        level = next_level(&level);
+    }
+    level[0]
+}
+
+pub(crate) fn proof(leaves: &[Hash32], index: usize) -> Vec<MerkleProofElement> {
+    assert!(index < leaves.len(), "merkle proof index out of range");
+    let mut out = Vec::new();
+    let mut level = leaves.to_vec();
+    let mut idx = index;
+    while level.len() > 1 {
+        let element = if idx.is_multiple_of(2) {
+            let sibling = if idx + 1 < level.len() {
+                level[idx + 1]
+            } else {
+                level[idx]
+            };
+            MerkleProofElement {
+                sibling,
+                side: MerkleSide::Right,
+            }
+        } else {
+            MerkleProofElement {
+                sibling: level[idx - 1],
+                side: MerkleSide::Left,
+            }
+        };
+        out.push(element);
+        level = next_level(&level);
+        idx /= 2;
+    }
+    out
+}
+
+pub(crate) fn verify(leaf: &Hash32, proof: &[MerkleProofElement], expected_root: &Hash32) -> bool {
+    let mut current = *leaf;
+    for element in proof {
+        current = match element.side {
+            MerkleSide::Left => node_hash(&element.sibling, &current),
+            MerkleSide::Right => node_hash(&current, &element.sibling),
+        };
+    }
+    &current == expected_root
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h32(s: &str) -> Hash32 {
+        let bytes: Vec<u8> = (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).expect("valid hex"))
+            .collect();
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&bytes);
+        out
+    }
+
+    fn fixture() -> Vec<Hash32> {
+        let mut recipient_pubkey = [0x11u8; 33];
+        recipient_pubkey[0] = 0x02;
+        let mut batch_id = [0u8; 16];
+        for (i, b) in batch_id.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        (1u64..=5)
+            .map(|i| leaf_hash(&recipient_pubkey, &batch_id, i, &[i as u8; 32]))
+            .collect()
+    }
+
+    #[test]
+    fn root_matches_reference_vector() {
+        let leaves = fixture();
+        assert_eq!(leaves.len(), 5);
+        assert_eq!(
+            leaves[0],
+            h32("eabd11aa1b47ea65fa1c5a7cd7992dcaf9f0725ced14eabfebd20a697e8c08a9")
+        );
+        assert_eq!(
+            leaves[4],
+            h32("2a583c0c4ee4b0d8d985970116b8035830556eac01a123c0151f8d8dd9fa83fe")
+        );
+        assert_eq!(
+            root(&leaves),
+            h32("2a89ca7e910bae70bc3f03f0252ec22de83cc40a5b4ba1582b649be5ea667132")
+        );
+    }
+
+    #[test]
+    fn proof_roundtrips_and_matches_reference() {
+        let leaves = fixture();
+        let r = root(&leaves);
+
+        let p0 = proof(&leaves, 0);
+        assert_eq!(p0.len(), 3);
+        assert!(verify(&leaves[0], &p0, &r));
+        assert_eq!(
+            p0[0].sibling,
+            h32("7659a406e2a812a5ed733169fdccf6c02cef92e078c93c11a5332aa654061847")
+        );
+        assert_eq!(p0[0].side, MerkleSide::Right);
+
+        let p4 = proof(&leaves, 4);
+        assert!(verify(&leaves[4], &p4, &r));
+        assert_eq!(p4[0].sibling, leaves[4]);
+        assert_eq!(p4[0].side, MerkleSide::Right);
+        assert_eq!(p4[2].side, MerkleSide::Left);
+
+        let mut bad = leaves[0];
+        bad[0] ^= 0x01;
+        assert!(!verify(&bad, &p0, &r));
+    }
+
+    #[test]
+    fn single_leaf_root_is_leaf() {
+        let leaves = vec![fixture()[0]];
+        assert_eq!(root(&leaves), leaves[0]);
+        assert!(proof(&leaves, 0).is_empty());
+    }
+}

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -1704,13 +1704,13 @@ fn validate_async_payments_next_hash_index(next_index: u64) -> Result<(), JsonRp
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::kv_store::test_support::MemoryKvStore;
     use crate::utils::new_jsonrpc_request_id;
     use axum::{extract::Json, http::StatusCode, routing::post, Router};
     use bitcoin::secp256k1::{Secp256k1, SecretKey};
-    use std::collections::HashMap as StdHashMap;
     use std::str::FromStr;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex as StdMutex};
+    use std::sync::Arc;
     use std::time::Duration;
     use tokio::net::TcpListener;
     use tokio::time::sleep;
@@ -1739,81 +1739,6 @@ mod tests {
         ) -> Result<AsyncOrderOutboundInvoiceResultWire, JsonRpcErrorWire> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(self.result.clone())
-        }
-    }
-
-    #[derive(Default)]
-    struct MemoryKvStore {
-        entries: StdMutex<StdHashMap<(String, String, String), Vec<u8>>>,
-    }
-
-    impl KVStoreSync for MemoryKvStore {
-        fn read(
-            &self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-            key: &str,
-        ) -> Result<Vec<u8>, io::Error> {
-            self.entries
-                .lock()
-                .unwrap()
-                .get(&(
-                    primary_namespace.to_owned(),
-                    secondary_namespace.to_owned(),
-                    key.to_owned(),
-                ))
-                .cloned()
-                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "missing key"))
-        }
-
-        fn write(
-            &self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-            key: &str,
-            buf: Vec<u8>,
-        ) -> Result<(), io::Error> {
-            self.entries.lock().unwrap().insert(
-                (
-                    primary_namespace.to_owned(),
-                    secondary_namespace.to_owned(),
-                    key.to_owned(),
-                ),
-                buf,
-            );
-            Ok(())
-        }
-
-        fn remove(
-            &self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-            key: &str,
-            _lazy: bool,
-        ) -> Result<(), io::Error> {
-            self.entries.lock().unwrap().remove(&(
-                primary_namespace.to_owned(),
-                secondary_namespace.to_owned(),
-                key.to_owned(),
-            ));
-            Ok(())
-        }
-
-        fn list(
-            &self,
-            primary_namespace: &str,
-            secondary_namespace: &str,
-        ) -> Result<Vec<String>, io::Error> {
-            Ok(self
-                .entries
-                .lock()
-                .unwrap()
-                .keys()
-                .filter(|(primary, secondary, _)| {
-                    primary == primary_namespace && secondary == secondary_namespace
-                })
-                .map(|(_, _, key)| key.clone())
-                .collect())
         }
     }
 

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -109,6 +109,183 @@ pub struct AsyncOrderNewHashWire {
 pub(crate) struct AsyncOrderNewParamsWire {
     pub(crate) protocol_version: u64,
     pub(crate) hashes: Vec<AsyncOrderNewHashWire>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) batch: Option<ApayBatchCommitmentWire>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) address_sig: Option<String>,
+}
+
+pub(crate) const APAY_BATCH_EXPIRY_SECS: u64 = 365 * 24 * 60 * 60;
+const APAY_BATCH_ID_TAG: &[u8] = b"UTEXO_APAY_BATCH_ID_V1";
+pub(crate) const APAY_HASH_BATCH_TAG: &[u8] = b"UTEXO_APAY_HASH_BATCH_V1";
+pub(crate) const APAY_LNADDR_TAG: &[u8] = b"UTEXO_APAY_LNADDR_V1";
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ApayBatchCommitmentWire {
+    pub(crate) host_pubkey: String,
+    pub(crate) batch_id: String,
+    pub(crate) batch_root: String,
+    pub(crate) batch_size: u64,
+    pub(crate) batch_sig: String,
+    pub(crate) created_at: u64,
+    pub(crate) expires_at: u64,
+}
+
+fn apay_hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn apay_decode_hex_fixed<const N: usize>(
+    field: &str,
+    s: &str,
+) -> Result<[u8; N], JsonRpcErrorWire> {
+    let s = s.trim();
+    if s.len() != 2 * N {
+        return Err(JsonRpcErrorWire::invalid_params(format!(
+            "{field} must be {N}-byte hex"
+        )));
+    }
+    let mut out = [0u8; N];
+    for (slot, pair) in out.iter_mut().zip(s.as_bytes().chunks_exact(2)) {
+        let high = apay_hex_nibble(pair[0]).ok_or_else(|| {
+            JsonRpcErrorWire::invalid_params(format!("{field} must be {N}-byte hex"))
+        })?;
+        let low = apay_hex_nibble(pair[1]).ok_or_else(|| {
+            JsonRpcErrorWire::invalid_params(format!("{field} must be {N}-byte hex"))
+        })?;
+        *slot = (high << 4) | low;
+    }
+    Ok(out)
+}
+
+pub(crate) fn apay_derive_batch_id(recipient_pubkey: &[u8; 33], start_index: u64) -> [u8; 16] {
+    let mut material = Vec::with_capacity(APAY_BATCH_ID_TAG.len() + recipient_pubkey.len() + 8);
+    material.extend_from_slice(APAY_BATCH_ID_TAG);
+    material.extend_from_slice(recipient_pubkey);
+    material.extend_from_slice(&start_index.to_be_bytes());
+    let digest = sha256::Hash::hash(&material).to_byte_array();
+    let mut id = [0u8; 16];
+    id.copy_from_slice(&digest[..16]);
+    id
+}
+
+pub(crate) fn apay_batch_root(
+    recipient_pubkey: &[u8; 33],
+    batch_id: &[u8; 16],
+    hashes: &[AsyncOrderNewHashWire],
+) -> Result<[u8; 32], JsonRpcErrorWire> {
+    if hashes.is_empty() {
+        return Err(JsonRpcErrorWire::invalid_hash_batch());
+    }
+    let mut leaves = Vec::with_capacity(hashes.len());
+    for entry in hashes {
+        let payment_hash = validate_and_parse_payment_hash(&entry.payment_hash)
+            .map_err(|_| JsonRpcErrorWire::invalid_params("invalid_payment_hash"))?;
+        leaves.push(crate::apay_merkle::leaf_hash(
+            recipient_pubkey,
+            batch_id,
+            entry.hash_index,
+            &payment_hash.0,
+        ));
+    }
+    Ok(crate::apay_merkle::root(&leaves))
+}
+
+pub(crate) fn apay_commit_bytes(
+    recipient_pubkey: &[u8; 33],
+    host_pubkey: &[u8; 33],
+    batch_id: &[u8; 16],
+    batch_root: &[u8; 32],
+    batch_size: u64,
+    created_at: u64,
+    expires_at: u64,
+) -> Vec<u8> {
+    let mut data = Vec::with_capacity(APAY_HASH_BATCH_TAG.len() + 33 + 33 + 16 + 32 + 24);
+    data.extend_from_slice(APAY_HASH_BATCH_TAG);
+    data.extend_from_slice(recipient_pubkey);
+    data.extend_from_slice(host_pubkey);
+    data.extend_from_slice(batch_id);
+    data.extend_from_slice(batch_root);
+    data.extend_from_slice(&batch_size.to_be_bytes());
+    data.extend_from_slice(&created_at.to_be_bytes());
+    data.extend_from_slice(&expires_at.to_be_bytes());
+    data
+}
+
+pub(crate) fn apay_attest_bytes(
+    recipient_pubkey: &[u8; 33],
+    domain: &str,
+    username: &str,
+    expires_at: u64,
+) -> Vec<u8> {
+    let mut data =
+        Vec::with_capacity(APAY_LNADDR_TAG.len() + 33 + domain.len() + username.len() + 8);
+    data.extend_from_slice(APAY_LNADDR_TAG);
+    data.extend_from_slice(recipient_pubkey);
+    data.extend_from_slice(domain.as_bytes());
+    data.extend_from_slice(username.as_bytes());
+    data.extend_from_slice(&expires_at.to_be_bytes());
+    data
+}
+
+pub(crate) fn build_apay_address_attestation<F>(
+    recipient_pubkey_hex: &str,
+    domain: &str,
+    username: &str,
+    expires_at: u64,
+    sign: F,
+) -> Result<String, JsonRpcErrorWire>
+where
+    F: FnOnce(&[u8]) -> Result<String, ()>,
+{
+    let recipient_pubkey = apay_decode_hex_fixed::<33>("recipient_pubkey", recipient_pubkey_hex)?;
+    let attest = apay_attest_bytes(&recipient_pubkey, domain, username, expires_at);
+    sign(&attest)
+        .map_err(|_| JsonRpcErrorWire::internal_error("apay_attest_sign_failed".to_owned()))
+}
+
+pub(crate) fn build_apay_batch_commitment<F>(
+    recipient_pubkey_hex: &str,
+    host_pubkey_hex: &str,
+    start_index: u64,
+    hashes: &[AsyncOrderNewHashWire],
+    created_at: u64,
+    expires_at: u64,
+    sign: F,
+) -> Result<ApayBatchCommitmentWire, JsonRpcErrorWire>
+where
+    F: FnOnce(&[u8]) -> Result<String, ()>,
+{
+    let recipient_pubkey = apay_decode_hex_fixed::<33>("recipient_pubkey", recipient_pubkey_hex)?;
+    let host_pubkey = apay_decode_hex_fixed::<33>("host_pubkey", host_pubkey_hex)?;
+    let batch_id = apay_derive_batch_id(&recipient_pubkey, start_index);
+    let batch_root = apay_batch_root(&recipient_pubkey, &batch_id, hashes)?;
+    let commit = apay_commit_bytes(
+        &recipient_pubkey,
+        &host_pubkey,
+        &batch_id,
+        &batch_root,
+        hashes.len() as u64,
+        created_at,
+        expires_at,
+    );
+    let batch_sig = sign(&commit)
+        .map_err(|_| JsonRpcErrorWire::internal_error("apay_batch_sign_failed".to_owned()))?;
+    Ok(ApayBatchCommitmentWire {
+        host_pubkey: hex_str(&host_pubkey),
+        batch_id: hex_str(&batch_id),
+        batch_root: hex_str(&batch_root),
+        batch_size: hashes.len() as u64,
+        batch_sig,
+        created_at,
+        expires_at,
+    })
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -323,6 +500,10 @@ struct AsyncOrderNewLspRequest {
     peer_pubkey: String,
     protocol_version: u64,
     hashes: Vec<AsyncOrderNewHashWire>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    batch: Option<ApayBatchCommitmentWire>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    address_sig: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -457,6 +638,8 @@ impl AsyncOrderLspClient {
             peer_pubkey: hex_str(&sender_node_id.serialize()),
             protocol_version: params.protocol_version,
             hashes: params.hashes,
+            batch: params.batch,
+            address_sig: params.address_sig,
         };
         let mut builder = self
             .client
@@ -667,6 +850,8 @@ impl AsyncPaymentsPreimageRoot {
         Ok(AsyncOrderNewParamsWire {
             protocol_version: PROTOCOL_VERSION,
             hashes,
+            batch: None,
+            address_sig: None,
         })
     }
 }
@@ -1719,6 +1904,8 @@ mod tests {
                             .to_owned(),
                 },
             ],
+            batch: None,
+            address_sig: None,
         }
     }
 
@@ -2644,5 +2831,147 @@ mod tests {
             err.message,
             "async_order_lsp_request_failed: POST /internal/async_order/new timed out"
         );
+    }
+}
+
+#[cfg(test)]
+mod apay_commit_tests {
+    use super::*;
+
+    fn recipient_pubkey() -> [u8; 33] {
+        apay_decode_hex_fixed::<33>("recipient_pubkey", &format!("02{}", "11".repeat(32))).unwrap()
+    }
+    fn host_pubkey() -> [u8; 33] {
+        apay_decode_hex_fixed::<33>("host_pubkey", &format!("03{}", "22".repeat(32))).unwrap()
+    }
+    fn batch_id() -> [u8; 16] {
+        apay_decode_hex_fixed::<16>("batch_id", "000102030405060708090a0b0c0d0e0f").unwrap()
+    }
+    fn fixture_hashes() -> Vec<AsyncOrderNewHashWire> {
+        (1u64..=5)
+            .map(|i| AsyncOrderNewHashWire {
+                hash_index: i,
+                payment_hash: hex_str(&[i as u8; 32]),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn batch_root_matches_reference() {
+        let root = apay_batch_root(&recipient_pubkey(), &batch_id(), &fixture_hashes()).unwrap();
+        assert_eq!(
+            hex_str(&root),
+            "2a89ca7e910bae70bc3f03f0252ec22de83cc40a5b4ba1582b649be5ea667132"
+        );
+    }
+
+    #[test]
+    fn batch_root_reports_invalid_payment_hash() {
+        let mut hashes = fixture_hashes();
+        hashes[0].payment_hash = "not-hex".to_owned();
+        let err = apay_batch_root(&recipient_pubkey(), &batch_id(), &hashes).unwrap_err();
+        assert_eq!(err.message, "invalid_payment_hash");
+    }
+
+    #[test]
+    fn commit_bytes_match_reference() {
+        let root = apay_batch_root(&recipient_pubkey(), &batch_id(), &fixture_hashes()).unwrap();
+        let commit = apay_commit_bytes(
+            &recipient_pubkey(),
+            &host_pubkey(),
+            &batch_id(),
+            &root,
+            5,
+            1_700_000_000,
+            0,
+        );
+        assert_eq!(
+            hex_str(&commit),
+            "555445584f5f415041595f484153485f42415443485f5631021111111111111111111111111111111111111111111111111111111111111111032222222222222222222222222222222222222222222222222222222222222222000102030405060708090a0b0c0d0e0f2a89ca7e910bae70bc3f03f0252ec22de83cc40a5b4ba1582b649be5ea6671320000000000000005000000006553f1000000000000000000"
+        );
+    }
+
+    #[test]
+    fn attest_bytes_match_reference() {
+        let attest = apay_attest_bytes(&recipient_pubkey(), "utexo.com", "alice", 0);
+        assert_eq!(
+            hex_str(&attest),
+            "555445584f5f415041595f4c4e414444525f5631021111111111111111111111111111111111111111111111111111111111111111757465786f2e636f6d616c6963650000000000000000"
+        );
+    }
+
+    #[test]
+    fn derive_batch_id_is_deterministic() {
+        let a = apay_derive_batch_id(&recipient_pubkey(), 1);
+        let b = apay_derive_batch_id(&recipient_pubkey(), 1);
+        let c = apay_derive_batch_id(&recipient_pubkey(), 2);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn build_commitment_signs_commit() {
+        let hashes = fixture_hashes();
+        let rp_hex = format!("02{}", "11".repeat(32));
+        let hp_hex = format!("03{}", "22".repeat(32));
+        let commitment =
+            build_apay_batch_commitment(&rp_hex, &hp_hex, 1, &hashes, 1_700_000_000, 0, |msg| {
+                Ok(hex_str(msg))
+            })
+            .unwrap();
+        let bid = apay_derive_batch_id(&recipient_pubkey(), 1);
+        let root = apay_batch_root(&recipient_pubkey(), &bid, &hashes).unwrap();
+        assert_eq!(commitment.batch_id, hex_str(&bid));
+        assert_eq!(commitment.batch_root, hex_str(&root));
+        assert_eq!(commitment.batch_size, 5);
+        let expected_commit = apay_commit_bytes(
+            &recipient_pubkey(),
+            &host_pubkey(),
+            &bid,
+            &root,
+            5,
+            1_700_000_000,
+            0,
+        );
+        assert_eq!(commitment.batch_sig, hex_str(&expected_commit));
+    }
+
+    #[test]
+    fn build_attestation_signs_attest() {
+        let rp_hex = format!("02{}", "11".repeat(32));
+        let sig = build_apay_address_attestation(&rp_hex, "utexo.com", "alice", 0, |msg| {
+            Ok(hex_str(msg))
+        })
+        .unwrap();
+        let expected = apay_attest_bytes(&recipient_pubkey(), "utexo.com", "alice", 0);
+        assert_eq!(sig, hex_str(&expected));
+    }
+
+    #[test]
+    fn build_commitment_reports_invalid_pubkey_field() {
+        let hashes = fixture_hashes();
+        let hp_hex = format!("03{}", "22".repeat(32));
+        let err = build_apay_batch_commitment("02", &hp_hex, 1, &hashes, 1_700_000_000, 0, |_| {
+            Ok(String::new())
+        })
+        .unwrap_err();
+        assert_eq!(err.message, "recipient_pubkey must be 33-byte hex");
+
+        let rp_hex = format!("02{}", "11".repeat(32));
+        let err =
+            build_apay_batch_commitment(&rp_hex, "not-hex", 1, &hashes, 1_700_000_000, 0, |_| {
+                Ok(String::new())
+            })
+            .unwrap_err();
+        assert_eq!(err.message, "host_pubkey must be 33-byte hex");
+    }
+
+    #[test]
+    fn build_attestation_reports_invalid_recipient_pubkey() {
+        let err = build_apay_address_attestation("not-hex", "utexo.com", "alice", 0, |_| {
+            Ok(String::new())
+        })
+        .unwrap_err();
+        assert_eq!(err.message, "recipient_pubkey must be 33-byte hex");
     }
 }

--- a/src/core_types.rs
+++ b/src/core_types.rs
@@ -18,6 +18,10 @@ pub mod async_order {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub(crate) struct AsyncOrderNewRequest {
         pub(crate) host_node_id: String,
+        #[serde(default)]
+        pub(crate) username: Option<String>,
+        #[serde(default)]
+        pub(crate) domain: Option<String>,
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/kv_store.rs
+++ b/src/kv_store.rs
@@ -178,3 +178,86 @@ impl KVStoreSync for SeaOrmKvStore {
         Ok(keys)
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::{collections::HashMap, sync::Mutex};
+
+    use bitcoin::io;
+    use lightning::util::persist::KVStoreSync;
+
+    #[derive(Default)]
+    pub(crate) struct MemoryKvStore {
+        entries: Mutex<HashMap<(String, String, String), Vec<u8>>>,
+    }
+
+    impl KVStoreSync for MemoryKvStore {
+        fn read(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+        ) -> Result<Vec<u8>, io::Error> {
+            self.entries
+                .lock()
+                .unwrap()
+                .get(&(
+                    primary_namespace.to_owned(),
+                    secondary_namespace.to_owned(),
+                    key.to_owned(),
+                ))
+                .cloned()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "missing key"))
+        }
+
+        fn write(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            buf: Vec<u8>,
+        ) -> Result<(), io::Error> {
+            self.entries.lock().unwrap().insert(
+                (
+                    primary_namespace.to_owned(),
+                    secondary_namespace.to_owned(),
+                    key.to_owned(),
+                ),
+                buf,
+            );
+            Ok(())
+        }
+
+        fn remove(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+            key: &str,
+            _lazy: bool,
+        ) -> Result<(), io::Error> {
+            self.entries.lock().unwrap().remove(&(
+                primary_namespace.to_owned(),
+                secondary_namespace.to_owned(),
+                key.to_owned(),
+            ));
+            Ok(())
+        }
+
+        fn list(
+            &self,
+            primary_namespace: &str,
+            secondary_namespace: &str,
+        ) -> Result<Vec<String>, io::Error> {
+            Ok(self
+                .entries
+                .lock()
+                .unwrap()
+                .keys()
+                .filter(|(primary, secondary, _)| {
+                    primary == primary_namespace && secondary == secondary_namespace
+                })
+                .map(|(_, _, key)| key.clone())
+                .collect())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
+mod apay_merkle;
 mod args;
 mod async_order;
 mod auth;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod apay_merkle;
 mod args;
 mod async_order;
 mod auth;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -71,9 +71,8 @@ use tokio::{
 };
 
 use crate::async_order::{
-    read_async_payments_next_hash_index, write_async_payments_next_hash_index,
-    AsyncOrderNewParamsWire, AsyncOrderNewResultWire, AsyncOrderOutboundInvoiceResultWire,
-    ASYNC_ORDER_MAX_HASH_BATCH_SIZE, ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
+    write_async_payments_next_hash_index, AsyncOrderNewResultWire,
+    AsyncOrderOutboundInvoiceResultWire, ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
 };
 use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
@@ -1493,39 +1492,7 @@ pub(crate) async fn async_order_new(
         )));
     }
 
-    let start_index =
-        read_async_payments_next_hash_index(unlocked_state.kv_store.as_ref(), &host_node_id)
-            .map_err(|err| APIError::Unexpected(err.message))?;
-    let params = if unlocked_state.external_signer_mode {
-        let external_signer = unlocked_state
-            .external_signer
-            .as_ref()
-            .ok_or_else(|| APIError::Unexpected("external signer missing".to_string()))?;
-        let hashes = external_signer
-            .prepare_async_payments_hashes(
-                hex_str(&host_node_id.serialize()),
-                start_index,
-                ASYNC_ORDER_MAX_HASH_BATCH_SIZE as u32,
-            )
-            .map_err(|e| APIError::ExternalSignerProtocolError(e.to_string()))?;
-        AsyncOrderNewParamsWire {
-            protocol_version: 1,
-            hashes: hashes
-                .into_iter()
-                .map(|entry| crate::async_order::AsyncOrderNewHashWire {
-                    hash_index: entry.hash_index,
-                    payment_hash: entry.payment_hash_hex,
-                })
-                .collect(),
-            batch: None,
-            address_sig: None,
-        }
-    } else {
-        unlocked_state
-            .async_payments_preimage_root
-            .prepare_async_order_new_params(start_index, ASYNC_ORDER_MAX_HASH_BATCH_SIZE)
-            .map_err(|err| APIError::InvalidRequest(err.message))?
-    };
+    let params = unlocked_state.prepare_apay_order_params(&host_node_id)?;
     let hashes = params.hashes.clone();
     let first_hash_index = hashes
         .first()

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1517,6 +1517,8 @@ pub(crate) async fn async_order_new(
                     payment_hash: entry.payment_hash_hex,
                 })
                 .collect(),
+            batch: None,
+            address_sig: None,
         }
     } else {
         unlocked_state
@@ -1533,6 +1535,15 @@ pub(crate) async fn async_order_new(
         .last()
         .map(|entry| entry.hash_index)
         .expect("validated async_order.new hash batch is non-empty");
+
+    let params = unlocked_state.attach_apay_signatures(
+        params,
+        &hex_str(&host_node_id.serialize()),
+        first_hash_index,
+        payload.username.as_deref(),
+        payload.domain.as_deref(),
+    )?;
+
     let request_id = new_jsonrpc_request_id();
 
     let response_rx = unlocked_state

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -2,9 +2,8 @@
 // If route-level business logic changes, keep SDK equivalents in sync.
 
 use crate::async_order::{
-    read_async_payments_next_hash_index, write_async_payments_next_hash_index,
-    AsyncOrderNewResultWire, AsyncOrderOutboundInvoiceResultWire, ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
-    ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
+    write_async_payments_next_hash_index, AsyncOrderNewResultWire,
+    AsyncOrderOutboundInvoiceResultWire, ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
 };
 use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
@@ -1167,14 +1166,7 @@ pub(crate) async fn async_order_new(
         )));
     }
 
-    let params = unlocked_state
-        .async_payments_preimage_root
-        .prepare_async_order_new_params(
-            read_async_payments_next_hash_index(unlocked_state.kv_store.as_ref(), &host_node_id)
-                .map_err(|err| APIError::Unexpected(err.message))?,
-            ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
-        )
-        .map_err(|err| APIError::InvalidRequest(err.message))?;
+    let params = unlocked_state.prepare_apay_order_params(&host_node_id)?;
     let hashes = params.hashes.clone();
     let first_hash_index = hashes
         .first()

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1184,6 +1184,15 @@ pub(crate) async fn async_order_new(
         .last()
         .map(|entry| entry.hash_index)
         .expect("validated async_order.new hash batch is non-empty");
+
+    let params = unlocked_state.attach_apay_signatures(
+        params,
+        &crate::utils::hex_str(&host_node_id.serialize()),
+        first_hash_index,
+        request.username.as_deref(),
+        request.domain.as_deref(),
+    )?;
+
     let request_id = new_jsonrpc_request_id();
 
     let response_rx = unlocked_state

--- a/src/signer/external.rs
+++ b/src/signer/external.rs
@@ -35,6 +35,144 @@ use super::vls_adapter::{ExternalSignerBackend, VlsSignerAdapter};
 use super::RlnEntropySource;
 use super::RlnKeysInterface;
 
+const ZBASE32_ALPHABET: &[u8; 32] = b"ybndrfg8ejkmcpqxot1uwisza345h769";
+
+fn zbase32_encode(data: &[u8]) -> String {
+    let mut out = String::with_capacity((data.len() * 8).div_ceil(5));
+    let mut bit_buffer = 0u16;
+    let mut pending_bits = 0u8;
+
+    for byte in data {
+        bit_buffer = (bit_buffer << 8) | u16::from(*byte);
+        pending_bits += 8;
+        while pending_bits >= 5 {
+            pending_bits -= 5;
+            let alphabet_index = ((bit_buffer >> pending_bits) & 0x1f) as usize;
+            out.push(ZBASE32_ALPHABET[alphabet_index] as char);
+        }
+    }
+
+    if pending_bits > 0 {
+        let alphabet_index = ((bit_buffer << (5 - pending_bits)) & 0x1f) as usize;
+        out.push(ZBASE32_ALPHABET[alphabet_index] as char);
+    }
+
+    out
+}
+
+fn ln_signed_message_from_compact(signature_hex: &str, recovery_id: u8) -> Result<String, ()> {
+    RecoveryId::from_i32(i32::from(recovery_id)).map_err(|_| ())?;
+    let compact_signature = Vec::<u8>::from_hex(signature_hex).map_err(|_| ())?;
+    if compact_signature.len() != 64 {
+        return Err(());
+    }
+
+    let mut recoverable_signature = Vec::with_capacity(65);
+    recoverable_signature.push(31 + recovery_id);
+    recoverable_signature.extend_from_slice(&compact_signature);
+    Ok(zbase32_encode(&recoverable_signature))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::hashes::{sha256d, Hash};
+    use bitcoin::secp256k1::{Message, Secp256k1, SecretKey};
+    use std::sync::Mutex;
+
+    use crate::signer::proto::{decode_signer_request, encode_signer_response};
+    use crate::signer::transport::ExternalSignerTransport;
+    use crate::signer::vls_adapter::VlsSignerAdapter;
+
+    struct RawMessageTransport {
+        signature_hex: String,
+        recovery_id: u8,
+        seen_message_hex: Mutex<Option<String>>,
+    }
+
+    impl ExternalSignerTransport for RawMessageTransport {
+        fn call(&self, request: &[u8]) -> Result<Vec<u8>, RlnSignerError> {
+            let req = decode_signer_request(request)?;
+            let response = match req {
+                ExternalSignerRequest::Node(ExternalNodeRequest::SignMessageRaw {
+                    message_hex,
+                }) => {
+                    *self.seen_message_hex.lock().expect("lock") = Some(message_hex);
+                    ExternalSignerResponse::Node(ExternalNodeResponse::RecoverableSignature {
+                        signature_hex: self.signature_hex.clone(),
+                        recovery_id: self.recovery_id,
+                    })
+                }
+                other => {
+                    return Err(RlnSignerError::Protocol(format!(
+                        "unexpected request: {other:?}"
+                    )))
+                }
+            };
+            encode_signer_response(&response)
+        }
+    }
+
+    #[test]
+    fn zbase32_encode_matches_known_vectors() {
+        assert_eq!(zbase32_encode(&[]), "");
+        assert_eq!(zbase32_encode(&[0x00]), "yy");
+        assert_eq!(zbase32_encode(&[0x80]), "oy");
+        assert_eq!(zbase32_encode(&[0x8b, 0x88, 0x80]), "tqrey");
+    }
+
+    #[test]
+    fn ln_signed_message_conversion_matches_ldk() {
+        let secp = Secp256k1::new();
+        let secret = SecretKey::from_slice(&[1u8; 32]).expect("secret");
+        let message: &[u8] = b"\x00\xffapay";
+        let digest = sha256d::Hash::hash(&[&b"Lightning Signed Message:"[..], message].concat());
+        let signature =
+            secp.sign_ecdsa_recoverable(&Message::from_digest(digest.to_byte_array()), &secret);
+        let (recovery_id, compact) = signature.serialize_compact();
+
+        let actual = ln_signed_message_from_compact(
+            &compact.to_lower_hex_string(),
+            recovery_id.to_i32() as u8,
+        )
+        .expect("convert");
+        let expected = lightning::util::message_signing::sign(message, &secret);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn external_sign_message_uses_raw_hex_and_returns_zbase32() {
+        let secp = Secp256k1::new();
+        let secret = SecretKey::from_slice(&[2u8; 32]).expect("secret");
+        let message: &[u8] = b"\x00\xffapay";
+        let digest = sha256d::Hash::hash(&[&b"Lightning Signed Message:"[..], message].concat());
+        let signature =
+            secp.sign_ecdsa_recoverable(&Message::from_digest(digest.to_byte_array()), &secret);
+        let (recovery_id, compact) = signature.serialize_compact();
+
+        let transport = Arc::new(RawMessageTransport {
+            signature_hex: compact.to_lower_hex_string(),
+            recovery_id: recovery_id.to_i32() as u8,
+            seen_message_hex: Mutex::new(None),
+        });
+        let signer = ExternalSigner {
+            backend: Arc::new(VlsSignerAdapter::new(transport.clone())),
+        };
+
+        let signed_message = signer.sign_message(message).expect("sign");
+
+        assert_eq!(
+            transport.seen_message_hex.lock().expect("lock").as_deref(),
+            Some("00ff61706179")
+        );
+        assert_eq!(
+            signed_message,
+            lightning::util::message_signing::sign(message, &secret)
+        );
+    }
+}
+
 /// Transport-backed external signer: LDK `NodeSigner` / channel / PSBT ops delegate to the host.
 /// Bootstrap currently carries only public signer identity/config, while runtime signer
 /// operations fetch all signing-capable material through the external signer backend.
@@ -556,15 +694,18 @@ impl NodeSigner for ExternalSigner {
     }
 
     fn sign_message(&self, msg: &[u8]) -> Result<String, ()> {
-        let req = ExternalSignerRequest::Node(ExternalNodeRequest::SignMessage {
-            message: String::from_utf8(msg.to_vec()).map_err(|_| ())?,
+        let req = ExternalSignerRequest::Node(ExternalNodeRequest::SignMessageRaw {
+            message_hex: msg.to_lower_hex_string(),
         });
         let resp = self.backend.call(req).map_err(|_| ())?;
-        let ExternalSignerResponse::Node(ExternalNodeResponse::Signature { signature_hex }) = resp
+        let ExternalSignerResponse::Node(ExternalNodeResponse::RecoverableSignature {
+            signature_hex,
+            recovery_id,
+        }) = resp
         else {
             return Err(());
         };
-        Ok(signature_hex)
+        ln_signed_message_from_compact(&signature_hex, recovery_id)
     }
 }
 

--- a/src/signer/proto.rs
+++ b/src/signer/proto.rs
@@ -221,10 +221,16 @@ struct SignMessageV1 {
 }
 
 #[derive(Clone, PartialEq, Message)]
+struct SignMessageRawV1 {
+    #[prost(string, tag = "1")]
+    pub message_hex: String,
+}
+
+#[derive(Clone, PartialEq, Message)]
 struct NodeRequestV1 {
     #[prost(
         oneof = "node_request_v1::Kind",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25"
     )]
     pub kind: Option<node_request_v1::Kind>,
 }
@@ -275,6 +281,8 @@ mod node_request_v1 {
         SignGossipMessage(SignGossipMessageV1),
         #[prost(message, tag = "9")]
         SignMessage(SignMessageV1),
+        #[prost(message, tag = "25")]
+        SignMessageRaw(SignMessageRawV1),
     }
 }
 
@@ -1283,6 +1291,9 @@ impl From<NodeRequest> for NodeRequestV1 {
             NodeRequest::SignMessage { message } => {
                 node_request_v1::Kind::SignMessage(SignMessageV1 { message })
             }
+            NodeRequest::SignMessageRaw { message_hex } => {
+                node_request_v1::Kind::SignMessageRaw(SignMessageRawV1 { message_hex })
+            }
         };
         Self { kind: Some(kind) }
     }
@@ -1392,6 +1403,9 @@ impl TryFrom<NodeRequestV1> for NodeRequest {
                 message_hex: v.message_hex,
             }),
             node_request_v1::Kind::SignMessage(v) => Ok(Self::SignMessage { message: v.message }),
+            node_request_v1::Kind::SignMessageRaw(v) => Ok(Self::SignMessageRaw {
+                message_hex: v.message_hex,
+            }),
         }
     }
 }
@@ -2248,6 +2262,16 @@ mod tests {
     fn request_roundtrip() {
         let request = SignerRequest::Node(NodeRequest::SignMessage {
             message: "hello".to_string(),
+        });
+        let wire = encode_signer_request(&request).expect("encode");
+        let decoded = decode_signer_request(&wire).expect("decode");
+        assert_eq!(decoded, request);
+    }
+
+    #[test]
+    fn raw_message_request_roundtrip() {
+        let request = SignerRequest::Node(NodeRequest::SignMessageRaw {
+            message_hex: "00ff".to_string(),
         });
         let wire = encode_signer_request(&request).expect("encode");
         let decoded = decode_signer_request(&wire).expect("decode");

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -1399,7 +1399,29 @@ impl SdkNode {
         let state = self.handle.app_state();
         let response = block_on_sdk(sdk::async_order_new(
             state,
-            AsyncOrderNewRequest { host_node_id },
+            AsyncOrderNewRequest {
+                host_node_id,
+                username: None,
+                domain: None,
+            },
+        ))?;
+        Ok(response)
+    }
+
+    pub fn apay_new_with_address(
+        &self,
+        host_node_id: String,
+        username: String,
+        domain: String,
+    ) -> Result<AsyncOrderNewResponse, RlnError> {
+        let state = self.handle.app_state();
+        let response = block_on_sdk(sdk::async_order_new(
+            state,
+            AsyncOrderNewRequest {
+                host_node_id,
+                username: Some(username),
+                domain: Some(domain),
+            },
         ))?;
         Ok(response)
     }
@@ -1683,6 +1705,15 @@ pub fn sdk_send_rgb(request: SendRgbRequest) -> Result<SendRgbResponse, RlnError
 pub fn sdk_apay_new(host_node_id: String) -> Result<AsyncOrderNewResponse, RlnError> {
     let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
     SdkNode { handle }.apay_new(host_node_id)
+}
+
+pub fn sdk_apay_new_with_address(
+    host_node_id: String,
+    username: String,
+    domain: String,
+) -> Result<AsyncOrderNewResponse, RlnError> {
+    let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
+    SdkNode { handle }.apay_new_with_address(host_node_id, username, domain)
 }
 
 uniffi::include_scaffolding!("rgb_lightning_node");

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -402,3 +402,126 @@ mod uniffi_smoke_tests {
         assert!(matches!(res, Err(RlnError::InvalidRequest)));
     }
 }
+
+#[cfg(all(test, feature = "vls"))]
+mod external_apay_signing_tests {
+    use std::{str::FromStr, sync::Arc};
+
+    use bitcoin::{
+        hex::FromHex,
+        secp256k1::{PublicKey, Secp256k1, SecretKey},
+    };
+    use lightning::{
+        sign::{KeysManager, NodeSigner},
+        util::message_signing,
+    };
+
+    use crate::{
+        async_order::{
+            apay_attest_bytes, apay_commit_bytes, build_apay_address_attestation,
+            build_apay_batch_commitment, AsyncOrderNewHashWire,
+        },
+        kv_store::test_support::MemoryKvStore,
+        signer::{ExternalSigner, ExternalSignerTransport},
+        uniffi_api::UniffiExternalSignerTransport,
+    };
+
+    fn external_signer_from_seed(seed_hex: String) -> (ExternalSigner, PublicKey) {
+        let host = crate::NativeExternalSigner::new(seed_hex, "regtest".to_string(), Some(true))
+            .expect("native signer");
+        let transport: Arc<dyn ExternalSignerTransport> =
+            Arc::new(UniffiExternalSignerTransport::new(host));
+        let attachment =
+            crate::ldk::attach_external_signer_transport(transport).expect("attachment");
+        let node_id =
+            PublicKey::from_str(&attachment.bootstrap.identity.node_id).expect("bootstrap node id");
+        let signer = ExternalSigner::from_attachment(&attachment).expect("external signer");
+        (signer, node_id)
+    }
+
+    fn decode_fixed<const N: usize>(hex: &str) -> [u8; N] {
+        Vec::<u8>::from_hex(hex)
+            .expect("valid hex")
+            .try_into()
+            .expect("expected length")
+    }
+
+    #[test]
+    fn external_message_signing_matches_internal_mode() {
+        let (signer, node_id) = external_signer_from_seed("33".repeat(32));
+        let message: &[u8] = b"\x00\xff\xfe binary commitment bytes";
+
+        let external_sig = NodeSigner::sign_message(&signer, message).expect("external sign");
+        assert!(message_signing::verify(message, &external_sig, &node_id));
+
+        let keys_manager = KeysManager::new(
+            &[0x33u8; 32],
+            42,
+            42,
+            true,
+            std::env::temp_dir().join(format!("rln-signer-parity-{}", uuid::Uuid::new_v4())),
+            Arc::new(MemoryKvStore::default()),
+        );
+        let secp = Secp256k1::new();
+        let internal_node_id =
+            PublicKey::from_secret_key(&secp, &keys_manager.get_node_secret_key());
+        assert_eq!(internal_node_id, node_id);
+
+        let internal_sig = message_signing::sign(message, &keys_manager.get_node_secret_key());
+        assert_eq!(external_sig, internal_sig);
+    }
+
+    #[test]
+    fn external_signatures_verify() {
+        let (signer, node_id) = external_signer_from_seed("44".repeat(32));
+        let node_id_hex = node_id.to_string();
+        let secp = Secp256k1::new();
+        let host_pubkey = PublicKey::from_secret_key(
+            &secp,
+            &SecretKey::from_slice(&[9u8; 32]).expect("host secret"),
+        );
+        let host_pubkey_hex = host_pubkey.to_string();
+
+        let prepared = signer
+            .prepare_async_payments_hashes(host_pubkey_hex.clone(), 1, 4)
+            .expect("prepare hashes");
+        assert_eq!(prepared.len(), 4);
+        let hashes: Vec<AsyncOrderNewHashWire> = prepared
+            .iter()
+            .map(|entry| AsyncOrderNewHashWire {
+                hash_index: entry.hash_index,
+                payment_hash: entry.payment_hash_hex.clone(),
+            })
+            .collect();
+
+        let batch = build_apay_batch_commitment(
+            &node_id_hex,
+            &host_pubkey_hex,
+            1,
+            &hashes,
+            1_000,
+            2_000,
+            |msg| NodeSigner::sign_message(&signer, msg),
+        )
+        .expect("batch commitment");
+
+        let commit = apay_commit_bytes(
+            &decode_fixed::<33>(&node_id_hex),
+            &decode_fixed::<33>(&batch.host_pubkey),
+            &decode_fixed::<16>(&batch.batch_id),
+            &decode_fixed::<32>(&batch.batch_root),
+            batch.batch_size,
+            batch.created_at,
+            batch.expires_at,
+        );
+        assert!(message_signing::verify(&commit, &batch.batch_sig, &node_id));
+
+        let address_sig =
+            build_apay_address_attestation(&node_id_hex, "utexo.com", "xalkan", 0, |msg| {
+                NodeSigner::sign_message(&signer, msg)
+            })
+            .expect("address attestation");
+        let attest = apay_attest_bytes(&decode_fixed::<33>(&node_id_hex), "utexo.com", "xalkan", 0);
+        assert!(message_signing::verify(&attest, &address_sig, &node_id));
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -262,6 +262,49 @@ impl UnlockedAppState {
         self.virtual_channel_session_store.lock().unwrap()
     }
 
+    pub(crate) fn prepare_apay_order_params(
+        &self,
+        host_node_id: &PublicKey,
+    ) -> Result<crate::async_order::AsyncOrderNewParamsWire, APIError> {
+        let start_index = crate::async_order::read_async_payments_next_hash_index(
+            self.kv_store.as_ref(),
+            host_node_id,
+        )
+        .map_err(|err| APIError::Unexpected(err.message))?;
+        if self.external_signer_mode {
+            let external_signer = self
+                .external_signer
+                .as_ref()
+                .ok_or_else(|| APIError::Unexpected("external signer missing".to_string()))?;
+            let hashes = external_signer
+                .prepare_async_payments_hashes(
+                    hex_str(&host_node_id.serialize()),
+                    start_index,
+                    crate::async_order::ASYNC_ORDER_MAX_HASH_BATCH_SIZE as u32,
+                )
+                .map_err(|e| APIError::ExternalSignerProtocolError(e.to_string()))?;
+            Ok(crate::async_order::AsyncOrderNewParamsWire {
+                protocol_version: 1,
+                hashes: hashes
+                    .into_iter()
+                    .map(|entry| crate::async_order::AsyncOrderNewHashWire {
+                        hash_index: entry.hash_index,
+                        payment_hash: entry.payment_hash_hex,
+                    })
+                    .collect(),
+                batch: None,
+                address_sig: None,
+            })
+        } else {
+            self.async_payments_preimage_root
+                .prepare_async_order_new_params(
+                    start_index,
+                    crate::async_order::ASYNC_ORDER_MAX_HASH_BATCH_SIZE,
+                )
+                .map_err(|err| APIError::InvalidRequest(err.message))
+        }
+    }
+
     pub(crate) fn sign_node_message(&self, message: &[u8]) -> Result<String, APIError> {
         self.signer
             .sign_message(message)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -184,6 +184,52 @@ pub(crate) struct UnlockedAppState {
 }
 
 impl UnlockedAppState {
+    pub(crate) fn attach_apay_signatures(
+        &self,
+        mut params: crate::async_order::AsyncOrderNewParamsWire,
+        host_pubkey_hex: &str,
+        first_hash_index: u64,
+        username: Option<&str>,
+        domain: Option<&str>,
+    ) -> Result<crate::async_order::AsyncOrderNewParamsWire, APIError> {
+        if username.is_some() != domain.is_some() {
+            return Err(APIError::InvalidRequest(
+                "username and domain must be supplied together".to_string(),
+            ));
+        }
+
+        let recipient_pubkey = self.runtime_node_pubkey();
+        let created_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let expires_at = created_at.saturating_add(crate::async_order::APAY_BATCH_EXPIRY_SECS);
+        let batch = crate::async_order::build_apay_batch_commitment(
+            &recipient_pubkey,
+            host_pubkey_hex,
+            first_hash_index,
+            &params.hashes,
+            created_at,
+            expires_at,
+            |msg| self.sign_node_message(msg).map_err(|_| ()),
+        )
+        .map_err(|err| APIError::InvalidRequest(err.message))?;
+        params.batch = Some(batch);
+
+        if let (Some(username), Some(domain)) = (username, domain) {
+            let address_sig = crate::async_order::build_apay_address_attestation(
+                &recipient_pubkey,
+                domain,
+                username,
+                0,
+                |msg| self.sign_node_message(msg).map_err(|_| ()),
+            )
+            .map_err(|err| APIError::InvalidRequest(err.message))?;
+            params.address_sig = Some(address_sig);
+        }
+        Ok(params)
+    }
+
     pub(crate) fn get_inbound_payments(&self) -> MutexGuard<'_, InboundPaymentInfoStorage> {
         self.inbound_payments.lock().unwrap()
     }


### PR DESCRIPTION
The current async payment LNURL invoice is signed by the LSP, not the recipient, so a payer can't verify the invoice's `payment_hash` was generated by the intended recipient. Therefore, a malicious host could substitute a hash it controls and claim the inbound payment. This PR adds the recipient-side production & signing of the proof material (issue #44). Recipients now attach a node-signed batch commitment (+ optional address attestation) to `async_order.new`, the foundation a payer needs to verify the served `payment_hash` is recipient-generated (the guarantee is non-substitution, not non-reuse).

- New `src/apay_merkle.rs`: domain-separated Merkle (0x00 leaf / 0x01 node prefixes, tagged), odd trailing node duplicated `H(last,last)`. Byte-identical to the Go Utexo-LSP implementation; pinned by a shared reference vector in tests.
- `src/async_order.rs`: `ApayBatchCommitmentWire`; canonical signed encoders `apay_commit_bytes` / `apay_attest_bytes`; deterministic `apay_derive_batch_id`; `apay_batch_root`; `build_apay_batch_commitment` / `build_apay_address_attestation`. Optional `batch` / `address_sig` added to `AsyncOrderNewParamsWire` + the host→LSP `AsyncOrderNewLspRequest`.
- `src/utils.rs`: `UnlockedAppState::attach_apay_signatures` builds & recipient RLN signs the batch commitment (and the address attestation when username+domain are supplied). Consume-and-return (takes params by value, returns it) so it's atomic on error; shared by the HTTP and SDK paths.
- `routes.rs` / `sdk/mod.rs` / `core_types.rs`: `/apay/new` calls the shared helper; `AsyncOrderNewRequest` gains optional username+domain. `openapi.yaml` documents the new fields.
- `uniffi_api` + `bindings/*.udl`: additive `apay_new_with_address(host_node_id, username, domain)`; existing `apay_new` unchanged so mobile callers don't break.

Some decisions & conventions:
- Signs with the node identity key via the existing `sign_message` LN signed-message envelope (recoverable ECDSA) — no new key management.
- `commit = "UTEXO_APAY_HASH_BATCH_V1" ‖ recipient_pubkey ‖ host_pubkey ‖ batch_id ‖ batch_root ‖ batch_size ‖ created_at ‖ expires_at`. The `recipient_pubkey` is implicit (the authenticated sender) and never on the wire; `host_pubkey` is bound so the recipient authorizes a specific host, which enables a fraud proof (two same-hash invoices signed by that host).
- Protocol version stays `1`, and batch/attestation fields are optional/additive.
- Deterministic `batch_id = SHA256("UTEXO_APAY_BATCH_ID_V1" ‖ recipient_pubkey ‖ start_index)[..16]`; `/apay/new` replays reproduce the same batch (idempotent).
- Address attestation is expiryless (`expires_at = 0`, not transmitted), so the signature is a pure function of `(recipient_pubkey, domain, username)`, and re-supplying the name is a no-op. Batch `expires_at` (~1y) is signed for forward-compat only, not enforced here.
- Odd-node duplication is consensus-critical (must match the Go verifier); signing `batch_size` pins the leaf count and neutralizes the duplication ambiguity.
- `proof`/`verify` exist but are test-only today (payer phase), hence module `#![allow(dead_code)]`.

Pairs with the LSP side: https://github.com/UTEXO-Protocol/utexo-lsp/pull/22