### PR TITLE
APAY outbound invoice request and settlement in external-signer mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -293,7 +293,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -482,11 +482,10 @@ checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "ec5dc7e09f7bb15f0062da7c03086d6b71a2c84e0af4fccbbc7d8c6559847816"
 dependencies = [
- "bitcoin-internals",
  "bitcoin_hashes",
 ]
 
@@ -712,14 +711,13 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.9"
+version = "0.32.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf93e61f2dbc3e3c41234ca26a65e2c0b0975c52e0f069ab9893ebbede584d3"
+checksum = "39581299241111285f3268ba75ddf372746fd041620918b145c1af9d75e91b6c"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32 0.11.1",
- "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
@@ -746,23 +744,14 @@ checksum = "0468a0cbe4fb594b40940e107694c4edfc316a9d83bbeeff14ba1acbdfd291c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
-dependencies = [
- "serde",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
 
 [[package]]
 name = "bitcoin-push-decoder"
@@ -777,19 +766,18 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.3"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
+checksum = "57bad157b78d0d1b22c4cbb6a35a566211fc4d14866a37f2c780652b50f3b845"
 dependencies = [
- "bitcoin-internals",
  "serde",
 ]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.2.2",
@@ -798,18 +786,18 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "bitreq"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df90cd78f0510165fd370574676aeb57dbec0ee3bfff68645bb7b0e9a65dbd5"
+checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
 dependencies = [
  "rustls 0.23.40",
  "rustls-webpki 0.103.13",
@@ -867,7 +855,7 @@ checksum = "a6836000a836c3fc91ad5db2c95552c556b8347a6f6782a8f77a00d3fd989122"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -887,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -946,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1011,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1077,7 +1065,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1286,7 +1274,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1329,7 +1317,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1342,7 +1330,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1353,7 +1341,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1364,7 +1352,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1381,7 +1369,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1410,7 +1398,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1422,7 +1409,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1443,7 +1430,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1512,13 +1499,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1931,7 +1918,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2051,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2201,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2246,9 +2233,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2481,7 +2468,7 @@ checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2543,9 +2530,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -2556,13 +2543,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2592,7 +2579,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2611,7 +2598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2626,13 +2613,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2665,14 +2651,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2799,7 +2785,7 @@ version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2810,7 +2796,7 @@ checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2898,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -2962,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -2999,9 +2985,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniscript"
-version = "12.3.6"
+version = "12.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14116d8342edd3626b0f8e84df16f4e6a76dc04799ba747493403236a1b8ac5"
+checksum = "b8343cc1ef1408bd9bdbf69f7aef47017dfab7e6349ec26fddf62e0e9fb5a4cf"
 dependencies = [
  "bech32 0.11.1",
  "bitcoin",
@@ -3033,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3228,9 +3214,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3248,7 +3234,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3259,18 +3245,18 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.6.0+3.6.2"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3315,7 +3301,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3426,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "pgvector"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
 dependencies = [
  "serde",
 ]
@@ -3565,7 +3551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3596,7 +3582,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3616,7 +3602,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "version_check",
  "yansi",
 ]
@@ -3709,7 +3695,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3895,9 +3881,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags",
 ]
@@ -3930,14 +3916,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3958,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -4004,9 +3990,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4141,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#0d46c9a51765b41044b37682828a52a1676761f2"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#28c7fef8e695b0ba93ff351d4a4404e71dc56109"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4154,7 +4140,7 @@ dependencies = [
  "hex",
  "hkdf",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rgb-invoicing",
  "rgb-lib-migration",
  "rgb-ops",
@@ -4186,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#0d46c9a51765b41044b37682828a52a1676761f2"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#28c7fef8e695b0ba93ff351d4a4404e71dc56109"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -4418,9 +4404,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -4505,9 +4491,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -4605,15 +4591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4645,7 +4622,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4671,12 +4648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
 name = "sea-bae"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4686,7 +4657,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4749,7 +4720,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-ident",
 ]
 
@@ -4804,7 +4775,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 2.0.18",
 ]
 
@@ -4830,7 +4801,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4941,7 +4912,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5002,9 +4973,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -5018,14 +4989,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5053,28 +5024,27 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5123,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5150,7 +5120,7 @@ dependencies = [
 [[package]]
 name = "signer-external"
 version = "0.1.0-alpha"
-source = "git+https://github.com/UTEXO-Protocol/rln-external-signer.git?branch=main#168faab43779f944d1b7e9ed85b47d463cf44ab0"
+source = "git+https://github.com/UTEXO-Protocol/rln-external-signer.git?branch=main#545ed83597a1dd89925ed472b3a2b192c17de9ea"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -5236,24 +5206,24 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5347,7 +5317,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5370,7 +5340,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tokio",
  "url",
 ]
