### PR TITLE
feat(vss): VSS in external-signer mode + c-ffi v0.5.2 build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,10 @@ refuses to start to avoid corrupting state. After a previous owner shuts
 down its fence is intentionally left behind; on a legitimate device wipe and
 restore the operator must call `POST /vssclearfence` (or
 `SdkNode::vss_clear_fence`) once between `init` and `unlock` to take over
-the store.
+the store. In internal-mnemonic mode this is authenticated by the wallet
+password; in external-signer mode (no mnemonic on the node) the password is
+ignored and the VSS identity is reconstructed from the persisted
+`key_source.json`, matching the identity the node acquires the fence under.
 
 VSS replication is best-effort: a write that fails to reach the server is
 queued and retried on later successful writes. The number of pending writes is

--- a/bindings/c-ffi/Cargo.lock
+++ b/bindings/c-ffi/Cargo.lock
@@ -562,7 +562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b59a3f7fbe678874fa34354097644a171276e02a49934c13b3d61c54610ddf39"
 dependencies = [
  "bdk_core",
- "electrum-client",
+ "electrum-client 0.24.1",
 ]
 
 [[package]]
@@ -1594,6 +1594,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "electrum-client"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b1f8783238bb18e6e137875b0a66f3dffe6c7ea84066e05d033cf180b150f"
+dependencies = [
+ "bitcoin",
+ "byteorder",
+ "libc",
+ "log",
+ "rustls 0.23.39",
+ "serde",
+ "serde_json",
+ "webpki-roots 0.25.4",
+ "winapi",
 ]
 
 [[package]]
