### PR TITLE
Add pagination and status/time/direction filtering to list endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -664,7 +664,8 @@ paths:
         List the node's LN payments (inbound and outbound) ordered most-recent
         first. Supports index-based cursor pagination: pass the
         last_index_offset of a page as the next index_offset to fetch the next,
-        older page.
+        older page. Optionally filter by status, direction (inbound/outbound)
+        and creation time interval.
       parameters:
         - in: query
           name: index_offset
@@ -684,6 +685,46 @@ paths:
           description: >-
             Maximum number of payments to return. Defaults to 100 when absent or
             zero.
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
+            enum:
+              - Pending
+              - Succeeded
+              - Failed
+              - Claimable
+              - Claiming
+              - Cancelled
+          description: Return only payments with this HTLC status.
+        - in: query
+          name: direction
+          required: false
+          schema:
+            type: string
+            enum:
+              - Inbound
+              - Outbound
+          description: Return only inbound or only outbound payments.
+        - in: query
+          name: created_after
+          required: false
+          schema:
+            type: integer
+            format: uint64
+          description: >-
+            Return only payments created at or after this Unix timestamp
+            (seconds).
+        - in: query
+          name: created_before
+          required: false
+          schema:
+            type: integer
+            format: uint64
+          description: >-
+            Return only payments created at or before this Unix timestamp
+            (seconds).
       responses:
         '200':
           description: Successful operation
@@ -722,7 +763,10 @@ paths:
       tags:
         - On-chain
       summary: List transactions
-      description: List the node's on-chain transactions
+      description: >-
+        List the node's on-chain transactions, ordered most-recent first.
+        Supports index-based cursor pagination: pass the last_index_offset of a
+        page as the next index_offset to fetch the next, older page.
       requestBody:
         content:
           application/json:
@@ -740,7 +784,10 @@ paths:
       tags:
         - RGB
       summary: List transfers
-      description: List the node's on-chain RGB transfers
+      description: >-
+        List the node's RGB transfers for an asset, ordered most-recent first.
+        Supports index-based cursor pagination (idx) and optional filtering by
+        status and creation time interval.
       requestBody:
         content:
           application/json:
@@ -758,7 +805,10 @@ paths:
       tags:
         - On-chain
       summary: List unspents
-      description: List the unspent outputs of the internal BDK wallet
+      description: >-
+        List the unspent outputs of the internal BDK wallet. Supports
+        index-based cursor pagination: pass the last_index_offset of a page as
+        the next index_offset to fetch the next page.
       requestBody:
         content:
           application/json:
@@ -2639,15 +2689,41 @@ components:
         skip_sync:
           type: boolean
           example: false
+        index_offset:
+          type:
+            - integer
+            - 'null'
+          format: uint64
+          description: >-
+            Exclusive upper-bound cursor: only transactions with a lower index
+            are returned. 0 or absent means start from the most recent.
+        max_transactions:
+          type:
+            - integer
+            - 'null'
+          format: uint64
+          description: Maximum number to return. Defaults to 100 when absent or zero.
     ListTransactionsResponse:
       type: object
       required:
         - transactions
+        - first_index_offset
+        - last_index_offset
       properties:
         transactions:
           type: array
           items:
             $ref: '#/components/schemas/Transaction'
+        first_index_offset:
+          type: integer
+          format: uint64
+          description: Index of the first transaction in the page, or 0 when empty.
+        last_index_offset:
+          type: integer
+          format: uint64
+          description: >-
+            Index of the last transaction in the page, or 0 when empty. Pass as
+            index_offset to fetch the next, older page.
     ListTransfersRequest:
       type: object
       required:
@@ -2656,15 +2732,70 @@ components:
         asset_id:
           type: string
           example: rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ8
+        index_offset:
+          type:
+            - integer
+            - 'null'
+          format: uint64
+          description: >-
+            Exclusive upper-bound cursor: only transfers with a lower idx are
+            returned. 0 or absent means start from the most recent.
+        max_transfers:
+          type:
+            - integer
+            - 'null'
+          format: uint64
+          description: Maximum number to return. Defaults to 100 when absent or zero.
+        status:
+          type:
+            - string
+            - 'null'
+          enum:
+            - Initiated
+            - WaitingCounterparty
+            - WaitingSafeHeight
+            - WaitingConfirmations
+            - Settled
+            - Failed
+            - null
+          description: Return only transfers with this status.
+        created_after:
+          type:
+            - integer
+            - 'null'
+          format: uint64
+          description: >-
+            Return only transfers created at or after this Unix timestamp
+            (seconds).
+        created_before:
+          type:
+            - integer
+            - 'null'
+          format: uint64
+          description: >-
+            Return only transfers created at or before this Unix timestamp
+            (seconds).
     ListTransfersResponse:
       type: object
       required:
         - transfers
