### PR TITLE
Add payment pagination + description hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,21 @@ dedicated extra output containing the anchor to the RGB state transition.
 More context on how RGB works on the Lightning Network can be found
 [here](https://docs.rgb.info/lightning-network-compatibility).
 
-The RGB functionality for now can be tested only in regtest or testnet
-environments, but an advanced user may be able to apply changes in order to use
-it also on other networks.
+The node supports the regtest, signet, testnet3, testnet4 and mainnet networks,
+selected at startup via the `--network` flag (accepted values: `regtest`,
+`signet`, `signetcustom`, `testnet`/`testnet3`, `testnet4`, `mainnet`/`bitcoin`).
 Please be careful, this software is early alpha, we do not take any
 responsibility for loss of funds or any other issue you may encounter.
 
 Also note that [rust-lightning] has been changed in order to support RGB
-channels,
-[here](https://github.com/RGB-Tools/rust-lightning/compare/v0.2.2...rgb)
-a comparison with `v0.2.2`, the version we applied the changes to.
+channels; the node builds against the UTEXO-Protocol fork, tracked as a git
+submodule on branch `dev`.
 
 ## Install
 
 Clone the project, including (shallow) submodules:
 ```sh
-git clone https://github.com/RGB-Tools/rgb-lightning-node --recurse-submodules --shallow-submodules
+git clone https://github.com/UTEXO-Protocol/rgb-lightning-node --recurse-submodules --shallow-submodules
 ```
 
 Then, from the project root, install the `rgb-lightning-node` binary by
@@ -285,7 +284,7 @@ The node currently exposes the following APIs:
 
 To get more details about the available APIs see the [OpenAPI specification].
 A Swagger UI for the `master` branch is generated from the specification and
-available at https://rgb-tools.github.io/rgb-lightning-node.
+available at https://utexo-protocol.github.io/rgb-lightning-node.
 Otherwise a local copy can be exposed. To do so, from the project root, run:
 
 ```sh
@@ -505,7 +504,7 @@ staleness.
 [ldk-sample]: https://github.com/lightningdevkit/ldk-sample
 [OpenAPI specification]: /openapi.yaml
 [rgb-lightning-sample]: https://github.com/RGB-Tools/rgb-lightning-sample
-[rust-lightning]: https://github.com/lightningdevkit/rust-lightning
+[rust-lightning]: https://github.com/UTEXO-Protocol/rust-lightning
 [Iris Wallet desktop]: https://github.com/RGB-Tools/iris-wallet-desktop
 [KaleidoSwap]: https://kaleidoswap.com/
 [Lnfi]: https://www.lnfi.network/

--- a/bindings/c-ffi/src/json_types.rs
+++ b/bindings/c-ffi/src/json_types.rs
@@ -594,6 +594,7 @@ pub(crate) struct JsonPayment {
     pub updated_at: u64,
     pub payee_pubkey: String,
     pub preimage: Option<String>,
+    pub description_hash: Option<String>,
 }
 
 impl From<Payment> for JsonPayment {
@@ -609,6 +610,7 @@ impl From<Payment> for JsonPayment {
             updated_at: p.updated_at,
             payee_pubkey: fmt_pubkey(&p.payee_pubkey),
             preimage: p.preimage,
+            description_hash: p.description_hash,
         }
     }
 }

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -209,6 +209,7 @@ dictionary Payment {
     u64 updated_at;
     PublicKey payee_pubkey;
     string? preimage;
+    string? description_hash;
 };
 
 enum PaymentType {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -660,7 +660,30 @@ paths:
       tags:
         - Payments
       summary: List payments
-      description: List the node's LN payments
+      description: >-
+        List the node's LN payments (inbound and outbound) ordered most-recent
+        first. Supports index-based cursor pagination: pass the
+        last_index_offset of a page as the next index_offset to fetch the next,
+        older page.
+      parameters:
+        - in: query
+          name: index_offset
+          required: false
+          schema:
+            type: integer
+            format: uint64
+          description: >-
+            Exclusive upper-bound cursor: only payments with a lower index are
+            returned. 0 or absent means start from the most recent payment.
+        - in: query
+          name: max_payments
+          required: false
+          schema:
+            type: integer
+            format: uint64
+          description: >-
+            Maximum number of payments to return. Defaults to 100 when absent or
+            zero.
       responses:
         '200':
           description: Successful operation
@@ -2563,11 +2586,28 @@ components:
       type: object
       required:
         - payments
+        - first_index_offset
+        - last_index_offset
       properties:
         payments:
           type: array
           items:
             $ref: '#/components/schemas/Payment'
+        first_index_offset:
+          type: integer
+          format: uint64
+          description: >-
+            Index of the first (most recent) payment in the returned page, or 0
+            when the page is empty.
+          example: 100
+        last_index_offset:
+          type: integer
+          format: uint64
+          description: >-
+            Index of the last (oldest) payment in the returned page, or 0 when
+            the page is empty. Pass this as index_offset to fetch the next,
+            older page.
+          example: 51
     ListPeersResponse:
       type: object
       required:
@@ -2972,6 +3012,12 @@ components:
         preimage:
           type: string
           example: 89d28bd306aa9bb906fd0ac31092d04c37c919a171b343083167e2a3cdc60578
+        description_hash:
+          type:
+            - string
+            - 'null'
+          description: BOLT11 description hash (the h tag), hex-encoded, if present
+          example: 00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff
     Peer:
       type: object
       required:

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -252,6 +252,8 @@ pub(crate) struct PaymentInfo {
     pub(crate) expires_at: Option<u64>,
     pub(crate) claim_deadline_height: Option<u32>,
     pub(crate) invoice_type: Option<InvoiceType>,
+    pub(crate) description_hash: Option<[u8; 32]>,
+    pub(crate) payment_idx: Option<u64>,
 }
 
 impl_writeable_tlv_based!(PaymentInfo, {
@@ -265,6 +267,8 @@ impl_writeable_tlv_based!(PaymentInfo, {
     (14, expires_at, option),
     (16, claim_deadline_height, option),
     (18, invoice_type, option),
+    (20, description_hash, option),
+    (22, payment_idx, option),
 });
 
 pub(crate) struct InboundPaymentInfoStorage {
@@ -372,10 +376,15 @@ impl VirtualChannelSessionStore {
 
 fn persist_staged_inbound_payment(
     kv_store: &dyn KVStoreSync,
+    next_payment_idx: &std::sync::atomic::AtomicU64,
     inbound: &mut InboundPaymentInfoStorage,
     payment_hash: PaymentHash,
-    payment_info: PaymentInfo,
+    mut payment_info: PaymentInfo,
 ) -> Result<(), JsonRpcErrorWire> {
+    if payment_info.payment_idx.is_none() {
+        payment_info.payment_idx =
+            Some(next_payment_idx.fetch_add(1, std::sync::atomic::Ordering::SeqCst));
+    }
     let mut staged_inbound = InboundPaymentInfoStorage {
         payments: inbound.payments.clone(),
     };
@@ -460,8 +469,25 @@ impl UnlockedAppState {
         self.get_taker_swaps().swaps.clone()
     }
 
-    pub(crate) fn add_inbound_payment(&self, payment_hash: PaymentHash, payment_info: PaymentInfo) {
+    /// Assign a stable, monotonically increasing index to a payment if it does
+    /// not already have one. Indices are shared across inbound and outbound
+    /// payments so the two sets can be merged and paged in a stable order.
+    pub(crate) fn stamp_payment_idx(&self, payment_info: &mut PaymentInfo) {
+        if payment_info.payment_idx.is_none() {
+            payment_info.payment_idx = Some(
+                self.next_payment_idx
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst),
+            );
+        }
+    }
+
+    pub(crate) fn add_inbound_payment(
+        &self,
+        payment_hash: PaymentHash,
+        mut payment_info: PaymentInfo,
+    ) {
         let mut inbound = self.get_inbound_payments();
+        self.stamp_payment_idx(&mut payment_info);
         inbound.payments.insert(payment_hash, payment_info);
         self.save_inbound_payments(inbound);
     }
@@ -469,7 +495,7 @@ impl UnlockedAppState {
     pub(crate) fn add_outbound_payment(
         &self,
         payment_id: PaymentId,
-        payment_info: PaymentInfo,
+        mut payment_info: PaymentInfo,
     ) -> Result<(), APIError> {
         let mut outbound = self.get_outbound_payments();
         if let Some(existing_payment) = outbound.payments.get(&payment_id) {
@@ -479,6 +505,7 @@ impl UnlockedAppState {
                 ));
             }
         }
+        self.stamp_payment_idx(&mut payment_info);
         outbound.payments.insert(payment_id, payment_info);
         self.save_outbound_payments(outbound);
         Ok(())
@@ -637,7 +664,7 @@ impl UnlockedAppState {
             }
             Entry::Vacant(e) => {
                 let created_at = get_current_timestamp();
-                e.insert(PaymentInfo {
+                let mut payment_info = PaymentInfo {
                     preimage,
                     secret,
                     status,
@@ -648,7 +675,11 @@ impl UnlockedAppState {
                     expires_at: None,
                     claim_deadline_height,
                     invoice_type,
-                });
+                    description_hash: None,
+                    payment_idx: None,
+                };
+                self.stamp_payment_idx(&mut payment_info);
+                e.insert(payment_info);
             }
         }
         self.save_inbound_payments(inbound);
@@ -1100,6 +1131,7 @@ struct AsyncOrderRecipientInvoiceProvider {
     inbound_payments: Arc<Mutex<InboundPaymentInfoStorage>>,
     async_payments_preimage_root: Arc<AsyncPaymentsPreimageRoot>,
     kv_store: Arc<SyncedKvStore>,
+    next_payment_idx: Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl AsyncOrderRecipientInvoiceProvider {
@@ -1207,6 +1239,7 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
         };
         persist_staged_inbound_payment(
             self.kv_store.as_ref(),
+            self.next_payment_idx.as_ref(),
             &mut inbound,
             requested_payment_hash,
             PaymentInfo {
@@ -1222,6 +1255,8 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
                 invoice_type: Some(InvoiceType::Hodl {
                     async_payment_recipient: true,
                 }),
+                description_hash: crate::routes::description_hash_from_invoice(&invoice),
+                payment_idx: None,
             },
         )?;
 
@@ -4318,6 +4353,67 @@ pub(crate) async fn start_ldk(
         }
     }));
 
+    // Seed the shared payment-index counter and backfill any records persisted
+    // before payment indexing existed. Missing indices are assigned
+    // deterministically by (created_at, payment hash/id) so the ordering is
+    // stable across restarts.
+    let next_payment_idx = {
+        let mut inbound_g = inbound_payments.lock().unwrap();
+        let mut outbound_g = outbound_payments.lock().unwrap();
+
+        let mut max_idx = 0u64;
+        for info in inbound_g
+            .payments
+            .values()
+            .chain(outbound_g.payments.values())
+        {
+            if let Some(i) = info.payment_idx {
+                max_idx = max_idx.max(i);
+            }
+        }
+
+        let mut missing: Vec<(u64, [u8; 32], bool)> = Vec::new();
+        for (h, info) in inbound_g.payments.iter() {
+            if info.payment_idx.is_none() {
+                missing.push((info.created_at, h.0, true));
+            }
+        }
+        for (id, info) in outbound_g.payments.iter() {
+            if info.payment_idx.is_none() {
+                missing.push((info.created_at, id.0, false));
+            }
+        }
+        missing.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+
+        let mut changed = false;
+        for (_, key, is_inbound) in missing {
+            max_idx += 1;
+            if is_inbound {
+                inbound_g
+                    .payments
+                    .get_mut(&PaymentHash(key))
+                    .unwrap()
+                    .payment_idx = Some(max_idx);
+            } else {
+                outbound_g
+                    .payments
+                    .get_mut(&PaymentId(key))
+                    .unwrap()
+                    .payment_idx = Some(max_idx);
+            }
+            changed = true;
+        }
+        if changed {
+            kv_store
+                .write("", "", INBOUND_PAYMENTS_KEY, inbound_g.encode())
+                .unwrap();
+            kv_store
+                .write("", "", OUTBOUND_PAYMENTS_KEY, outbound_g.encode())
+                .unwrap();
+        }
+        Arc::new(std::sync::atomic::AtomicU64::new(max_idx + 1))
+    };
+
     let bump_wallet_source = Arc::new(RgbBumpWalletSource {
         inner: rgb_wallet_wrapper.clone(),
         signer: keys_manager.clone(),
@@ -4416,6 +4512,7 @@ pub(crate) async fn start_ldk(
         inbound_payments: Arc::clone(&inbound_payments),
         async_payments_preimage_root: Arc::clone(&async_payments_preimage_root),
         kv_store: Arc::clone(&kv_store),
+        next_payment_idx: Arc::clone(&next_payment_idx),
     }));
 
     let unlocked_state = Arc::new(UnlockedAppState {
@@ -4446,6 +4543,7 @@ pub(crate) async fn start_ldk(
         external_node_id,
         virtual_channel_draft_store,
         virtual_channel_session_store,
+        next_payment_idx,
     });
 
     // Refresh the RGS snapshot on a fixed interval (RGS mode only). The first

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -3890,12 +3890,7 @@ pub(crate) async fn start_ldk(
                 bitcoin_network,
                 database_type: DatabaseType::Sqlite,
                 max_allocations_per_utxo: 1,
-                supported_schemas: vec![
-                    AssetSchema::Nia,
-                    AssetSchema::Cfa,
-                    AssetSchema::Uda,
-                    AssetSchema::Ifa,
-                ],
+                supported_schemas: vec![AssetSchema::Nia, AssetSchema::Cfa, AssetSchema::Uda],
                 reuse_addresses: false,
             },
             keys,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -803,9 +803,19 @@ pub(crate) struct ListChannelsResponse {
 }
 
 #[derive(Deserialize, Serialize)]
+pub(crate) struct ListPaymentsRequest {
+    pub(crate) index_offset: Option<u64>,
+    pub(crate) max_payments: Option<u64>,
+}
+
+#[derive(Deserialize, Serialize)]
 pub(crate) struct ListPaymentsResponse {
     pub(crate) payments: Vec<Payment>,
+    pub(crate) first_index_offset: u64,
+    pub(crate) last_index_offset: u64,
 }
+
+const DEFAULT_MAX_PAYMENTS: u64 = 100;
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct ListPeersResponse {
@@ -978,6 +988,14 @@ pub(crate) struct Payment {
     pub(crate) updated_at: u64,
     pub(crate) payee_pubkey: String,
     pub(crate) preimage: Option<String>,
+    pub(crate) description_hash: Option<String>,
+}
+
+pub(crate) fn description_hash_from_invoice(invoice: &Bolt11Invoice) -> Option<[u8; 32]> {
+    match invoice.description() {
+        lightning_invoice::Bolt11InvoiceDescriptionRef::Hash(hash) => Some(hash.0.to_byte_array()),
+        _ => None,
+    }
 }
 
 fn payment_type_from_invoice(invoice_type: Option<InvoiceType>) -> PaymentType {
@@ -2449,6 +2467,7 @@ pub(crate) async fn get_payment(
                             updated_at: payment_info.updated_at,
                             payee_pubkey: payment_info.payee_pubkey.to_string(),
                             preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                            description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
                         },
                     }));
                 }
@@ -2478,6 +2497,7 @@ pub(crate) async fn get_payment(
                             updated_at: payment_info.updated_at,
                             payee_pubkey: payment_info.payee_pubkey.to_string(),
                             preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                            description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
                         },
                     }));
                 }
@@ -2826,6 +2846,8 @@ pub(crate) async fn keysend(
                 expires_at: None,
                 invoice_type: None,
                 payee_pubkey: dest_pubkey,
+                description_hash: None,
+                payment_idx: None,
 
                 updated_at: created_at,
             },
@@ -3051,13 +3073,14 @@ pub(crate) async fn list_channels(
 
 pub(crate) async fn list_payments(
     State(state): State<Arc<AppState>>,
+    axum::extract::Query(params): axum::extract::Query<ListPaymentsRequest>,
 ) -> Result<Json<ListPaymentsResponse>, APIError> {
     let guard = state.check_unlocked().await?;
     let unlocked_state = guard.as_ref().unwrap();
 
     let inbound_payments = unlocked_state.list_updated_inbound_payments();
     let outbound_payments = unlocked_state.outbound_payments();
-    let mut payments = vec![];
+    let mut all: Vec<(u64, Payment)> = vec![];
 
     for (payment_hash, payment_info) in &inbound_payments {
         let (asset_amount, asset_id) = match unlocked_state
@@ -3068,18 +3091,22 @@ pub(crate) async fn list_payments(
             Err(_) => (None, None),
         };
 
-        payments.push(Payment {
-            amt_msat: payment_info.amt_msat,
-            asset_amount,
-            asset_id,
-            payment_hash: hex_str(&payment_hash.0),
-            payment_type: payment_type_from_invoice(payment_info.invoice_type),
-            status: payment_info.status,
-            created_at: payment_info.created_at,
-            updated_at: payment_info.updated_at,
-            payee_pubkey: payment_info.payee_pubkey.to_string(),
-            preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
-        });
+        all.push((
+            payment_info.payment_idx.unwrap_or(0),
+            Payment {
+                amt_msat: payment_info.amt_msat,
+                asset_amount,
+                asset_id,
+                payment_hash: hex_str(&payment_hash.0),
+                payment_type: payment_type_from_invoice(payment_info.invoice_type),
+                status: payment_info.status,
+                created_at: payment_info.created_at,
+                updated_at: payment_info.updated_at,
+                payee_pubkey: payment_info.payee_pubkey.to_string(),
+                preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
+            },
+        ));
     }
 
     for (payment_id, payment_info) in &outbound_payments {
@@ -3093,21 +3120,50 @@ pub(crate) async fn list_payments(
             Err(_) => (None, None),
         };
 
-        payments.push(Payment {
-            amt_msat: payment_info.amt_msat,
-            asset_amount,
-            asset_id,
-            payment_hash: hex_str(&payment_hash.0),
-            payment_type: PaymentType::Outbound,
-            status: payment_info.status,
-            created_at: payment_info.created_at,
-            updated_at: payment_info.updated_at,
-            payee_pubkey: payment_info.payee_pubkey.to_string(),
-            preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
-        });
+        all.push((
+            payment_info.payment_idx.unwrap_or(0),
+            Payment {
+                amt_msat: payment_info.amt_msat,
+                asset_amount,
+                asset_id,
+                payment_hash: hex_str(&payment_hash.0),
+                payment_type: PaymentType::Outbound,
+                status: payment_info.status,
+                created_at: payment_info.created_at,
+                updated_at: payment_info.updated_at,
+                payee_pubkey: payment_info.payee_pubkey.to_string(),
+                preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
+            },
+        ));
     }
 
-    Ok(Json(ListPaymentsResponse { payments }))
+    // Newest-first ordering by stable payment index.
+    all.sort_by_key(|(idx, _)| std::cmp::Reverse(*idx));
+
+    let index_offset = params.index_offset.unwrap_or(0);
+    let max_payments = match params.max_payments {
+        Some(0) | None => DEFAULT_MAX_PAYMENTS,
+        Some(m) => m,
+    };
+
+    // `index_offset` is an exclusive upper-bound cursor; 0 means no bound
+    // (start from the most recent payment).
+    let page: Vec<(u64, Payment)> = all
+        .into_iter()
+        .filter(|(idx, _)| index_offset == 0 || *idx < index_offset)
+        .take(max_payments as usize)
+        .collect();
+
+    let first_index_offset = page.first().map(|(idx, _)| *idx).unwrap_or(0);
+    let last_index_offset = page.last().map(|(idx, _)| *idx).unwrap_or(0);
+    let payments = page.into_iter().map(|(_, p)| p).collect();
+
+    Ok(Json(ListPaymentsResponse {
+        payments,
+        first_index_offset,
+        last_index_offset,
+    }))
 }
 
 pub(crate) async fn list_peers(
@@ -3376,6 +3432,8 @@ pub(crate) async fn ln_invoice(
                 expires_at: Some(created_at + payload.expiry_sec as u64),
                 claim_deadline_height: None,
                 invoice_type: Some(invoice_type),
+                description_hash: description_hash_from_invoice(&invoice),
+                payment_idx: None,
             },
         );
 
@@ -4490,6 +4548,8 @@ pub(crate) async fn send_payment(
                     expires_at: None,
                     claim_deadline_height: None,
                     invoice_type: None,
+                    description_hash: None,
+                    payment_idx: None,
                 },
             )?;
 
@@ -4596,6 +4656,8 @@ pub(crate) async fn send_payment(
                     expires_at: None,
                     claim_deadline_height: None,
                     invoice_type: None,
+                    description_hash: description_hash_from_invoice(&invoice),
+                    payment_idx: None,
                 },
             )?;
             let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -2526,6 +2526,8 @@ pub(crate) async fn keysend(
             payee_pubkey: dest_pubkey,
             expires_at: None,
             invoice_type: None,
+            description_hash: None,
+            payment_idx: None,
         },
     )?;
     if let Some((contract_id, rgb_amount)) = rgb_payment {
@@ -3061,6 +3063,8 @@ pub(crate) async fn send_payment(
                     .ok_or(APIError::InvalidInvoice(s!("missing signing pubkey")))?,
                 expires_at: None,
                 invoice_type: None,
+                description_hash: None,
+                payment_idx: None,
             },
         )?;
 
@@ -3157,6 +3161,8 @@ pub(crate) async fn send_payment(
                 payee_pubkey: invoice.get_payee_pub_key(),
                 expires_at: None,
                 invoice_type: None,
+                description_hash: crate::routes::description_hash_from_invoice(&invoice),
+                payment_idx: None,
             },
         )?;
         let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());
@@ -3763,6 +3769,8 @@ pub(crate) async fn create_ln_invoice(
             payee_pubkey: unlocked_state.runtime_node_id(),
             expires_at: Some(created_at + expiry_sec as u64),
             invoice_type: Some(invoice_type),
+            description_hash: crate::routes::description_hash_from_invoice(&invoice),
+            payment_idx: None,
         },
     );
 

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -582,6 +582,7 @@ pub(crate) struct PaymentData {
     pub(crate) updated_at: u64,
     pub(crate) payee_pubkey: String,
     pub(crate) preimage: Option<String>,
+    pub(crate) description_hash: Option<String>,
 }
 
 pub(crate) struct CancelHodlInvoiceRequestData {
@@ -3814,6 +3815,7 @@ pub(crate) async fn list_payments(state: Arc<AppState>) -> Result<Vec<PaymentDat
             updated_at: payment_info.updated_at,
             payee_pubkey: payment_info.payee_pubkey.to_string(),
             preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+            description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
         });
     }
 
@@ -3838,6 +3840,7 @@ pub(crate) async fn list_payments(state: Arc<AppState>) -> Result<Vec<PaymentDat
             updated_at: payment_info.updated_at,
             payee_pubkey: payment_info.payee_pubkey.to_string(),
             preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+            description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
         });
     }
 
@@ -3883,6 +3886,7 @@ pub(crate) async fn get_payment(
                         updated_at: payment_info.updated_at,
                         payee_pubkey: payment_info.payee_pubkey.to_string(),
                         preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                        description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
                     });
                 }
             }
@@ -3910,6 +3914,7 @@ pub(crate) async fn get_payment(
                         updated_at: payment_info.updated_at,
                         payee_pubkey: payment_info.payee_pubkey.to_string(),
                         preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                        description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
                     });
                 }
             }

--- a/src/test/inflate.rs
+++ b/src/test/inflate.rs
@@ -5,6 +5,7 @@ const TEST_DIR_BASE: &str = "tmp/inflate/";
 #[serial_test::serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[traced_test]
+#[ignore = "IFA removed from supported_schemas"]
 async fn success() {
     initialize();
 

--- a/src/test/issue.rs
+++ b/src/test/issue.rs
@@ -26,26 +26,21 @@ async fn issue() {
 
     // issue assets
     let asset_cfa = issue_asset_cfa(node1_addr, Some(file_path)).await;
-    let asset_ifa = issue_asset_ifa(node1_addr).await;
     let asset_nia = issue_asset_nia(node1_addr).await;
     let asset_uda = issue_asset_uda(node1_addr, Some(file_path)).await;
 
     // check /listassets
     let assets = list_assets(node1_addr).await;
     let assets_cfa = assets.cfa.unwrap();
-    let assets_ifa = assets.ifa.unwrap();
     let assets_nia = assets.nia.unwrap();
     let assets_uda = assets.uda.unwrap();
     assert_eq!(assets_cfa.len(), 1);
-    assert_eq!(assets_ifa.len(), 1);
     assert_eq!(assets_nia.len(), 1);
     assert_eq!(assets_uda.len(), 1);
     let cfa_asset = assets_cfa.first().unwrap();
-    let ifa_asset = assets_ifa.first().unwrap();
     let nia_asset = assets_nia.first().unwrap();
     let uda_asset = assets_uda.first().unwrap();
     assert_eq!(cfa_asset.asset_id, asset_cfa.asset_id);
-    assert_eq!(ifa_asset.asset_id, asset_ifa.asset_id);
     assert_eq!(nia_asset.asset_id, asset_nia.asset_id);
     assert_eq!(uda_asset.asset_id, asset_uda.asset_id);
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1048,18 +1048,33 @@ async fn list_channels(node_address: SocketAddr) -> Vec<Channel> {
 }
 
 async fn list_payments(node_address: SocketAddr) -> Vec<Payment> {
+    list_payments_full(node_address, None, None).await.payments
+}
+
+async fn list_payments_full(
+    node_address: SocketAddr,
+    index_offset: Option<u64>,
+    max_payments: Option<u64>,
+) -> ListPaymentsResponse {
     println!("listing payments for node {node_address}");
-    let res = reqwest::Client::new()
-        .get(format!("http://{node_address}/listpayments"))
-        .send()
-        .await
-        .unwrap();
+    let mut url = format!("http://{node_address}/listpayments");
+    let mut query = vec![];
+    if let Some(offset) = index_offset {
+        query.push(format!("index_offset={offset}"));
+    }
+    if let Some(max) = max_payments {
+        query.push(format!("max_payments={max}"));
+    }
+    if !query.is_empty() {
+        url.push('?');
+        url.push_str(&query.join("&"));
+    }
+    let res = reqwest::Client::new().get(url).send().await.unwrap();
     check_response_is_ok(res)
         .await
         .json::<ListPaymentsResponse>()
         .await
         .unwrap()
-        .payments
 }
 
 async fn get_payment(
@@ -1204,6 +1219,37 @@ async fn ln_invoice(
         InvoiceType::AutoClaim,
     )
     .await
+}
+
+async fn ln_invoice_with_description_hash(
+    node_address: SocketAddr,
+    amt_msat: Option<u64>,
+    expiry_sec: u32,
+    description_hash: Option<&str>,
+) -> LNInvoiceResponse {
+    println!(
+        "generating invoice with description_hash {description_hash:?} for node {node_address}"
+    );
+    let payload = LNInvoiceRequest {
+        amt_msat: Some(amt_msat.unwrap_or(3000000)),
+        expiry_sec,
+        asset_id: None,
+        asset_amount: None,
+        payment_hash: None,
+        description_hash: description_hash.map(|s| s.to_string()),
+        min_final_cltv_expiry_delta: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/lninvoice"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<LNInvoiceResponse>()
+        .await
+        .unwrap()
 }
 
 async fn ln_invoice_hodl(

--- a/src/test/payment.rs
+++ b/src/test/payment.rs
@@ -405,3 +405,155 @@ async fn same_invoice_twice_and_expired_inbound_payments() {
         "found expired inbound payments still Pending: {still_pending:?}"
     );
 }
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn description_hash() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}description_hash/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(600_000),
+        Some(300_000_000),
+        None,
+        None,
+    )
+    .await;
+
+    // 32-byte sha256 description hash, hex-encoded.
+    let dh = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+    // Invoice WITH a description_hash.
+    let invoice = ln_invoice_with_description_hash(node2_addr, Some(3_000_000), 900, Some(dh))
+        .await
+        .invoice;
+    let decoded = decode_ln_invoice(node1_addr, &invoice).await;
+    assert_eq!(decoded.description_hash.as_deref(), Some(dh));
+    send_payment(node1_addr, invoice.clone()).await;
+
+    let out = get_payment(node1_addr, &decoded.payment_hash, PaymentType::Outbound).await;
+    assert_eq!(out.description_hash.as_deref(), Some(dh));
+    let inb = get_payment(
+        node2_addr,
+        &decoded.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
+    assert_eq!(inb.description_hash.as_deref(), Some(dh));
+
+    let listed = list_payments(node2_addr)
+        .await
+        .into_iter()
+        .find(|p| p.payment_hash == decoded.payment_hash)
+        .unwrap();
+    assert_eq!(listed.description_hash.as_deref(), Some(dh));
+
+    // Invoice WITHOUT a description_hash.
+    let invoice2 = ln_invoice(node2_addr, Some(3_000_000), None, None, 900)
+        .await
+        .invoice;
+    let decoded2 = decode_ln_invoice(node1_addr, &invoice2).await;
+    assert_eq!(decoded2.description_hash, None);
+    send_payment(node1_addr, invoice2.clone()).await;
+    let out2 = get_payment(node1_addr, &decoded2.payment_hash, PaymentType::Outbound).await;
+    assert_eq!(out2.description_hash, None);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn pagination() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}pagination/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(600_000),
+        Some(300_000_000),
+        None,
+        None,
+    )
+    .await;
+
+    // Make several vanilla payments node1 -> node2 so the sender accumulates
+    // a handful of indexed outbound payments.
+    let total = 5u64;
+    for i in 0..total {
+        let invoice = ln_invoice(node2_addr, Some(3_000_000 + i * 1000), None, None, 900)
+            .await
+            .invoice;
+        send_payment(node1_addr, invoice).await;
+    }
+
+    // Default page: most recent first, no upper bound.
+    let all = list_payments_full(node1_addr, None, None).await;
+    assert_eq!(all.payments.len() as u64, total);
+    // Newest item carries the highest index, oldest the lowest.
+    assert!(all.first_index_offset >= all.last_index_offset);
+
+    // max_payments bounds the page to the newest N.
+    let page = list_payments_full(node1_addr, None, Some(2)).await;
+    assert_eq!(page.payments.len(), 2);
+    assert_eq!(page.first_index_offset, all.first_index_offset);
+    assert_eq!(
+        page.payments[0].payment_hash, all.payments[0].payment_hash,
+        "first page should start at the most recent payment"
+    );
+
+    // Walk to the next, older page using the cursor.
+    let next = list_payments_full(node1_addr, Some(page.last_index_offset), Some(2)).await;
+    assert_eq!(next.payments.len(), 2);
+    assert!(next.first_index_offset < page.last_index_offset);
+
+    // No overlap between consecutive pages.
+    let page_hashes: Vec<&String> = page.payments.iter().map(|p| &p.payment_hash).collect();
+    for p in &next.payments {
+        assert!(
+            !page_hashes.contains(&&p.payment_hash),
+            "pages must not overlap"
+        );
+    }
+
+    // Walking the cursor to exhaustion yields exactly `total` unique payments.
+    let mut seen: Vec<String> = vec![];
+    let mut cursor: Option<u64> = None;
+    loop {
+        let resp = list_payments_full(node1_addr, cursor, Some(2)).await;
+        if resp.payments.is_empty() {
+            break;
+        }
+        for p in &resp.payments {
+            assert!(
+                !seen.contains(&p.payment_hash),
+                "no duplicates across pages"
+            );
+            seen.push(p.payment_hash.clone());
+        }
+        cursor = Some(resp.last_index_offset);
+    }
+    assert_eq!(seen.len() as u64, total);
+}

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -191,6 +191,7 @@ fn map_payment_data(data: crate::sdk::PaymentData) -> Result<Payment, RlnError> 
         updated_at: data.updated_at,
         payee_pubkey,
         preimage: data.preimage,
+        description_hash: data.description_hash,
     })
 }
 

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -375,6 +375,7 @@ mod uniffi_smoke_tests {
             payee_pubkey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
                 .to_string(),
             preimage: expected_preimage.clone(),
+            description_hash: None,
         };
 
         let mapped = map_payment_data(data).expect("payment mapping should succeed");

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -125,6 +125,7 @@ pub struct Payment {
     pub updated_at: u64,
     pub payee_pubkey: PublicKey,
     pub preimage: Option<String>,
+    pub description_hash: Option<String>,
 }
 
 pub enum PaymentType {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -181,6 +181,7 @@ pub(crate) struct UnlockedAppState {
     pub(crate) external_node_id: Option<String>,
     pub(crate) virtual_channel_draft_store: Arc<Mutex<VirtualChannelDraftStore>>,
     pub(crate) virtual_channel_session_store: Arc<Mutex<VirtualChannelSessionStore>>,
+    pub(crate) next_payment_idx: Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl UnlockedAppState {


### PR DESCRIPTION
Closes #61 

Adds the BOLT11 `description_hash` to payment objects and index-based pagination to `/listpayments`. Backward-compatible: new fields are optional and existing no-parameter callers keep working.

## 1. `description_hash`

The BOLT11 `h`-tag is now exposed (hex) on the payment objects returned by `/getpayment` and `/listpayments`, for both inbound and outbound payments. It is populated for invoices that carry a description hash (created with one, or paid against one) and is `null` for keysend, offers, and plain/empty descriptions.

```jsonc
// payment object
{
  "payment_hash": "…",
  "description_hash": "00112233…eeff",  // null when absent
  ...
}
```

## 2. Pagination for `/listpayments`

Each payment is assigned a stable, monotonically increasing index when recorded. `/listpayments` pages over the merged inbound + outbound set, **newest first**.

It stays a `GET` with two optional query params:

| Param | Meaning |
|---|---|
| `index_offset` | Exclusive cursor: return payments with a lower index. `0`/absent = start from the newest. |
| `max_payments` | Page size. Defaults to `100`. |

Response adds `first_index_offset` (newest item in the page) and `last_index_offset` (oldest item in the page).

**Paging through history:** call with no params for the most recent page, then pass the previous page's `last_index_offset` as the next `index_offset`.

```
GET /listpayments?max_payments=50
  -> payments [idx 120 … 71], first_index_offset=120, last_index_offset=71

GET /listpayments?max_payments=50&index_offset=71
  -> payments [idx 70 … 21], first_index_offset=70, last_index_offset=21
```

Empty page returns both offsets as `0`.

### Notes
- The index lives on `PaymentInfo` (persisted, TLV-optional). On startup, any pre-existing payments without an index are backfilled deterministically, so pagination is stable across restarts.

## Other changes (high level)

- **Bindings parity:** `description_hash` added to the SDK, uniffi (`.udl`), and c-ffi `Payment` types. Pagination is **not** mirrored to the bindings yet (would be a breaking signature change to `list_payments()`).
- **README:** documents all supported networks (regtest, signet, testnet3, testnet4, mainnet) and updates repo references to UTEXO-Protocol.
- **IFA:** removed from the wallet's `supported_schemas`.