@@ -5551,9 +5521,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5577,7 +5547,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5664,7 +5634,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5675,7 +5645,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5698,12 +5668,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5713,15 +5682,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5776,7 +5745,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5954,7 +5923,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6014,7 +5983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6044,9 +6013,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -6142,7 +6111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6172,7 +6141,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.118",
  "toml 0.5.11",
  "uniffi_meta",
 ]
@@ -6263,9 +6232,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "serde_core",
@@ -6428,9 +6397,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -6452,9 +6421,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6466,9 +6435,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6476,9 +6445,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6486,22 +6455,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -6555,9 +6524,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6689,7 +6658,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6700,7 +6669,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7014,7 +6983,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease 0.2.37",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7030,7 +6999,7 @@ dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7086,9 +7055,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7103,28 +7072,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7144,15 +7113,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -7184,7 +7153,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -144,9 +144,9 @@ use crate::signer::{
 use crate::swap::SwapData;
 use crate::utils::{
     check_port_is_available, connect_peer_if_necessary, do_connect_peer, get_current_timestamp,
-    hex_str, validate_and_parse_payment_hash, AppState, StaticState, UnlockedAppState,
-    ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST, ELECTRUM_URL_SIGNET, ELECTRUM_URL_TESTNET,
-    ELECTRUM_URL_TESTNET4, PROXY_ENDPOINT_LOCAL, PROXY_ENDPOINT_PUBLIC,
+    hex_str, validate_and_parse_payment_hash, validate_and_parse_payment_preimage, AppState,
+    StaticState, UnlockedAppState, ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST, ELECTRUM_URL_SIGNET,
+    ELECTRUM_URL_TESTNET, ELECTRUM_URL_TESTNET4, PROXY_ENDPOINT_LOCAL, PROXY_ENDPOINT_PUBLIC,
 };
 
 const VIRTUAL_CHANNEL_DOMAIN_SEPARATOR: &[u8] = b"rln_virtual_channels_v0";
