### PR TITLE
Fix: Remove rgb_send_lock

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -313,9 +313,6 @@ pub enum APIError {
     #[error("No valid transport endpoint found")]
     NoValidTransportEndpoint,
 
-    #[error("Cannot perform this operation while an open channel operation is in progress")]
-    OpenChannelInProgress,
-
     #[error("Output below the dust limit")]
     OutputBelowDustLimit,
 
@@ -588,7 +585,6 @@ impl IntoResponse for APIError {
             | APIError::NoAvailableUtxos
             | APIError::NoRoute
             | APIError::NotInitialized
-            | APIError::OpenChannelInProgress
             | APIError::PaymentNotFound(_)
             | APIError::RecipientIDAlreadyUsed
             | APIError::SwapNotFound(_)

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1428,7 +1428,6 @@ fn normalize_funding_psbt_locktime(
 // FundingGenerationReady. Returns the value to propagate from the event handler: `Err(ReplayEvent)`
 // to retry the event (for transient network errors), or `Ok(())` after force-closing the channel
 // (for terminal errors).
-#[allow(dead_code)]
 fn handle_funding_prepare_err(
     e: RgbLibError,
     channel_manager: &ChannelManager,
@@ -1556,7 +1555,6 @@ async fn handle_ldk_events(
                         false,
                     );
                     unlocked_state.virtual_channel_draft_delete(&temporary_channel_id);
-                    *unlocked_state.rgb_send_lock.lock().unwrap() = false;
                 };
 
                 let mut virtual_funding_txo = virtual_channel_synthetic_outpoint(
@@ -1757,7 +1755,6 @@ async fn handle_ldk_events(
                             updated_at: get_current_timestamp(),
                         });
                         unlocked_state.virtual_channel_draft_delete(&temporary_channel_id);
-                        *unlocked_state.rgb_send_lock.lock().unwrap() = false;
                         tracing::info!(
                             "EVENT: registered trusted no-broadcast funding {} for virtual channel {}",
                             virtual_funding_txo,
@@ -1777,7 +1774,6 @@ async fn handle_ldk_events(
                             false,
                         );
                         unlocked_state.virtual_channel_draft_delete(&temporary_channel_id);
-                        *unlocked_state.rgb_send_lock.lock().unwrap() = false;
                     }
                 }
                 return Ok(());
@@ -1814,29 +1810,21 @@ async fn handle_ldk_events(
 
                 let unlocked_state_copy = unlocked_state.clone();
                 let res = tokio::task::spawn_blocking(
-                    move || -> Result<(String, Option<i32>), String> {
-                        let res = unlocked_state_copy
-                            .rgb_send_begin(
-                                recipient_map,
-                                true,
-                                FEE_RATE,
-                                MIN_CHANNEL_CONFIRMATIONS,
-                                None,
-                                false,
-                                // Final locktime: this colored tx funds an LN channel.
-                                Some(0),
-                            )
-                            .map_err(|e| e.to_string())?;
-                        let fascia_str = fs::read_to_string(&res.details.fascia_path)
-                            .map_err(|e| e.to_string())?;
-                        let fascia: Fascia =
-                            serde_json::from_str(&fascia_str).map_err(|e| e.to_string())?;
-                        unlocked_state_copy
-                            .rgb_consume_fascia(fascia, None)
-                            .map_err(|e| e.to_string())?;
-                        unlocked_state_copy
-                            .rgb_create_consignments(res.psbt.clone())
-                            .map_err(|e| e.to_string())?;
+                    move || -> Result<(String, Option<i32>), RgbLibError> {
+                        let res = unlocked_state_copy.rgb_send_begin(
+                            recipient_map,
+                            true,
+                            FEE_RATE,
+                            MIN_CHANNEL_CONFIRMATIONS,
+                            None,
+                            false,
+                            // Final locktime: this colored tx funds an LN channel.
+                            Some(0),
+                        )?;
+                        let fascia_str = fs::read_to_string(&res.details.fascia_path).unwrap();
+                        let fascia: Fascia = serde_json::from_str(&fascia_str).unwrap();
+                        unlocked_state_copy.rgb_consume_fascia(fascia, None)?;
+                        unlocked_state_copy.rgb_create_consignments(res.psbt.clone())?;
                         Ok((res.psbt, res.batch_transfer_idx))
                     },
                 )
@@ -1844,9 +1832,18 @@ async fn handle_ldk_events(
                 .unwrap();
                 let (unsigned_psbt, batch_transfer_idx) = match res {
                     Ok(result) => result,
+                    // A failed funding preparation (e.g. the asset allocation is
+                    // momentarily reserved by a concurrent open) must fail the
+                    // channel so the caller can retry, not retry the event
+                    // forever. handle_open_chan_fail (on ChannelClosed) then
+                    // releases any reserved allocation.
                     Err(e) => {
-                        tracing::error!("cannot prepare channel funding transfer: {e}");
-                        return Err(ReplayEvent());
+                        return handle_funding_prepare_err(
+                            e,
+                            &unlocked_state.channel_manager,
+                            &temporary_channel_id,
+                            &counterparty_node_id,
+                        );
                     }
                 };
                 // Record the batch transfer index on the channel's RGB info so a failed
@@ -1866,9 +1863,25 @@ async fn handle_ldk_events(
                 }
                 (unsigned_psbt, Some(asset_id))
             } else {
-                let raw_psbt = unlocked_state
-                    .rgb_send_btc_begin(addr.to_address(), channel_value_satoshis, FEE_RATE)
-                    .unwrap();
+                // Mirror the colored path: a failed funding preparation must fail
+                // the channel (so the caller can retry) rather than panic the event
+                // task. handle_funding_prepare_err force-closes on terminal errors
+                // and replays the event on transient network errors.
+                let raw_psbt = match unlocked_state.rgb_send_btc_begin(
+                    addr.to_address(),
+                    channel_value_satoshis,
+                    FEE_RATE,
+                ) {
+                    Ok(psbt) => psbt,
+                    Err(e) => {
+                        return handle_funding_prepare_err(
+                            e,
+                            &unlocked_state.channel_manager,
+                            &temporary_channel_id,
+                            &counterparty_node_id,
+                        );
+                    }
+                };
                 let current_best_height =
                     unlocked_state.channel_manager.current_best_block().height;
                 let unsigned_psbt =
@@ -1985,7 +1998,6 @@ async fn handle_ldk_events(
                 tracing::error!(
                     "ERROR: Channel went away before we could fund it. The peer disconnected or refused the channel.",
                 );
-                *unlocked_state.rgb_send_lock.lock().unwrap() = false;
             }
         }
         Event::FundingTxBroadcastSafe { .. } => {
@@ -2577,7 +2589,6 @@ async fn handle_ldk_events(
                 .virtual_channel_session_store()
                 .contains_key(&channel_id)
             {
-                *unlocked_state.rgb_send_lock.lock().unwrap() = false;
                 tracing::info!(
                     "EVENT: virtual channel {} is pending in trusted no-broadcast mode",
                     channel_id,
@@ -2610,8 +2621,6 @@ async fn handle_ldk_events(
                         }
                     })
                     .await;
-
-                    *unlocked_state.rgb_send_lock.lock().unwrap() = false;
 
                     let finalize_result = join_result.map_err(|join_err| {
                         tracing::error!("Channel opening finalization task failed: {join_err:?}");
@@ -2696,8 +2705,6 @@ async fn handle_ldk_events(
                 reason
             );
 
-            *unlocked_state.rgb_send_lock.lock().unwrap() = false;
-
             // Release any funds locked for a funding tx that was never broadcast.
             handle_open_chan_fail(&channel_id, unlocked_state.clone()).await;
 
@@ -2729,7 +2736,6 @@ async fn handle_ldk_events(
                     &format!("virtual_channel_{}", channel_id),
                     false,
                 );
-                *unlocked_state.rgb_send_lock.lock().unwrap() = false;
 
                 tracing::warn!(
                     "EVENT: cleaned up failed virtual open draft {} after channel close {}",
@@ -4537,7 +4543,6 @@ pub(crate) async fn start_ldk(
         taker_swaps,
         router: Arc::clone(&router),
         output_sweeper: Arc::clone(&output_sweeper),
-        rgb_send_lock: Arc::new(Mutex::new(false)),
         channel_ids_map,
         proxy_endpoint: proxy_endpoint.to_string(),
         external_signer_mode,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -3885,10 +3885,6 @@ pub(crate) async fn open_channel(
         let guard = state.check_unlocked().await?;
         let unlocked_state = guard.as_ref().unwrap();
 
-        if *unlocked_state.rgb_send_lock.lock().unwrap() {
-            return Err(APIError::OpenChannelInProgress);
-        }
-
         let is_virtual_open = match payload.virtual_open_mode.as_deref() {
             None => false,
             Some(VIRTUAL_OPEN_MODE_TRUSTED_NO_BROADCAST) => true,
@@ -4180,14 +4176,6 @@ pub(crate) async fn open_channel(
             (temporary_channel_id, None)
         };
 
-        // Only colored opens perform an RGB send during funding, so only they need
-        // the RGB send lock. Vanilla opens that stall (e.g. an unresponsive peer)
-        // must not hold it, or they would block all subsequent opens indefinitely.
-        if colored_info.is_some() {
-            *unlocked_state.rgb_send_lock.lock().unwrap() = true;
-            tracing::debug!("RGB send lock set to true");
-        }
-
         let temporary_channel_id = unlocked_state
             .channel_manager
             .create_channel(
@@ -4201,8 +4189,6 @@ pub(crate) async fn open_channel(
                 payload.push_asset_amount,
             )
             .map_err(|e| {
-                *unlocked_state.rgb_send_lock.lock().unwrap() = false;
-                tracing::debug!("RGB send lock set to false (open channel failure: {e:?})");
                 if let Some(temp_id_str) = rgb_metadata_temp_id_str.as_deref() {
                     let _ = unlocked_state
                         .kv_store

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1646,10 +1646,6 @@ pub(crate) async fn send_rgb(
     let guard = check_unlocked(&state).await?;
     let unlocked_state = guard.as_ref().unwrap();
 
-    if *unlocked_state.rgb_send_lock.lock().unwrap() {
-        return Err(APIError::OpenChannelInProgress);
-    }
-
     let send_result = if unlocked_state.external_signer_mode {
         let unlocked_state_copy = unlocked_state.clone();
         let begin_result = tokio::task::spawn_blocking(move || {
@@ -2349,10 +2345,6 @@ pub(crate) async fn issue_asset_nia(
         ));
     }
 
-    if *unlocked_state.rgb_send_lock.lock().unwrap() {
-        return Err(APIError::OpenChannelInProgress);
-    }
-
     let asset = unlocked_state.rgb_issue_asset_nia(
         request.ticker,
         request.name,
@@ -2373,10 +2365,6 @@ pub(crate) async fn issue_asset_cfa(
         return Err(APIError::UnsupportedInExternalSignerMode(
             "asset issuance is not supported in external signer mode".to_string(),
         ));
-    }
-
-    if *unlocked_state.rgb_send_lock.lock().unwrap() {
-        return Err(APIError::OpenChannelInProgress);
     }
 
     let file_path = request.file_digest.map(|d| {
@@ -2410,10 +2398,6 @@ pub(crate) async fn issue_asset_ifa(
         ));
     }
 
-    if *unlocked_state.rgb_send_lock.lock().unwrap() {
-        return Err(APIError::OpenChannelInProgress);
-    }
-
     let asset = unlocked_state.rgb_issue_asset_ifa(
         request.ticker,
         request.name,
@@ -2436,10 +2420,6 @@ pub(crate) async fn issue_asset_uda(
         return Err(APIError::UnsupportedInExternalSignerMode(
             "asset issuance is not supported in external signer mode".to_string(),
         ));
-    }
-
-    if *unlocked_state.rgb_send_lock.lock().unwrap() {
-        return Err(APIError::OpenChannelInProgress);
     }
 
     let rgb_media_dir = unlocked_state.rgb_get_media_dir();
@@ -2639,10 +2619,6 @@ pub(crate) async fn rgb_invoice(
     let guard = check_unlocked(&state).await?;
     let unlocked_state = guard.as_ref().unwrap();
 
-    if *unlocked_state.rgb_send_lock.lock().unwrap() {
-        return Err(APIError::OpenChannelInProgress);
-    }
-
     let assignment = match request.assignment_kind {
         Some(kind) => rgb_assignment_from_kind(kind, request.assignment_amount)?,
         None => RgbLibAssignment::Any,
@@ -2683,10 +2659,6 @@ pub(crate) async fn open_channel(
 ) -> Result<OpenChannelData, APIError> {
     let guard = check_unlocked(&state).await?;
     let unlocked_state = guard.as_ref().unwrap();
-
-    if *unlocked_state.rgb_send_lock.lock().unwrap() {
-        return Err(APIError::OpenChannelInProgress);
-    }
 
     let is_virtual_open = match request.virtual_open_mode.as_deref() {
         None => false,
@@ -2958,13 +2930,6 @@ pub(crate) async fn open_channel(
             (temporary_channel_id, None)
         };
 
-    // Only colored opens perform an RGB send during funding, so only they need the
-    // RGB send lock. Vanilla opens that stall must not hold it (see routes.rs).
-    if colored_info.is_some() {
-        *unlocked_state.rgb_send_lock.lock().unwrap() = true;
-        tracing::debug!("RGB send lock set to true");
-    }
-
     let temporary_channel_id = unlocked_state
         .channel_manager
         .create_channel(
@@ -2978,8 +2943,6 @@ pub(crate) async fn open_channel(
             request.push_asset_amount,
         )
         .map_err(|e| {
-            *unlocked_state.rgb_send_lock.lock().unwrap() = false;
-            tracing::debug!("RGB send lock set to false (open channel failure: {e:?})");
             if let Some(temp_id_str) = rgb_metadata_temp_id_str.as_deref() {
                 let _ = unlocked_state
                     .kv_store
@@ -4041,10 +4004,6 @@ pub(crate) async fn inflate(
         return Err(APIError::UnsupportedInExternalSignerMode(
             "inflate is not supported in external signer mode".to_string(),
         ));
-    }
-
-    if *unlocked_state.rgb_send_lock.lock().unwrap() {
-        return Err(APIError::OpenChannelInProgress);
     }
 
     let unlocked_state_copy = unlocked_state.clone();

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1626,7 +1626,13 @@ async fn open_channel_raw(
             }
         }
         if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 50.0 {
-            panic!("cannot find funding TX")
+            // The channel may have been force-closed before reaching
+            // ChannelPending (e.g. a colored funding preparation failed because
+            // the asset allocation was momentarily reserved by a concurrent
+            // open). Surface a retryable error so open_channel_with_retry tries
+            // again once the contending open has settled.
+            println!("cannot find funding TX for channel to {dest_peer_pubkey}");
+            return Err(reqwest::StatusCode::FORBIDDEN);
         }
     }
     let channel_id = channel_id.unwrap();

--- a/src/test/openchannel_fail.rs
+++ b/src/test/openchannel_fail.rs
@@ -580,34 +580,7 @@ async fn openchannel_fail() {
         .await
         .unwrap();
     assert!(res.status() == reqwest::StatusCode::OK);
-    // open a 2nd channel while the previous open is still in progess (fail)
-    let payload = OpenChannelRequest {
-        peer_pubkey_and_opt_addr: format!("{node2_pubkey}@127.0.0.1:{NODE2_PEER_PORT}"),
-        capacity_sat: 100_000,
-        push_msat: 3_500_000,
-        asset_amount: Some(100),
-        asset_id: Some(asset_id),
-        push_asset_amount: None,
-        public: true,
-        with_anchors: true,
-        fee_base_msat: None,
-        fee_proportional_millionths: None,
-        temporary_channel_id: None,
-        virtual_open_mode: None,
-    };
-    let res = reqwest::Client::new()
-        .post(format!("http://{node1_addr}/openchannel"))
-        .json(&payload)
-        .send()
-        .await
-        .unwrap();
-    check_response_is_nok(
-        res,
-        reqwest::StatusCode::FORBIDDEN,
-        "Cannot perform this operation while an open channel operation is in progress",
-        "OpenChannelInProgress",
-    )
-    .await;
+    let _ = asset_id;
 
     let t_0 = OffsetDateTime::now_utc();
     loop {

--- a/src/uniffi_api/README.md
+++ b/src/uniffi_api/README.md
@@ -202,7 +202,7 @@ Detailed structure:
 - User/input/domain validation failures are surfaced as `RlnError::InvalidRequest`.
 - Missing resources (`PaymentNotFound`, `SwapNotFound`, `Unknown*`) map to
   `RlnError::NotFound`.
-- State conflicts (`OpenChannelInProgress`, `Already*`, etc.) map to
+- State conflicts (`Already*`, `ChangingState`, etc.) map to
   `RlnError::Conflict`.
 - Initialization/locked-state situations return `RlnError::NotInitialized`.
 

--- a/src/uniffi_api/state.rs
+++ b/src/uniffi_api/state.rs
@@ -144,7 +144,6 @@ pub(crate) fn map_api_error(err: APIError) -> RlnError {
         | APIError::CannotCloseChannel(_)
         | APIError::CannotEstimateFees
         | APIError::ChangingState
-        | APIError::OpenChannelInProgress
         | APIError::InsufficientAssets
         | APIError::InvalidIndexer(_)
         | APIError::InvalidProxyEndpoint

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -270,10 +270,6 @@ mod uniffi_smoke_tests {
             RlnError::NotFound
         ));
         assert!(matches!(
-            super::super::state::map_api_error(crate::error::APIError::OpenChannelInProgress),
-            RlnError::Conflict
-        ));
-        assert!(matches!(
             super::super::state::map_api_error(crate::error::APIError::FailedBitcoindConnection(
                 "down".to_string()
             )),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -173,7 +173,6 @@ pub(crate) struct UnlockedAppState {
     pub(crate) rgb_wallet_wrapper: Arc<RgbLibWalletWrapper>,
     pub(crate) router: Arc<Router>,
     pub(crate) output_sweeper: Arc<OutputSweeper>,
-    pub(crate) rgb_send_lock: Arc<Mutex<bool>>,
     pub(crate) channel_ids_map: Arc<Mutex<ChannelIdsMap>>,
     pub(crate) proxy_endpoint: String,
     pub(crate) external_signer_mode: bool,


### PR DESCRIPTION
We keep an app-level `rgb_send_lock` (UTEXO-fork-only; absent upstream) that serializes every colored channel open. Without it, `concurrent_openchannel` breaks: contended colored opens get stuck pending and the test panics with `cannot find funding TX`. The lock is a band-aid hiding an RLN-side regression.

## Root cause
On a colored open, funding is prepared in the `FundingGenerationReady` handler. When `rgb_send_begin` fails (e.g. the asset allocation is momentarily reserved by another in-flight open), the handler returned `Err(ReplayEvent())`, which makes LDK **retry the event forever** instead of failing the channel. The fix helper `handle_funding_prepare_err` already existed but was `#[allow(dead_code)]` and unused. Upstream has no lock because it routes the error through `handle_funding_prepare_err` (force-close terminal errors so the caller retries; replay only on transient network errors) and surfaces `InsufficientAssets` → HTTP 403 → retry.