+        - first_index_offset
+        - last_index_offset
       properties:
         transfers:
           type: array
           items:
             $ref: '#/components/schemas/Transfer'
+        first_index_offset:
+          type: integer
+          format: uint64
+          description: Index (idx) of the first transfer in the page, or 0 when empty.
+        last_index_offset:
+          type: integer
+          format: uint64
+          description: >-
+            Index (idx) of the last transfer in the page, or 0 when empty. Pass
+            as index_offset to fetch the next, older page.
     ListUnspentsRequest:
       type: object
       required:
@@ -2677,15 +2808,41 @@ components:
         skip_sync:
           type: boolean
           example: false
+        index_offset:
+          type:
+            - integer
+            - 'null'
+          format: uint64
+          description: >-
+            Exclusive upper-bound cursor: only unspents with a lower index are
+            returned. 0 or absent means start from the first.
+        max_unspents:
+          type:
+            - integer
+            - 'null'
+          format: uint64
+          description: Maximum number to return. Defaults to 100 when absent or zero.
     ListUnspentsResponse:
       type: object
       required:
         - unspents
+        - first_index_offset
+        - last_index_offset
       properties:
         unspents:
           type: array
           items:
             $ref: '#/components/schemas/Unspent'
+        first_index_offset:
+          type: integer
+          format: uint64
+          description: Index of the first unspent in the page, or 0 when empty.
+        last_index_offset:
+          type: integer
+          format: uint64
+          description: >-
+            Index of the last unspent in the page, or 0 when empty. Pass as
+            index_offset to fetch the next page.
     LNInvoiceRequest:
       type: object
       required:

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -806,6 +806,10 @@ pub(crate) struct ListChannelsResponse {
 pub(crate) struct ListPaymentsRequest {
     pub(crate) index_offset: Option<u64>,
     pub(crate) max_payments: Option<u64>,
+    pub(crate) status: Option<HTLCStatus>,
+    pub(crate) direction: Option<PaymentDirection>,
+    pub(crate) created_after: Option<u64>,
+    pub(crate) created_before: Option<u64>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -816,6 +820,41 @@ pub(crate) struct ListPaymentsResponse {
 }
 
 const DEFAULT_MAX_PAYMENTS: u64 = 100;
+const DEFAULT_MAX_TRANSFERS: u64 = 100;
+const DEFAULT_MAX_UNSPENTS: u64 = 100;
+const DEFAULT_MAX_TRANSACTIONS: u64 = 100;
+
+/// Resolve a caller-supplied page size, treating absent or zero as the default.
+fn resolve_page_size(max: Option<u64>, default: u64) -> u64 {
+    match max {
+        Some(0) | None => default,
+        Some(m) => m,
+    }
+}
+
+/// Inclusive `[after, before]` timestamp filter; an absent bound is open-ended.
+fn in_time_range(ts: u64, after: Option<u64>, before: Option<u64>) -> bool {
+    after.map_or(true, |a| ts >= a) && before.map_or(true, |b| ts <= b)
+}
+
+/// Newest-first cursor pagination over `(index, value)` pairs. `index_offset`
+/// is an exclusive upper bound (0 = start from the newest); returns the page
+/// plus its first (newest) and last (oldest) index, both 0 when empty.
+fn paginate_newest_first<T>(
+    mut items: Vec<(u64, T)>,
+    index_offset: u64,
+    max: u64,
+) -> (Vec<T>, u64, u64) {
+    items.sort_by_key(|(idx, _)| std::cmp::Reverse(*idx));
+    let page: Vec<(u64, T)> = items
+        .into_iter()
+        .filter(|(idx, _)| index_offset == 0 || *idx < index_offset)
+        .take(max as usize)
+        .collect();
+    let first = page.first().map(|(idx, _)| *idx).unwrap_or(0);
+    let last = page.last().map(|(idx, _)| *idx).unwrap_or(0);
+    (page.into_iter().map(|(_, v)| v).collect(), first, last)
+}
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct ListPeersResponse {
@@ -831,32 +870,47 @@ pub(crate) struct ListSwapsResponse {
 #[derive(Deserialize, Serialize)]
 pub(crate) struct ListTransactionsRequest {
     pub(crate) skip_sync: bool,
+    pub(crate) index_offset: Option<u64>,
+    pub(crate) max_transactions: Option<u64>,
 }
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct ListTransactionsResponse {
     pub(crate) transactions: Vec<Transaction>,
+    pub(crate) first_index_offset: u64,
+    pub(crate) last_index_offset: u64,
 }
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct ListTransfersRequest {
     pub(crate) asset_id: String,
+    pub(crate) index_offset: Option<u64>,
+    pub(crate) max_transfers: Option<u64>,
+    pub(crate) status: Option<TransferStatus>,
+    pub(crate) created_after: Option<u64>,
+    pub(crate) created_before: Option<u64>,
 }
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct ListTransfersResponse {
     pub(crate) transfers: Vec<Transfer>,
+    pub(crate) first_index_offset: u64,
+    pub(crate) last_index_offset: u64,
 }
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct ListUnspentsRequest {
     pub(crate) settled_only: bool,
     pub(crate) skip_sync: bool,
+    pub(crate) index_offset: Option<u64>,
+    pub(crate) max_unspents: Option<u64>,
 }
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct ListUnspentsResponse {
     pub(crate) unspents: Vec<Unspent>,
+    pub(crate) first_index_offset: u64,
+    pub(crate) last_index_offset: u64,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -974,6 +1028,21 @@ pub(crate) enum PaymentType {
     Outbound,
     InboundAutoClaim,
     InboundHodl,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+pub(crate) enum PaymentDirection {
+    Inbound,
+    Outbound,
+}
+
+impl PaymentType {
+    fn direction(self) -> PaymentDirection {
+        match self {
+            PaymentType::Outbound => PaymentDirection::Outbound,
+            PaymentType::InboundAutoClaim | PaymentType::InboundHodl => PaymentDirection::Inbound,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -3138,26 +3207,19 @@ pub(crate) async fn list_payments(
         ));
     }
 
-    // Newest-first ordering by stable payment index.
-    all.sort_by_key(|(idx, _)| std::cmp::Reverse(*idx));
+    all.retain(|(_, p)| {
+        params.status.map_or(true, |s| p.status == s)
+            && params
+                .direction
+                .map_or(true, |d| p.payment_type.direction() == d)
+            && in_time_range(p.created_at, params.created_after, params.created_before)
+    });
 
-    let index_offset = params.index_offset.unwrap_or(0);
-    let max_payments = match params.max_payments {
-        Some(0) | None => DEFAULT_MAX_PAYMENTS,
-        Some(m) => m,
-    };
-
-    // `index_offset` is an exclusive upper-bound cursor; 0 means no bound
-    // (start from the most recent payment).
-    let page: Vec<(u64, Payment)> = all
-        .into_iter()
-        .filter(|(idx, _)| index_offset == 0 || *idx < index_offset)
-        .take(max_payments as usize)
-        .collect();
-
-    let first_index_offset = page.first().map(|(idx, _)| *idx).unwrap_or(0);
-    let last_index_offset = page.last().map(|(idx, _)| *idx).unwrap_or(0);
-    let payments = page.into_iter().map(|(_, p)| p).collect();
+    let (payments, first_index_offset, last_index_offset) = paginate_newest_first(
+        all,
+        params.index_offset.unwrap_or(0),
+        resolve_page_size(params.max_payments, DEFAULT_MAX_PAYMENTS),
+    );
 
     Ok(Json(ListPaymentsResponse {
         payments,
@@ -3261,7 +3323,30 @@ pub(crate) async fn list_transactions(
         })
     }
 
-    Ok(Json(ListTransactionsResponse { transactions }))
+    // No stable index; order newest-first (unconfirmed first, then by height)
+    // and derive a descending index so the cursor walks a consistent snapshot.
+    transactions.sort_by(|a, b| {
+        let ha = a.confirmation_time.as_ref().map_or(u32::MAX, |c| c.height);
+        let hb = b.confirmation_time.as_ref().map_or(u32::MAX, |c| c.height);
+        hb.cmp(&ha).then_with(|| a.txid.cmp(&b.txid))
+    });
+    let count = transactions.len() as u64;
+    let indexed = transactions
+        .into_iter()
+        .enumerate()
+        .map(|(i, t)| (count - i as u64, t))
+        .collect();
+    let (transactions, first_index_offset, last_index_offset) = paginate_newest_first(
+        indexed,
+        payload.index_offset.unwrap_or(0),
+        resolve_page_size(payload.max_transactions, DEFAULT_MAX_TRANSACTIONS),
+    );
+
+    Ok(Json(ListTransactionsResponse {
+        transactions,
+        first_index_offset,
+        last_index_offset,
+    }))
 }
 
 pub(crate) async fn list_transfers(
@@ -3315,7 +3400,28 @@ pub(crate) async fn list_transfers(
                 .collect(),
         })
     }
-    Ok(Json(ListTransfersResponse { transfers }))
+
+    transfers.retain(|t| {
+        payload.status.as_ref().map_or(true, |s| &t.status == s)
+            && in_time_range(
+                t.created_at as u64,
+                payload.created_after,
+                payload.created_before,
+            )
+    });
+
+    let indexed = transfers.into_iter().map(|t| (t.idx as u64, t)).collect();
+    let (transfers, first_index_offset, last_index_offset) = paginate_newest_first(
+        indexed,
+        payload.index_offset.unwrap_or(0),
+        resolve_page_size(payload.max_transfers, DEFAULT_MAX_TRANSFERS),
+    );
+
+    Ok(Json(ListTransfersResponse {
+        transfers,
+        first_index_offset,
+        last_index_offset,
+    }))
 }
 
 pub(crate) async fn list_unspents(
@@ -3344,7 +3450,27 @@ pub(crate) async fn list_unspents(
                 .collect(),
         })
     }
-    Ok(Json(ListUnspentsResponse { unspents }))
+
+    // UTXOs have no stable index; derive a deterministic descending one from a
+    // fixed (outpoint) ordering so the cursor walks a consistent snapshot.
+    unspents.sort_by(|a, b| a.utxo.outpoint.cmp(&b.utxo.outpoint));
+    let count = unspents.len() as u64;
+    let indexed = unspents
+        .into_iter()
+        .enumerate()
+        .map(|(i, u)| (count - i as u64, u))
+        .collect();
+    let (unspents, first_index_offset, last_index_offset) = paginate_newest_first(
+        indexed,
+        payload.index_offset.unwrap_or(0),
+        resolve_page_size(payload.max_unspents, DEFAULT_MAX_UNSPENTS),
+    );
+
+    Ok(Json(ListUnspentsResponse {
+        unspents,
+        first_index_offset,
+        last_index_offset,
+    }))
 }
 
 pub(crate) async fn ln_invoice(
@@ -5078,5 +5204,60 @@ mod request_tests {
     fn node_info_response_rgs_timestamp_null_when_absent() {
         let json = serde_json::to_value(sample_node_info(None)).unwrap();
         assert!(json["latest_rgs_snapshot_timestamp"].is_null());
+    }
+
+    fn pairs(indexes: &[u64]) -> Vec<(u64, String)> {
+        indexes.iter().map(|i| (*i, format!("v{i}"))).collect()
+    }
+
+    #[test]
+    fn paginate_orders_newest_first_unbounded() {
+        let (page, first, last) = paginate_newest_first(pairs(&[3, 1, 5, 2, 4]), 0, 100);
+        assert_eq!(page, vec!["v5", "v4", "v3", "v2", "v1"]);
+        assert_eq!(first, 5);
+        assert_eq!(last, 1);
+    }
+
+    #[test]
+    fn paginate_max_bounds_to_newest_n() {
+        let (page, first, last) = paginate_newest_first(pairs(&[3, 1, 5, 2, 4]), 0, 2);
+        assert_eq!(page, vec!["v5", "v4"]);
+        assert_eq!(first, 5);
+        assert_eq!(last, 4);
+    }
+
+    #[test]
+    fn paginate_index_offset_is_exclusive_upper_bound() {
+        let (page, first, last) = paginate_newest_first(pairs(&[3, 1, 5, 2, 4]), 4, 2);
+        assert_eq!(page, vec!["v3", "v2"]);
+        assert_eq!(first, 3);
+        assert_eq!(last, 2);
+    }
+
+    #[test]
+    fn paginate_empty_page_reports_zero_offsets() {
+        let (page, first, last) = paginate_newest_first(pairs(&[3, 1, 2]), 1, 100);
+        assert!(page.is_empty());
+        assert_eq!(first, 0);
+        assert_eq!(last, 0);
+    }
+
+    #[test]
+    fn paginate_walks_cursor_to_exhaustion_without_overlap() {
+        let all = [5u64, 4, 3, 2, 1];
+        let mut seen = vec![];
+        let mut cursor = 0u64;
+        loop {
+            let (page, _first, last) = paginate_newest_first(pairs(&all), cursor, 2);
+            if page.is_empty() {
+                break;
+            }
+            for v in &page {
+                assert!(!seen.contains(v));
+                seen.push(v.clone());
+            }
+            cursor = last;
+        }
+        assert_eq!(seen, vec!["v5", "v4", "v3", "v2", "v1"]);
     }
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -834,7 +834,7 @@ fn resolve_page_size(max: Option<u64>, default: u64) -> u64 {
 
 /// Inclusive `[after, before]` timestamp filter; an absent bound is open-ended.
 fn in_time_range(ts: u64, after: Option<u64>, before: Option<u64>) -> bool {
-    after.map_or(true, |a| ts >= a) && before.map_or(true, |b| ts <= b)
+    after.is_none_or(|a| ts >= a) && before.is_none_or(|b| ts <= b)
 }
 
 /// Newest-first cursor pagination over `(index, value)` pairs. `index_offset`
@@ -3208,10 +3208,10 @@ pub(crate) async fn list_payments(
     }
 
     all.retain(|(_, p)| {
-        params.status.map_or(true, |s| p.status == s)
+        params.status.is_none_or(|s| p.status == s)
             && params
                 .direction
-                .map_or(true, |d| p.payment_type.direction() == d)
+                .is_none_or(|d| p.payment_type.direction() == d)
             && in_time_range(p.created_at, params.created_after, params.created_before)
     });
 
@@ -3402,7 +3402,7 @@ pub(crate) async fn list_transfers(
     }
 
     transfers.retain(|t| {
-        payload.status.as_ref().map_or(true, |s| &t.status == s)
+        payload.status.as_ref().is_none_or(|s| &t.status == s)
             && in_time_range(
                 t.created_at as u64,
                 payload.created_after,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -58,11 +58,11 @@ use crate::routes::{
     ListPeersResponse, ListSwapsResponse, ListTransactionsRequest, ListTransactionsResponse,
     ListTransfersRequest, ListTransfersResponse, ListUnspentsRequest, ListUnspentsResponse,
     MakerExecuteRequest, MakerInitRequest, MakerInitResponse, NetworkInfoResponse,
-    NodeInfoResponse, OpenChannelRequest, OpenChannelResponse, Payment, PaymentType, Peer,
-    PostAssetMediaResponse, Recipient, RefreshRequest, RestoreRequest, RevokeTokenRequest,
-    RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest, SendBtcResponse, SendPaymentRequest,
-    SendPaymentResponse, SendRgbRequest, SendRgbResponse, Swap, TakerRequest, Transaction,
-    Transfer, UnlockRequest, Unspent, WitnessData,
+    NodeInfoResponse, OpenChannelRequest, OpenChannelResponse, Payment, PaymentDirection,
+    PaymentType, Peer, PostAssetMediaResponse, Recipient, RefreshRequest, RestoreRequest,
+    RevokeTokenRequest, RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest, SendBtcResponse,
+    SendPaymentRequest, SendPaymentResponse, SendRgbRequest, SendRgbResponse, Swap, TakerRequest,
+    Transaction, Transfer, TransferStatus, UnlockRequest, Unspent, WitnessData,
 };
 use crate::utils::{
     get_db_path, hex_str, hex_str_to_vec, validate_and_parse_payment_hash, AppState,
@@ -1077,6 +1077,44 @@ async fn list_payments_full(
         .unwrap()
 }
 
+#[derive(Default)]
+struct ListPaymentsFilter {
+    status: Option<HTLCStatus>,
+    direction: Option<PaymentDirection>,
+    created_after: Option<u64>,
+    created_before: Option<u64>,
+}
+
+async fn list_payments_filtered(
+    node_address: SocketAddr,
+    filter: ListPaymentsFilter,
+) -> ListPaymentsResponse {
+    let mut query = vec![];
+    if let Some(s) = filter.status {
+        query.push(format!("status={s:?}"));
+    }
+    if let Some(d) = filter.direction {
+        query.push(format!("direction={d:?}"));
+    }
+    if let Some(a) = filter.created_after {
+        query.push(format!("created_after={a}"));
+    }
+    if let Some(b) = filter.created_before {
+        query.push(format!("created_before={b}"));
+    }
+    let mut url = format!("http://{node_address}/listpayments");
+    if !query.is_empty() {
+        url.push('?');
+        url.push_str(&query.join("&"));
+    }
+    let res = reqwest::Client::new().get(url).send().await.unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<ListPaymentsResponse>()
+        .await
+        .unwrap()
+}
+
 async fn get_payment(
     node_address: SocketAddr,
     payment_hash: &str,
@@ -1147,8 +1185,22 @@ async fn get_swap(node_address: SocketAddr, payment_hash: &str, taker: bool) -> 
 }
 
 async fn list_transactions(node_address: SocketAddr) -> Vec<Transaction> {
+    list_transactions_full(node_address, None, None)
+        .await
+        .transactions
+}
+
+async fn list_transactions_full(
+    node_address: SocketAddr,
+    index_offset: Option<u64>,
+    max_transactions: Option<u64>,
+) -> ListTransactionsResponse {
     println!("listing transactions for node {node_address}");
-    let payload = ListTransactionsRequest { skip_sync: false };
+    let payload = ListTransactionsRequest {
+        skip_sync: false,
+        index_offset,
+        max_transactions,
+    };
     let res = reqwest::Client::new()
         .post(format!("http://{node_address}/listtransactions"))
         .json(&payload)
@@ -1160,13 +1212,36 @@ async fn list_transactions(node_address: SocketAddr) -> Vec<Transaction> {
         .json::<ListTransactionsResponse>()
         .await
         .unwrap()
-        .transactions
 }
 
 async fn list_transfers(node_address: SocketAddr, asset_id: &str) -> Vec<Transfer> {
+    list_transfers_full(node_address, asset_id, ListTransfersFilter::default())
+        .await
+        .transfers
+}
+
+#[derive(Default)]
+struct ListTransfersFilter {
+    index_offset: Option<u64>,
+    max_transfers: Option<u64>,
+    status: Option<TransferStatus>,
+    created_after: Option<u64>,
+    created_before: Option<u64>,
+}
+
+async fn list_transfers_full(
+    node_address: SocketAddr,
+    asset_id: &str,
+    filter: ListTransfersFilter,
+) -> ListTransfersResponse {
     println!("listing transfers for asset {asset_id} on node {node_address}");
     let payload = ListTransfersRequest {
         asset_id: asset_id.to_string(),
+        index_offset: filter.index_offset,
+        max_transfers: filter.max_transfers,
+        status: filter.status,
+        created_after: filter.created_after,
+        created_before: filter.created_before,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node_address}/listtransfers"))
@@ -1179,14 +1254,23 @@ async fn list_transfers(node_address: SocketAddr, asset_id: &str) -> Vec<Transfe
         .json::<ListTransfersResponse>()
         .await
         .unwrap()
-        .transfers
 }
 
 async fn list_unspents(node_address: SocketAddr) -> Vec<Unspent> {
+    list_unspents_full(node_address, None, None).await.unspents
+}
+
+async fn list_unspents_full(
+    node_address: SocketAddr,
+    index_offset: Option<u64>,
+    max_unspents: Option<u64>,
+) -> ListUnspentsResponse {
     println!("listing unspents for node {node_address}");
     let payload = ListUnspentsRequest {
         settled_only: false,
         skip_sync: false,
+        index_offset,
+        max_unspents,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node_address}/listunspents"))
@@ -1199,7 +1283,6 @@ async fn list_unspents(node_address: SocketAddr) -> Vec<Unspent> {
         .json::<ListUnspentsResponse>()
         .await
         .unwrap()
-        .unspents
 }
 
 async fn ln_invoice(
@@ -2638,6 +2721,7 @@ mod openchannel_fail;
 mod openchannel_no_indexer;
 mod openchannel_optional_addr;
 mod openchannel_push_asset_amount;
+mod pagination_filters;
 mod payment;
 mod refuse_high_fees;
 mod restart;

--- a/src/test/pagination_filters.rs
+++ b/src/test/pagination_filters.rs
@@ -1,0 +1,196 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/pagination_filters/";
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn transfers_pagination_and_filter() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}transfers/node1");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}transfers/node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+
+    let sends = 3u64;
+    for _ in 0..sends {
+        let recipient_id = rgb_invoice(node2_addr, Some(asset_id.clone()), false)
+            .await
+            .recipient_id;
+        send_asset(
+            node1_addr,
+            &asset_id,
+            Assignment::Fungible(100),
+            recipient_id,
+            None,
+        )
+        .await;
+        mine(false);
+        refresh_transfers(node2_addr).await;
+        refresh_transfers(node1_addr).await;
+    }
+
+    let all = list_transfers_full(node1_addr, &asset_id, ListTransfersFilter::default()).await;
+    let total = all.transfers.len();
+    assert!(total as u64 >= sends);
+    assert!(all.first_index_offset >= all.last_index_offset);
+    assert_eq!(
+        all.first_index_offset,
+        all.transfers.first().unwrap().idx as u64
+    );
+    assert_eq!(
+        all.last_index_offset,
+        all.transfers.last().unwrap().idx as u64
+    );
+
+    let page = list_transfers_full(
+        node1_addr,
+        &asset_id,
+        ListTransfersFilter {
+            max_transfers: Some(2),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert_eq!(page.transfers.len(), 2);
+    assert_eq!(page.first_index_offset, all.first_index_offset);
+
+    let mut seen = vec![];
+    let mut cursor = None;
+    loop {
+        let resp = list_transfers_full(
+            node1_addr,
+            &asset_id,
+            ListTransfersFilter {
+                index_offset: cursor,
+                max_transfers: Some(2),
+                ..Default::default()
+            },
+        )
+        .await;
+        if resp.transfers.is_empty() {
+            break;
+        }
+        for t in &resp.transfers {
+            assert!(!seen.contains(&t.idx));
+            seen.push(t.idx);
+        }
+        cursor = Some(resp.last_index_offset);
+    }
+    assert_eq!(seen.len(), total);
+
+    let settled = list_transfers_full(
+        node1_addr,
+        &asset_id,
+        ListTransfersFilter {
+            status: Some(TransferStatus::Settled),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(settled
+        .transfers
+        .iter()
+        .all(|t| t.status == TransferStatus::Settled));
+
+    let created = all.transfers.first().unwrap().created_at as u64;
+    let future = created + 1_000_000;
+    let before = list_transfers_full(
+        node1_addr,
+        &asset_id,
+        ListTransfersFilter {
+            created_before: Some(future),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert_eq!(before.transfers.len(), total);
+    let after = list_transfers_full(
+        node1_addr,
+        &asset_id,
+        ListTransfersFilter {
+            created_after: Some(future),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(after.transfers.is_empty());
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn unspents_pagination() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}unspents/node1");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    fund_and_create_utxos(node1_addr, None).await;
+
+    let all = list_unspents_full(node1_addr, None, None).await;
+    let total = all.unspents.len();
+    assert!(total > 2);
+    assert_eq!(all.first_index_offset, total as u64);
+    assert_eq!(all.last_index_offset, 1);
+
+    let page = list_unspents_full(node1_addr, None, Some(2)).await;
+    assert_eq!(page.unspents.len(), 2);
+    assert_eq!(page.first_index_offset, total as u64);
+
+    let mut seen = vec![];
+    let mut cursor = None;
+    loop {
+        let resp = list_unspents_full(node1_addr, cursor, Some(2)).await;
+        if resp.unspents.is_empty() {
+            break;
+        }
+        for u in &resp.unspents {
+            assert!(!seen.contains(&u.utxo.outpoint));
+            seen.push(u.utxo.outpoint.clone());
+        }
+        cursor = Some(resp.last_index_offset);
+    }
+    assert_eq!(seen.len(), total);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn transactions_pagination() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}transactions/node1");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    fund_and_create_utxos(node1_addr, None).await;
+
+    let all = list_transactions_full(node1_addr, None, None).await;
+    let total = all.transactions.len();
+    assert!(total >= 2);
+    assert_eq!(all.first_index_offset, total as u64);
+    assert_eq!(all.last_index_offset, 1);
+
+    let page = list_transactions_full(node1_addr, None, Some(1)).await;
+    assert_eq!(page.transactions.len(), 1);
+    assert_eq!(page.first_index_offset, total as u64);
+
+    let mut seen = vec![];
+    let mut cursor = None;
+    loop {
+        let resp = list_transactions_full(node1_addr, cursor, Some(1)).await;
+        if resp.transactions.is_empty() {
+            break;
+        }
+        for t in &resp.transactions {
+            assert!(!seen.contains(&t.txid));
+            seen.push(t.txid.clone());
+        }
+        cursor = Some(resp.last_index_offset);
+    }
+    assert_eq!(seen.len(), total);
+}

--- a/src/test/pagination_filters.rs
+++ b/src/test/pagination_filters.rs
@@ -20,9 +20,7 @@ async fn transfers_pagination_and_filter() {
 
     let sends = 3u64;
     for _ in 0..sends {
-        let recipient_id = rgb_invoice(node2_addr, Some(asset_id.clone()), false)
-            .await
-            .recipient_id;
+        let recipient_id = rgb_invoice(node2_addr, None, false).await.recipient_id;
         send_asset(
             node1_addr,
             &asset_id,

--- a/src/test/payment.rs
+++ b/src/test/payment.rs
@@ -557,3 +557,117 @@ async fn pagination() {
     }
     assert_eq!(seen.len() as u64, total);
 }
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn list_payments_filter() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}list_payments_filter/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(600_000),
+        Some(300_000_000),
+        None,
+        None,
+    )
+    .await;
+
+    let invoice = ln_invoice(node2_addr, Some(3_000_000), None, None, 900)
+        .await
+        .invoice;
+    send_payment(node1_addr, invoice).await;
+
+    let out = list_payments_filtered(
+        node1_addr,
+        ListPaymentsFilter {
+            direction: Some(PaymentDirection::Outbound),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(!out.payments.is_empty());
+    assert!(out
+        .payments
+        .iter()
+        .all(|p| p.payment_type == PaymentType::Outbound));
+
+    let inbound_on_sender = list_payments_filtered(
+        node1_addr,
+        ListPaymentsFilter {
+            direction: Some(PaymentDirection::Inbound),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(inbound_on_sender.payments.is_empty());
+
+    let inbound_on_receiver = list_payments_filtered(
+        node2_addr,
+        ListPaymentsFilter {
+            direction: Some(PaymentDirection::Inbound),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(!inbound_on_receiver.payments.is_empty());
+    assert!(inbound_on_receiver.payments.iter().all(|p| matches!(
+        p.payment_type,
+        PaymentType::InboundAutoClaim | PaymentType::InboundHodl
+    )));
+
+    let succeeded = list_payments_filtered(
+        node1_addr,
+        ListPaymentsFilter {
+            status: Some(HTLCStatus::Succeeded),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(succeeded
+        .payments
+        .iter()
+        .all(|p| p.status == HTLCStatus::Succeeded));
+
+    let failed = list_payments_filtered(
+        node1_addr,
+        ListPaymentsFilter {
+            status: Some(HTLCStatus::Failed),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(failed.payments.is_empty());
+
+    let future = out.payments.first().unwrap().created_at + 1_000_000;
+    let before = list_payments_filtered(
+        node1_addr,
+        ListPaymentsFilter {
+            created_before: Some(future),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(!before.payments.is_empty());
+    let after = list_payments_filtered(
+        node1_addr,
+        ListPaymentsFilter {
+            created_after: Some(future),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert!(after.payments.is_empty());
+}


### PR DESCRIPTION
Brings consistent pagination to the node's list endpoints and adds the filtering the exchange asked for. All paginated endpoints now share the same cursor model that `listpayments` already used: request a page size, walk backwards through history with a cursor, and use the offset returned by each page to fetch the next one.

## What changed

- **Payments**: keep the existing pagination, now also filterable by status, direction (inbound/outbound) and creation time interval.
- **Transfers**: gain full pagination plus filtering by status and time interval (they carry a stable index, status and timestamps).
- **Unspents** and **Transactions**: gain pagination only; they have no status or usable timestamp to filter on.

## Notes

- Endpoints without a natural index (unspents, transactions) paginate over a stable snapshot ordering; the cursor is meant for UI paging rather than as a durable, long-lived bookmark.
- The OpenAPI spec is updated to document every new parameter and response field.
- Covered by unit tests for the shared pagination logic and integration tests for each endpoint's pagination and filtering.