@@ -2688,7 +2705,6 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.2.2"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
 dependencies = [
  "bech32 0.11.1",
  "bincode",
@@ -2698,10 +2714,10 @@ dependencies = [
  "hashbrown 0.13.2",
  "libm",
  "lightning-invoice 0.34.0",
- "lightning-macros 0.2.1 (git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility)",
+ "lightning-macros 0.2.1",
  "lightning-types 0.3.1",
  "musig2",
- "possiblyrandom 0.2.0 (git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility)",
+ "possiblyrandom 0.2.0",
  "rgb-lib",
  "serde",
  "tokio",
@@ -2710,7 +2726,6 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.2.0"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -2718,13 +2733,12 @@ dependencies = [
  "lightning 0.2.2",
  "lightning-liquidity",
  "lightning-rapid-gossip-sync",
- "possiblyrandom 0.2.0 (git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility)",
+ "possiblyrandom 0.2.0",
 ]
 
 [[package]]
 name = "lightning-block-sync"
 version = "0.2.0"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
 dependencies = [
  "bitcoin",
  "chunked_transfer",
@@ -2736,7 +2750,6 @@ dependencies = [
 [[package]]
 name = "lightning-dns-resolver"
 version = "0.3.0"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
 dependencies = [
  "dnssec-prover",
  "lightning 0.2.2",
@@ -2758,7 +2771,6 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.34.0"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
 dependencies = [
  "bech32 0.11.1",
  "bitcoin",
@@ -2770,16 +2782,24 @@ dependencies = [
 [[package]]
 name = "lightning-liquidity"
 version = "0.2.0"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
 dependencies = [
  "bitcoin",
  "chrono",
  "lightning 0.2.2",
  "lightning-invoice 0.34.0",
- "lightning-macros 0.2.1 (git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility)",
+ "lightning-macros 0.2.1",
  "lightning-types 0.3.1",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "lightning-macros"
+version = "0.2.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2794,19 +2814,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "lightning-macros"
-version = "0.2.1"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "lightning-net-tokio"
 version = "0.2.0"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
 dependencies = [
  "bitcoin",
  "lightning 0.2.2",
@@ -2816,7 +2825,6 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.2.0"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
 dependencies = [
  "bitcoin",
  "lightning 0.2.2",
@@ -2827,12 +2835,24 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.2.0"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
  "bitcoin_hashes",
  "lightning 0.2.2",
+]
+
+[[package]]
+name = "lightning-transaction-sync"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7260095a79a44b09ebd97e77855ec8b7996ab939223369f66244974a374bd2c"
+dependencies = [
+ "bitcoin",
+ "electrum-client 0.24.1",
+ "esplora-client",
+ "lightning 0.2.2",
+ "lightning-macros 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2847,7 +2867,6 @@ dependencies = [
 [[package]]
 name = "lightning-types"
 version = "0.3.1"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
 dependencies = [
  "bitcoin",
 ]
@@ -3495,8 +3514,6 @@ dependencies = [
 [[package]]
 name = "possiblyrandom"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
 dependencies = [
  "getrandom 0.2.17",
 ]
@@ -3504,7 +3521,8 @@ dependencies = [
 [[package]]
 name = "possiblyrandom"
 version = "0.2.0"
-source = "git+https://github.com/rmn-boiko/rust-lightning.git?branch=feat%2Fexternal-signer-compatibility#aa313818b54e873014bc8c429823f1ace1cd8913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
 dependencies = [
  "getrandom 0.2.17",
 ]
@@ -4192,6 +4210,8 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "electrum-client 0.20.0",
+ "esplora-client",
  "futures",
  "hex-conservative 0.3.2",
  "lightning 0.2.2",
@@ -4203,6 +4223,7 @@ dependencies = [
  "lightning-net-tokio",
  "lightning-persister",
  "lightning-rapid-gossip-sync",
+ "lightning-transaction-sync",
  "magic-crypt",
  "prost 0.13.5",
  "rand 0.8.6",
@@ -4248,7 +4269,7 @@ dependencies = [
  "baid64",
  "base85",
  "chrono",
- "electrum-client",
+ "electrum-client 0.24.1",
  "esplora-client",
  "getrandom 0.3.4",
  "indexmap",
@@ -6257,7 +6278,7 @@ dependencies = [
 [[package]]
 name = "vls-core"
 version = "0.14.0"
-source = "git+https://github.com/rmn-boiko/vls-core.git?branch=feat%2Frgb-compatibility#7567813b4a9a90349afd05e1efa73134ea31364b"
+source = "git+https://github.com/UTEXO-Protocol/vls-core.git?branch=feat%2Frgb-compatibility#45c72edfd58620849eb486925439a76526b415ae"
 dependencies = [
  "ahash",
  "anyhow",
@@ -6329,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "vls-protocol-signer"
 version = "0.14.0"
-source = "git+https://github.com/rmn-boiko/vls-protocol-signer.git?branch=feat%2Frgb-compatibility#dddd336fcdf84c4febdd7af8363bda8d1721d893"
+source = "git+https://github.com/UTEXO-Protocol/vls-protocol-signer.git?branch=feat%2Frgb-compatibility#dddd336fcdf84c4febdd7af8363bda8d1721d893"
 dependencies = [
  "bit-vec",
  "log",

--- a/bindings/c-ffi/Cargo.toml
+++ b/bindings/c-ffi/Cargo.toml
@@ -39,14 +39,21 @@ default = []
 # Mirror the parent's [patch.crates-io] so we don't end up with two copies of
 # `lightning` (which fails with trait-bound errors). Keep in lock-step with
 # the parent's pins.
+#
+# IMPORTANT: `lightning` MUST resolve to the SAME rust-lightning the parent
+# builds — the pinned submodule at `../../rust-lightning`. The parent crate's
+# v0.5.2 source uses fork-specific APIs (e.g. `RgbInfo.batch_transfer_idx`)
+# that only exist at the submodule commit; pointing these at a separate
+# `rmn-boiko` branch tip drifts behind and fails to compile the parent
+# source. Using the submodule path guarantees they never skew again.
 [patch.crates-io]
-lightning = { git = "https://github.com/rmn-boiko/rust-lightning.git", branch = "feat/external-signer-compatibility" }
-lightning-background-processor = { git = "https://github.com/rmn-boiko/rust-lightning.git", branch = "feat/external-signer-compatibility" }
-lightning-block-sync = { git = "https://github.com/rmn-boiko/rust-lightning.git", branch = "feat/external-signer-compatibility" }
-lightning-dns-resolver = { git = "https://github.com/rmn-boiko/rust-lightning.git", branch = "feat/external-signer-compatibility" }
-lightning-invoice = { git = "https://github.com/rmn-boiko/rust-lightning.git", branch = "feat/external-signer-compatibility" }
-lightning-net-tokio = { git = "https://github.com/rmn-boiko/rust-lightning.git", branch = "feat/external-signer-compatibility" }
-lightning-persister = { git = "https://github.com/rmn-boiko/rust-lightning.git", branch = "feat/external-signer-compatibility" }
-lightning-rapid-gossip-sync = { git = "https://github.com/rmn-boiko/rust-lightning.git", branch = "feat/external-signer-compatibility" }
-vls-core = { git = "https://github.com/rmn-boiko/vls-core.git", branch = "feat/rgb-compatibility" }
-vls-protocol-signer = { git = "https://github.com/rmn-boiko/vls-protocol-signer.git", branch = "feat/rgb-compatibility" }
+lightning = { path = "../../rust-lightning/lightning" }
+lightning-background-processor = { path = "../../rust-lightning/lightning-background-processor" }
+lightning-block-sync = { path = "../../rust-lightning/lightning-block-sync" }
+lightning-dns-resolver = { path = "../../rust-lightning/lightning-dns-resolver" }
+lightning-invoice = { path = "../../rust-lightning/lightning-invoice" }
+lightning-net-tokio = { path = "../../rust-lightning/lightning-net-tokio" }
+lightning-persister = { path = "../../rust-lightning/lightning-persister" }
+lightning-rapid-gossip-sync = { path = "../../rust-lightning/lightning-rapid-gossip-sync" }
+vls-core = { git = "https://github.com/UTEXO-Protocol/vls-core.git", branch = "feat/rgb-compatibility" }
+vls-protocol-signer = { git = "https://github.com/UTEXO-Protocol/vls-protocol-signer.git", branch = "feat/rgb-compatibility" }

--- a/bindings/c-ffi/src/json_types.rs
+++ b/bindings/c-ffi/src/json_types.rs
@@ -178,6 +178,11 @@ pub(crate) struct JsonSdkUnlockRequest {
     pub announce_addresses: Vec<String>,
     #[serde(default)]
     pub announce_alias: Option<String>,
+    // None / omitted → P2P gossip (default). Some(url) → Rapid Gossip Sync
+    // against the given RGS server. Added to `UnlockRequest` upstream in the
+    // gossip integration (#42).
+    #[serde(default)]
+    pub gossip_rgs_server_url: Option<String>,
 }
 
 impl From<JsonSdkUnlockRequest> for SdkUnlockRequest {
@@ -192,6 +197,7 @@ impl From<JsonSdkUnlockRequest> for SdkUnlockRequest {
             proxy_endpoint: j.proxy_endpoint,
             announce_addresses: j.announce_addresses,
             announce_alias: j.announce_alias,
+            gossip_rgs_server_url: j.gossip_rgs_server_url,
         }
     }
 }

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -3198,6 +3198,100 @@ pub(crate) fn derive_vss_identity(
     })
 }
 
+/// Derive the VSS identity in external-signer mode, where the node does not
+/// hold the mnemonic and so cannot reproduce the `m/535'/1'` private
+/// derivation [`derive_vss_identity`] uses.
+///
+/// Instead we deterministically hash the public bootstrap identity (node id,
+/// account xpubs, master fingerprint, protocol version) into a 32-byte seed
+/// and use it directly as the VSS signing key. This mirrors how
+/// [`derive_async_payments_compat_seed_from_bootstrap`] derives the
+/// async-payments preimage root in external-signer mode, with a distinct
+/// domain-separation tag so the VSS signing key and the APay seed are never
+/// the same secret.
+///
+/// Properties:
+/// - **Stable across restarts.** The bootstrap identity is re-derived from
+///   the same mnemonic on every launch and persisted in the key-source file,
+///   so the same wallet always maps to the same VSS store id + signing key.
+/// - **Not mnemonic-equivalent.** The VSS identity here differs from the
+///   `m/535'/1'` identity an internal-mnemonic node would produce for the
+///   same seed, because the external signer never exposes that private
+///   derivation. A wallet that backs up in external-signer mode must restore
+///   in external-signer mode (which is the only mode WDK uses). Making the
+///   two modes converge would require the external signer itself to expose a
+///   VSS key derivation — out of scope here.
+#[cfg(feature = "vss")]
+pub(crate) fn derive_vss_identity_from_bootstrap(
+    bootstrap: &crate::signer::types::BootstrapData,
+) -> Result<VssIdentity, APIError> {
+    let mut seed_material = Vec::new();
+    seed_material.extend_from_slice(b"rln-vss-identity-v1");
+    seed_material.extend_from_slice(bootstrap.identity.node_id.as_bytes());
+    seed_material.extend_from_slice(bootstrap.identity.account_xpub_vanilla.as_bytes());
+    seed_material.extend_from_slice(bootstrap.identity.account_xpub_colored.as_bytes());
+    seed_material.extend_from_slice(bootstrap.identity.master_fingerprint.as_bytes());
+    seed_material.extend_from_slice(bootstrap.protocol_version.as_bytes());
+    let seed = <sha256::Hash as BitcoinHash>::hash(&seed_material).to_byte_array();
+
+    let secp = Secp256k1_30::new();
+    let signing_key = rgb_lib::bitcoin::secp256k1::SecretKey::from_slice(&seed).map_err(|e| {
+        APIError::FailedVssInit(format!("VSS identity: invalid derived key from bootstrap: {e}"))
+    })?;
+    let pubkey_hex = hex_str(&signing_key.public_key(&secp).serialize());
+    Ok(VssIdentity {
+        signing_key,
+        pubkey_hex,
+    })
+}
+
+#[cfg(all(test, feature = "vss"))]
+mod vss_bootstrap_identity_tests {
+    use super::*;
+    use crate::signer::types::{BootstrapData, SignerIdentity};
+
+    fn fake_bootstrap(node_id: &str) -> BootstrapData {
+        BootstrapData {
+            identity: SignerIdentity {
+                node_id: node_id.to_string(),
+                account_xpub_vanilla: "xv".to_string(),
+                account_xpub_colored: "xc".to_string(),
+                master_fingerprint: "deadbeef".to_string(),
+            },
+            protocol_version: "1".to_string(),
+            api_level: 1,
+        }
+    }
+
+    #[test]
+    fn deterministic_for_same_bootstrap() {
+        let b = fake_bootstrap(&"02".repeat(33));
+        let a = derive_vss_identity_from_bootstrap(&b).expect("derive");
+        let c = derive_vss_identity_from_bootstrap(&b).expect("derive");
+        assert_eq!(a.pubkey_hex, c.pubkey_hex);
+        assert_eq!(a.signing_key, c.signing_key);
+    }
+
+    #[test]
+    fn differs_for_different_bootstrap() {
+        let a = derive_vss_identity_from_bootstrap(&fake_bootstrap(&"02".repeat(33)))
+            .expect("derive");
+        let b = derive_vss_identity_from_bootstrap(&fake_bootstrap(&"03".repeat(33)))
+            .expect("derive");
+        assert_ne!(a.pubkey_hex, b.pubkey_hex);
+    }
+
+    #[test]
+    fn domain_separated_from_async_payments_seed() {
+        // The VSS signing key must not equal the APay preimage seed, even
+        // though both hash the same public bootstrap material.
+        let b = fake_bootstrap(&"02".repeat(33));
+        let vss = derive_vss_identity_from_bootstrap(&b).expect("derive");
+        let apay = crate::signer::types::derive_async_payments_compat_seed_from_bootstrap(&b);
+        assert_ne!(vss.signing_key.secret_bytes(), apay);
+    }
+}
+
 /// Restore the RGB wallet directory from VSS if (a) VSS is configured for this
 /// node, (b) the local wallet directory for `expected_fingerprint` is absent,
 /// and (c) VSS has a backup for the given store. Mirrors the KV-side
@@ -3393,10 +3487,24 @@ pub(crate) async fn start_ldk(
     // derivation. [[derive_vss_identity]]
     #[cfg(feature = "vss")]
     let vss_identity: Option<VssIdentity> = if static_state.vss_url.is_some() {
-        internal_mnemonic
-            .as_ref()
-            .map(|mnemonic| derive_vss_identity(mnemonic, static_state.network.into()))
-            .transpose()?
+        // Internal-mnemonic mode derives the VSS identity from the seed at
+        // `m/535'/1'`. External-signer mode never holds the mnemonic, so it
+        // derives a stable identity from the public bootstrap instead — see
+        // [[derive_vss_identity_from_bootstrap]]. Either path yields a VSS
+        // identity stable across restarts for the same wallet.
+        match internal_mnemonic.as_ref() {
+            Some(mnemonic) => {
+                Some(derive_vss_identity(mnemonic, static_state.network.into())?)
+            }
+            None => {
+                let bootstrap = external_bootstrap.as_ref().ok_or_else(|| {
+                    APIError::FailedVssInit(
+                        "VSS identity: external-signer mode is missing bootstrap data".into(),
+                    )
+                })?;
+                Some(derive_vss_identity_from_bootstrap(bootstrap)?)
+            }
+        }
     } else {
         None
     };

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -3281,7 +3281,9 @@ fn derive_vss_identity_from_public_material(
 
     let secp = Secp256k1_30::new();
     let signing_key = rgb_lib::bitcoin::secp256k1::SecretKey::from_slice(&seed).map_err(|e| {
-        APIError::FailedVssInit(format!("VSS identity: invalid derived key from bootstrap: {e}"))
+        APIError::FailedVssInit(format!(
+            "VSS identity: invalid derived key from bootstrap: {e}"
+        ))
     })?;
     let pubkey_hex = hex_str(&signing_key.public_key(&secp).serialize());
     Ok(VssIdentity {
@@ -3319,10 +3321,10 @@ mod vss_bootstrap_identity_tests {
 
     #[test]
     fn differs_for_different_bootstrap() {
-        let a = derive_vss_identity_from_bootstrap(&fake_bootstrap(&"02".repeat(33)))
-            .expect("derive");
-        let b = derive_vss_identity_from_bootstrap(&fake_bootstrap(&"03".repeat(33)))
-            .expect("derive");
+        let a =
+            derive_vss_identity_from_bootstrap(&fake_bootstrap(&"02".repeat(33))).expect("derive");
+        let b =
+            derive_vss_identity_from_bootstrap(&fake_bootstrap(&"03".repeat(33))).expect("derive");
         assert_ne!(a.pubkey_hex, b.pubkey_hex);
     }
 
@@ -3554,9 +3556,7 @@ pub(crate) async fn start_ldk(
         // [[derive_vss_identity_from_bootstrap]]. Either path yields a VSS
         // identity stable across restarts for the same wallet.
         match internal_mnemonic.as_ref() {
-            Some(mnemonic) => {
-                Some(derive_vss_identity(mnemonic, static_state.network.into())?)
-            }
+            Some(mnemonic) => Some(derive_vss_identity(mnemonic, static_state.network.into())?),
             None => {
                 let bootstrap = external_bootstrap.as_ref().ok_or_else(|| {
                     APIError::FailedVssInit(

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -3225,13 +3225,58 @@ pub(crate) fn derive_vss_identity(
 pub(crate) fn derive_vss_identity_from_bootstrap(
     bootstrap: &crate::signer::types::BootstrapData,
 ) -> Result<VssIdentity, APIError> {
+    derive_vss_identity_from_public_material(
+        &bootstrap.identity.node_id,
+        &bootstrap.identity.account_xpub_vanilla,
+        &bootstrap.identity.account_xpub_colored,
+        &bootstrap.identity.master_fingerprint,
+        &bootstrap.protocol_version,
+    )
+}
+
+/// Derive the same bootstrap VSS identity from the persisted `key_source.json`
+/// instead of a live [`BootstrapData`].
+///
+/// `vss_clear_fence` runs on a *locked* node, so it has no unlock request and
+/// therefore no in-memory bootstrap. But the bootstrap identity is mirrored
+/// verbatim into the key-source file at external-signer init
+/// ([`crate::signer::KeySourceFile::from_bootstrap`]), so this reconstructs a
+/// VSS identity byte-identical to the one [`derive_vss_identity_from_bootstrap`]
+/// produces at unlock — which is exactly what the single-writer fence needs so
+/// the clear targets the same store id the running node acquired. The
+/// `key_source_matches_bootstrap_identity` test pins that equivalence.
+#[cfg(feature = "vss")]
+pub(crate) fn derive_vss_identity_from_key_source(
+    key_source: &crate::signer::KeySourceFile,
+) -> Result<VssIdentity, APIError> {
+    derive_vss_identity_from_public_material(
+        &key_source.node_id,
+        &key_source.account_xpub_vanilla,
+        &key_source.account_xpub_colored,
+        &key_source.master_fingerprint,
+        &key_source.protocol_version,
+    )
+}
+
+/// Shared core for the external-signer VSS identity. Hashing the same fields in
+/// the same order is what guarantees the unlock-time (bootstrap) and
+/// fence-clear-time (key-source) derivations agree; keep both callers routed
+/// through here rather than duplicating the seed layout.
+#[cfg(feature = "vss")]
+fn derive_vss_identity_from_public_material(
+    node_id: &str,
+    account_xpub_vanilla: &str,
+    account_xpub_colored: &str,
+    master_fingerprint: &str,
+    protocol_version: &str,
+) -> Result<VssIdentity, APIError> {
     let mut seed_material = Vec::new();
     seed_material.extend_from_slice(b"rln-vss-identity-v1");
-    seed_material.extend_from_slice(bootstrap.identity.node_id.as_bytes());
-    seed_material.extend_from_slice(bootstrap.identity.account_xpub_vanilla.as_bytes());
-    seed_material.extend_from_slice(bootstrap.identity.account_xpub_colored.as_bytes());
-    seed_material.extend_from_slice(bootstrap.identity.master_fingerprint.as_bytes());
-    seed_material.extend_from_slice(bootstrap.protocol_version.as_bytes());
+    seed_material.extend_from_slice(node_id.as_bytes());
+    seed_material.extend_from_slice(account_xpub_vanilla.as_bytes());
+    seed_material.extend_from_slice(account_xpub_colored.as_bytes());
+    seed_material.extend_from_slice(master_fingerprint.as_bytes());
+    seed_material.extend_from_slice(protocol_version.as_bytes());
     let seed = <sha256::Hash as BitcoinHash>::hash(&seed_material).to_byte_array();
 
     let secp = Secp256k1_30::new();
@@ -3289,6 +3334,22 @@ mod vss_bootstrap_identity_tests {
         let vss = derive_vss_identity_from_bootstrap(&b).expect("derive");
         let apay = crate::signer::types::derive_async_payments_compat_seed_from_bootstrap(&b);
         assert_ne!(vss.signing_key.secret_bytes(), apay);
+    }
+
+    #[test]
+    fn key_source_matches_bootstrap_identity() {
+        // The fence-clear path derives the VSS identity from the persisted
+        // key_source.json, while unlock derives it from the live bootstrap.
+        // Both must resolve to the same store id + signing key, otherwise
+        // `vss_clear_fence` would delete the wrong fence and the running
+        // node's store would stay locked.
+        let b = fake_bootstrap(&"02".repeat(33));
+        let key_source = crate::signer::KeySourceFile::from_bootstrap(&b);
+        let from_bootstrap = derive_vss_identity_from_bootstrap(&b).expect("derive bootstrap");
+        let from_key_source =
+            derive_vss_identity_from_key_source(&key_source).expect("derive key source");
+        assert_eq!(from_bootstrap.pubkey_hex, from_key_source.pubkey_hex);
+        assert_eq!(from_bootstrap.signing_key, from_key_source.signing_key);
     }
 }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -80,14 +80,14 @@ use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
     AsyncOrderOutboundInvoiceResponse,
 };
-#[cfg(feature = "vss")]
-use crate::ldk::{derive_vss_identity, derive_vss_identity_from_key_source};
-#[cfg(feature = "vss")]
-use crate::signer::read_key_source_file;
 use crate::ldk::{
     clear_rgb_payment_pending, start_ldk, stop_ldk, LdkBackgroundServices,
     VirtualChannelSessionStatus,
 };
+#[cfg(feature = "vss")]
+use crate::ldk::{derive_vss_identity, derive_vss_identity_from_key_source};
+#[cfg(feature = "vss")]
+use crate::signer::read_key_source_file;
 use crate::swap::{SwapData, SwapInfo, SwapString};
 use crate::utils::{
     check_already_initialized, check_channel_id, check_password_strength, check_password_validity,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -81,7 +81,9 @@ use crate::core_types::async_order::{
     AsyncOrderOutboundInvoiceResponse,
 };
 #[cfg(feature = "vss")]
-use crate::ldk::derive_vss_identity;
+use crate::ldk::{derive_vss_identity, derive_vss_identity_from_key_source};
+#[cfg(feature = "vss")]
+use crate::signer::read_key_source_file;
 use crate::ldk::{
     clear_rgb_payment_pending, start_ldk, stop_ldk, LdkBackgroundServices,
     VirtualChannelSessionStatus,
@@ -4987,8 +4989,22 @@ pub(crate) async fn vss_clear_fence(
             .clone()
             .ok_or_else(|| APIError::FailedVssInit("VSS is not configured".to_string()))?;
 
-        let mnemonic = check_password_validity(&payload.password, &state.db())?;
-        let identity = derive_vss_identity(&mnemonic, state.static_state.network.into())?;
+        // Internal-mnemonic mode authenticates with the password and derives
+        // the `m/535'/1'` identity. External-signer mode holds no mnemonic, so
+        // it reconstructs the bootstrap identity from the persisted
+        // key_source.json — the same store id start_ldk acquired the fence
+        // under. Without this branch, external-signer nodes could never clear
+        // a leftover fence and would be wedged after their first shutdown.
+        // [[derive_vss_identity_from_key_source]]
+        let identity = match read_key_source_file(&state.static_state.storage_dir_path)
+            .map_err(|e| APIError::ExternalSignerProtocolError(e.to_string()))?
+        {
+            Some(key_source) => derive_vss_identity_from_key_source(&key_source)?,
+            None => {
+                let mnemonic = check_password_validity(&payload.password, &state.db())?;
+                derive_vss_identity(&mnemonic, state.static_state.network.into())?
+            }
+        };
 
         tokio::task::spawn_blocking(move || {
             let store = crate::vss_kv_store::VssKvStore::new(

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -13,7 +13,7 @@ use crate::core_types::async_order::{
 use crate::core_types::{FEE_RATE, MIN_CHANNEL_CONFIRMATIONS};
 use crate::error::APIError;
 #[cfg(feature = "vss")]
-use crate::ldk::derive_vss_identity;
+use crate::ldk::{derive_vss_identity, derive_vss_identity_from_key_source};
 use crate::ldk::{
     clear_rgb_payment_pending, start_ldk, write_rgb_payment_info_file, InvoiceType, PaymentInfo,
     VirtualChannelSessionStatus,
@@ -1858,8 +1858,22 @@ pub(crate) async fn vss_clear_fence(
             .clone()
             .ok_or_else(|| APIError::FailedVssInit("VSS is not configured".to_string()))?;
 
-        let mnemonic = check_password_validity(&request.password, &state.db())?;
-        let identity = derive_vss_identity(&mnemonic, state.static_state.network.into())?;
+        // Internal-mnemonic mode authenticates with the password and derives
+        // the `m/535'/1'` identity. External-signer mode holds no mnemonic, so
+        // it reconstructs the bootstrap identity from the persisted
+        // key_source.json — the same store id start_ldk acquired the fence
+        // under. Without this branch, external-signer nodes could never clear
+        // a leftover fence and would be wedged after their first shutdown.
+        // [[derive_vss_identity_from_key_source]]
+        let identity = match read_key_source_file(&state.static_state.storage_dir_path)
+            .map_err(|e| APIError::ExternalSignerProtocolError(e.to_string()))?
+        {
+            Some(key_source) => derive_vss_identity_from_key_source(&key_source)?,
+            None => {
+                let mnemonic = check_password_validity(&request.password, &state.db())?;
+                derive_vss_identity(&mnemonic, state.static_state.network.into())?
+            }
+        };
 
         tokio::task::spawn_blocking(move || {
             let store = crate::vss_kv_store::VssKvStore::new(

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -12,12 +12,12 @@ use crate::core_types::async_order::{
 };
 use crate::core_types::{FEE_RATE, MIN_CHANNEL_CONFIRMATIONS};
 use crate::error::APIError;
-#[cfg(feature = "vss")]
-use crate::ldk::{derive_vss_identity, derive_vss_identity_from_key_source};
 use crate::ldk::{
     clear_rgb_payment_pending, start_ldk, write_rgb_payment_info_file, InvoiceType, PaymentInfo,
     VirtualChannelSessionStatus,
 };
+#[cfg(feature = "vss")]
+use crate::ldk::{derive_vss_identity, derive_vss_identity_from_key_source};
 use crate::rgb::{check_rgb_proxy_endpoint, get_rgb_channel_info_optional};
 use crate::signer::{
     read_key_source_file, validate_bootstrap_payload, validate_key_source_matches_bootstrap,


### PR DESCRIPTION
## Problem

In external-signer mode the node never holds the mnemonic, so the existing `derive_vss_identity` (which derives `m/535'/1'` from the master xprv) cannot run: `internal_mnemonic` is `None` → `vss_identity` resolves to `None` → the `VssClient` is never built → `vssBackup()` fails with **"VSS is not configured"**.

Net effect: **VSS cloud backup is entirely non-functional for any external-signer wallet** (which is the only mode the WDK integration `@utexo/wdk-rgb-lightning` uses). This is the last genuinely-blocked feature in the WDK external-signer surface — APay was unblocked by #65, LSP is config-only.

## Fix

Add `derive_vss_identity_from_bootstrap`: a deterministic VSS identity hashed from the **public** bootstrap material (node id, account xpubs, master fingerprint, protocol version), domain-separated (`b"rln-vss-identity-v1"`) from the async-payments seed. `start_ldk` uses the mnemonic path when present and falls back to the bootstrap path in external-signer mode.

This mirrors exactly how #65 (`derive_async_payments_compat_seed_from_bootstrap`) already derives the async-payments preimage root in external-signer mode — same pattern, distinct domain tag so the VSS signing key and the APay seed are never the same secret.

## Properties / trade-offs

- ✅ **Stable across restarts** — the bootstrap is re-derived from the same seed on every launch and persisted in the key-source file, so the same wallet always maps to the same VSS store id + signing key (which the single-writer fence requires).
- ⚠️ **Not mnemonic-equivalent** — the external-signer VSS identity differs from the `m/535'/1'` identity an internal-mnemonic node would produce for the same seed, because the external signer never exposes that private derivation. A wallet that backs up in external-signer mode must restore in external-signer mode (the only mode WDK uses). Making the two modes converge would require the **external signer itself** to expose a VSS key derivation — out of scope for this PR; flagging for discussion.

## Tests

New unit tests (`vss_bootstrap_identity_tests`) cover:
- determinism for the same bootstrap,
- distinctness across different bootstraps,
- domain separation from the APay seed.

`cargo check --features vss,vls` and `cargo test --features vss,vls vss_bootstrap_identity` both green.

## Status

**Draft** — opened to build the WDK bindings (bare + nodejs) from this branch and validate `t120.vssBackupReplication` end-to-end against a live VSS server before marking ready.