@@ -254,6 +254,8 @@ pub(crate) struct PaymentInfo {
     pub(crate) invoice_type: Option<InvoiceType>,
     pub(crate) description_hash: Option<[u8; 32]>,
     pub(crate) payment_idx: Option<u64>,
+    pub(crate) async_hash_index: Option<u64>,
+    pub(crate) async_host_node_id: Option<PublicKey>,
 }
 
 impl_writeable_tlv_based!(PaymentInfo, {
@@ -269,6 +271,8 @@ impl_writeable_tlv_based!(PaymentInfo, {
     (18, invoice_type, option),
     (20, description_hash, option),
     (22, payment_idx, option),
+    (24, async_hash_index, option),
+    (26, async_host_node_id, option),
 });
 
 pub(crate) struct InboundPaymentInfoStorage {
@@ -677,6 +681,8 @@ impl UnlockedAppState {
                     invoice_type,
                     description_hash: None,
                     payment_idx: None,
+                    async_hash_index: None,
+                    async_host_node_id: None,
                 };
                 self.stamp_payment_idx(&mut payment_info);
                 e.insert(payment_info);
@@ -1132,6 +1138,8 @@ struct AsyncOrderRecipientInvoiceProvider {
     async_payments_preimage_root: Arc<AsyncPaymentsPreimageRoot>,
     kv_store: Arc<SyncedKvStore>,
     next_payment_idx: Arc<std::sync::atomic::AtomicU64>,
+    external_signer_mode: bool,
+    external_signer: Option<Arc<ExternalSigner>>,
 }
 
 impl AsyncOrderRecipientInvoiceProvider {
@@ -1149,7 +1157,7 @@ impl AsyncOrderRecipientInvoiceProvider {
 impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
     fn request_outbound_invoice(
         &self,
-        _sender_node_id: PublicKey,
+        sender_node_id: PublicKey,
         params: AsyncOrderRequestInvoiceParamsWire,
     ) -> Result<AsyncOrderOutboundInvoiceResultWire, JsonRpcErrorWire> {
         let hash_index = Self::parse_u64_field(&params.hash_index, "hash_index")?;
@@ -1179,21 +1187,48 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
         };
 
         let requested_payment_hash = validate_and_parse_payment_hash(&params.payment_hash)
-            .map_err(|_| {
-                JsonRpcErrorWire::application_error(
-                    ASYNC_ERROR_INVOICE_HASH_MISMATCH,
-                    "invoice_hash_mismatch",
+            .map_err(|_| JsonRpcErrorWire::invalid_params("async_order_invalid_payment_hash"))?;
+
+        let invoice_preimage = if self.external_signer_mode {
+            let external_signer = self.external_signer.as_ref().ok_or_else(|| {
+                JsonRpcErrorWire::internal_error(
+                    "async_order_external_signer_unavailable".to_owned(),
                 )
             })?;
-        let material = self
-            .async_payments_preimage_root
-            .derive_hash_material(hash_index)?;
-        if material.payment_hash != requested_payment_hash {
-            return Err(JsonRpcErrorWire::application_error(
-                ASYNC_ERROR_INVOICE_HASH_MISMATCH,
-                "invoice_hash_mismatch",
-            ));
-        }
+            let derived = external_signer
+                .prepare_async_payments_hashes(hex_str(&sender_node_id.serialize()), hash_index, 1)
+                .map_err(|err| {
+                    JsonRpcErrorWire::internal_error(format!(
+                        "async_order_signer_derive_failed: {err}"
+                    ))
+                })?;
+            let derived_hash = derived
+                .first()
+                .and_then(|entry| validate_and_parse_payment_hash(&entry.payment_hash_hex).ok())
+                .ok_or_else(|| {
+                    JsonRpcErrorWire::internal_error(
+                        "async_order_external_signer_derived_hash_error".to_owned(),
+                    )
+                })?;
+            if derived_hash != requested_payment_hash {
+                return Err(JsonRpcErrorWire::application_error(
+                    ASYNC_ERROR_INVOICE_HASH_MISMATCH,
+                    "invoice_hash_mismatch",
+                ));
+            }
+            None
+        } else {
+            let material = self
+                .async_payments_preimage_root
+                .derive_hash_material(hash_index)?;
+            if material.payment_hash != requested_payment_hash {
+                return Err(JsonRpcErrorWire::application_error(
+                    ASYNC_ERROR_INVOICE_HASH_MISMATCH,
+                    "invoice_hash_mismatch",
+                ));
+            }
+            Some(material.payment_preimage)
+        };
 
         let mut inbound = self.inbound_payments.lock().unwrap();
         if let Some(existing) = inbound.payments.get(&requested_payment_hash) {
@@ -1243,7 +1278,7 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
             &mut inbound,
             requested_payment_hash,
             PaymentInfo {
-                preimage: Some(material.payment_preimage),
+                preimage: invoice_preimage,
                 secret: Some(*invoice.payment_secret()),
                 status: HTLCStatus::Pending,
                 amt_msat: Some(amount_msat),
@@ -1257,6 +1292,8 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
                 }),
                 description_hash: crate::routes::description_hash_from_invoice(&invoice),
                 payment_idx: None,
+                async_hash_index: self.external_signer_mode.then_some(hash_index),
+                async_host_node_id: self.external_signer_mode.then_some(sender_node_id),
             },
         )?;
 
@@ -2128,14 +2165,68 @@ async fn handle_ldk_events(
                 InvoiceType::Hodl {
                     async_payment_recipient: true,
                 } => {
-                    let Some(stored_preimage) = invoice.preimage else {
-                        tracing::error!(
-                            "Missing stored preimage for async recipient invoice {:?}",
-                            payment_hash
-                        );
-                        return Err(ReplayEvent());
+                    let async_preimage = match invoice.preimage {
+                        Some(preimage) => preimage,
+                        None if unlocked_state.external_signer_mode => {
+                            let (
+                                Some(external_signer),
+                                Some(async_host_node_id),
+                                Some(async_hash_index),
+                            ) = (
+                                unlocked_state.external_signer.as_ref(),
+                                invoice.async_host_node_id,
+                                invoice.async_hash_index,
+                            )
+                            else {
+                                tracing::error!(
+                                    "Async recipient invoice for payment hash {:?} is missing the external-signer claim context",
+                                    payment_hash
+                                );
+                                return Err(ReplayEvent());
+                            };
+                            match external_signer.get_async_payment_preimage(
+                                hex_str(&async_host_node_id.serialize()),
+                                async_hash_index,
+                                hex_str(&payment_hash.0),
+                            ) {
+                                Ok(preimage_hex) => {
+                                    match validate_and_parse_payment_preimage(
+                                        &preimage_hex,
+                                        &payment_hash,
+                                    ) {
+                                        Ok(preimage) => preimage,
+                                        Err(_) => {
+                                            tracing::error!(
+                                                "The external signer returned an invalid async preimage for payment hash {:?}; failing back",
+                                                payment_hash
+                                            );
+                                            unlocked_state
+                                                .fail_htlc_backwards_and_update_inbound_payment(
+                                                    payment_hash,
+                                                    HTLCStatus::Failed,
+                                                );
+                                            return Ok(());
+                                        }
+                                    }
+                                }
+                                Err(err) => {
+                                    tracing::warn!(
+                                        "Async preimage fetch from external signer failed for payment hash {:?}: {err}; will retry",
+                                        payment_hash
+                                    );
+                                    return Err(ReplayEvent());
+                                }
+                            }
+                        }
+                        None => {
+                            tracing::error!(
+                                "Missing stored preimage for async recipient invoice {:?}",
+                                payment_hash
+                            );
+                            return Err(ReplayEvent());
+                        }
                     };
-                    unlocked_state.channel_manager.claim_funds(stored_preimage);
+                    unlocked_state.channel_manager.claim_funds(async_preimage);
                 }
                 InvoiceType::Hodl {
                     async_payment_recipient: false,
@@ -4690,6 +4781,8 @@ pub(crate) async fn start_ldk(
         async_payments_preimage_root: Arc::clone(&async_payments_preimage_root),
         kv_store: Arc::clone(&kv_store),
         next_payment_idx: Arc::clone(&next_payment_idx),
+        external_signer_mode,
+        external_signer: external_signer.clone(),
     }));
 
     let unlocked_state = Arc::new(UnlockedAppState {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -2897,6 +2897,8 @@ pub(crate) async fn keysend(
                 payee_pubkey: dest_pubkey,
                 description_hash: None,
                 payment_idx: None,
+                async_hash_index: None,
+                async_host_node_id: None,
 
                 updated_at: created_at,
             },
@@ -3540,6 +3542,8 @@ pub(crate) async fn ln_invoice(
                 invoice_type: Some(invoice_type),
                 description_hash: description_hash_from_invoice(&invoice),
                 payment_idx: None,
+                async_hash_index: None,
+                async_host_node_id: None,
             },
         );
 
@@ -4642,6 +4646,8 @@ pub(crate) async fn send_payment(
                     invoice_type: None,
                     description_hash: None,
                     payment_idx: None,
+                    async_hash_index: None,
+                    async_host_node_id: None,
                 },
             )?;
 
@@ -4750,6 +4756,8 @@ pub(crate) async fn send_payment(
                     invoice_type: None,
                     description_hash: description_hash_from_invoice(&invoice),
                     payment_idx: None,
+                    async_hash_index: None,
+                    async_host_node_id: None,
                 },
             )?;
             let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -2524,6 +2524,8 @@ pub(crate) async fn keysend(
             invoice_type: None,
             description_hash: None,
             payment_idx: None,
+            async_hash_index: None,
+            async_host_node_id: None,
         },
     )?;
     if let Some((contract_id, rgb_amount)) = rgb_payment {
@@ -3044,6 +3046,8 @@ pub(crate) async fn send_payment(
                 invoice_type: None,
                 description_hash: None,
                 payment_idx: None,
+                async_hash_index: None,
+                async_host_node_id: None,
             },
         )?;
 
@@ -3142,6 +3146,8 @@ pub(crate) async fn send_payment(
                 invoice_type: None,
                 description_hash: crate::routes::description_hash_from_invoice(&invoice),
                 payment_idx: None,
+                async_hash_index: None,
+                async_host_node_id: None,
             },
         )?;
         let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());
@@ -3750,6 +3756,8 @@ pub(crate) async fn create_ln_invoice(
             invoice_type: Some(invoice_type),
             description_hash: crate::routes::description_hash_from_invoice(&invoice),
             payment_idx: None,
+            async_hash_index: None,
+            async_host_node_id: None,
         },
     );
 
@@ -4476,6 +4484,15 @@ mod tests {
             _start_index: u64,
             _batch_size: u32,
         ) -> Result<Vec<crate::signer::types::AsyncPaymentsHashEntry>, RlnSignerError> {
+            Self::unsupported()
+        }
+
+        fn node_get_async_payment_preimage(
+            &self,
+            _host_node_id_hex: String,
+            _hash_index: u64,
+            _payment_hash_hex: String,
+        ) -> Result<String, RlnSignerError> {
             Self::unsupported()
         }
 

--- a/src/signer/external.rs
+++ b/src/signer/external.rs
@@ -266,6 +266,16 @@ impl ExternalSigner {
             .prepare_async_payments_hashes(host_node_id_hex, start_index, batch_size)
     }
 
+    pub(crate) fn get_async_payment_preimage(
+        &self,
+        host_node_id_hex: String,
+        hash_index: u64,
+        payment_hash_hex: String,
+    ) -> Result<String, RlnSignerError> {
+        self.backend
+            .node_get_async_payment_preimage(host_node_id_hex, hash_index, payment_hash_hex)
+    }
+
     fn recipient_label(recipient: Recipient) -> &'static str {
         match recipient {
             Recipient::Node => "node",

--- a/src/signer/in_process_transport.rs
+++ b/src/signer/in_process_transport.rs
@@ -199,6 +199,15 @@ mod tests {
             Err(RlnSignerError::Unsupported("unused".to_string()))
         }
 
+        fn node_get_async_payment_preimage(
+            &self,
+            _host_node_id_hex: String,
+            _hash_index: u64,
+            _payment_hash_hex: String,
+        ) -> Result<String, RlnSignerError> {
+            Err(RlnSignerError::Unsupported("unused".to_string()))
+        }
+
         fn generate_channel_keys_id(
             &self,
             _inbound: bool,

--- a/src/signer/proto.rs
+++ b/src/signer/proto.rs
@@ -195,6 +195,16 @@ struct AsyncPaymentsHashEntryV1 {
 }
 
 #[derive(Clone, PartialEq, Message)]
+struct GetAsyncPaymentPreimageV1 {
+    #[prost(string, tag = "1")]
+    pub host_node_id_hex: String,
+    #[prost(uint64, tag = "2")]
+    pub hash_index: u64,
+    #[prost(string, tag = "3")]
+    pub payment_hash_hex: String,
+}
+
+#[derive(Clone, PartialEq, Message)]
 struct SignInvoiceV1 {
     #[prost(string, tag = "1")]
     pub hrp: String,
@@ -230,7 +240,7 @@ struct SignMessageRawV1 {
 struct NodeRequestV1 {
     #[prost(
         oneof = "node_request_v1::Kind",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26"
     )]
     pub kind: Option<node_request_v1::Kind>,
 }
@@ -271,6 +281,8 @@ mod node_request_v1 {
         VerifyInboundPayment(VerifyInboundPaymentV1),
         #[prost(message, tag = "20")]
         GetPaymentPreimage(GetPaymentPreimageV1),
+        #[prost(message, tag = "26")]
+        GetAsyncPaymentPreimage(GetAsyncPaymentPreimageV1),
         #[prost(message, tag = "5")]
         Ecdh(EcdhV1),
         #[prost(message, tag = "6")]
@@ -1270,6 +1282,15 @@ impl From<NodeRequest> for NodeRequestV1 {
                 payment_hash_hex,
                 payment_secret_hex,
             }),
+            NodeRequest::GetAsyncPaymentPreimage {
+                host_node_id_hex,
+                hash_index,
+                payment_hash_hex,
+            } => node_request_v1::Kind::GetAsyncPaymentPreimage(GetAsyncPaymentPreimageV1 {
+                host_node_id_hex,
+                hash_index,
+                payment_hash_hex,
+            }),
             NodeRequest::Ecdh {
                 recipient,
                 other_key,
@@ -1387,6 +1408,13 @@ impl TryFrom<NodeRequestV1> for NodeRequest {
                 payment_hash_hex: v.payment_hash_hex,
                 payment_secret_hex: v.payment_secret_hex,
             }),
+            node_request_v1::Kind::GetAsyncPaymentPreimage(v) => {
+                Ok(Self::GetAsyncPaymentPreimage {
+                    host_node_id_hex: v.host_node_id_hex,
+                    hash_index: v.hash_index,
+                    payment_hash_hex: v.payment_hash_hex,
+                })
+            }
             node_request_v1::Kind::Ecdh(v) => Ok(Self::Ecdh {
                 recipient: v.recipient,
                 other_key: v.other_key,
@@ -2272,6 +2300,18 @@ mod tests {
     fn raw_message_request_roundtrip() {
         let request = SignerRequest::Node(NodeRequest::SignMessageRaw {
             message_hex: "00ff".to_string(),
+        });
+        let wire = encode_signer_request(&request).expect("encode");
+        let decoded = decode_signer_request(&wire).expect("decode");
+        assert_eq!(decoded, request);
+    }
+
+    #[test]
+    fn get_async_payment_preimage_request_roundtrip() {
+        let request = SignerRequest::Node(NodeRequest::GetAsyncPaymentPreimage {
+            host_node_id_hex: "03".repeat(33),
+            hash_index: 9,
+            payment_hash_hex: "ab".repeat(32),
         });
         let wire = encode_signer_request(&request).expect("encode");
         let decoded = decode_signer_request(&wire).expect("decode");

--- a/src/signer/vls_adapter.rs
+++ b/src/signer/vls_adapter.rs
@@ -89,6 +89,12 @@ pub(crate) trait ExternalSignerBackend: Send + Sync {
         start_index: u64,
         batch_size: u32,
     ) -> Result<Vec<AsyncPaymentsHashEntry>, RlnSignerError>;
+    fn node_get_async_payment_preimage(
+        &self,
+        host_node_id_hex: String,
+        hash_index: u64,
+        payment_hash_hex: String,
+    ) -> Result<String, RlnSignerError>;
     fn generate_channel_keys_id(
         &self,
         inbound: bool,
@@ -452,6 +458,28 @@ impl ExternalSignerBackend for VlsSignerAdapter {
             }
             other => Err(RlnSignerError::Protocol(format!(
                 "unexpected response for prepare_async_payments_hashes: {other:?}"
+            ))),
+        }
+    }
+
+    fn node_get_async_payment_preimage(
+        &self,
+        host_node_id_hex: String,
+        hash_index: u64,
+        payment_hash_hex: String,
+    ) -> Result<String, RlnSignerError> {
+        match self.call(ExternalSignerRequest::Node(
+            ExternalNodeRequest::GetAsyncPaymentPreimage {
+                host_node_id_hex,
+                hash_index,
+                payment_hash_hex,
+            },
+        ))? {
+            ExternalSignerResponse::Node(ExternalNodeResponse::PaymentPreimage {
+                payment_preimage_hex,
+            }) => Ok(payment_preimage_hex),
+            other => Err(RlnSignerError::Protocol(format!(
+                "unexpected response for node_get_async_payment_preimage: {other:?}"
             ))),
         }
     }

--- a/src/test/lib_sdk/helpers.rs
+++ b/src/test/lib_sdk/helpers.rs
@@ -362,6 +362,32 @@ pub(crate) fn wait_for_asset_balance(
     }
 }
 
+pub(crate) fn wait_for_synced_to_tip(node: &SdkNode, node_name: &str) {
+    let tip = get_block_count();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last_sync_err = None;
+    loop {
+        if let Err(err) = node.sync() {
+            last_sync_err = Some(format!("{err:?}"));
+        }
+        let height = node
+            .network_info()
+            .unwrap_or_else(|err| {
+                panic!("{node_name}: network_info while waiting for tip: {err:?}")
+            })
+            .height;
+        if height >= tip {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "{node_name}: chain height {height} did not reach tip {tip} within 30s \
+             (last sync error: {last_sync_err:?})"
+        );
+        sleep(Duration::from_secs(1));
+    }
+}
+
 pub(crate) fn wait_for_channel_funding_tx(
     node_a: &SdkNode,
     node_b: &SdkNode,

--- a/src/test/lib_sdk/send_receive.rs
+++ b/src/test/lib_sdk/send_receive.rs
@@ -45,7 +45,6 @@ fn send_receive() {
 
         let net_info = node_a.network_info().expect("node A network_info");
         assert_eq!(net_info.network, "Regtest");
-        let height_1 = net_info.height;
 
         fund_and_create_utxos(&node_a, "node A");
         fund_and_create_utxos(&node_b, "node B");
@@ -327,8 +326,7 @@ fn send_receive() {
             })
             .expect("node A sendbtc");
 
-        let net_info = node_a.network_info().expect("node A network_info final");
-        assert_eq!(net_info.height, height_1 + 10);
+        wait_for_synced_to_tip(&node_a, "node A");
     }));
 
     node_a.shutdown();


### PR DESCRIPTION
- Add external-signer support for async outbound invoice requests.
- Store async claim context on inbound payment records: `async_hash_index` and `async_host_node_id`.
- On settlement, fetch the async payment preimage from the external signer and validate it against the payment hash before claiming funds.
- Add signer RPC/wire support for `GetAsyncPaymentPreimage`. Wire the new signer call through `ExternalSigner`, `ExternalSignerBackend`, and `VlsSignerAdapter`.
- Update existing payment insertions to initialize the new async fields to `None`.