### PR TITLE
Feat: Enable 1-sat HTLCs for virtual channels

### DIFF
--- a/src/core_types.rs
+++ b/src/core_types.rs
@@ -8,6 +8,7 @@ pub(crate) const UTXO_SIZE_SAT: u32 = 32000;
 pub(crate) const MIN_CHANNEL_CONFIRMATIONS: u8 = 6;
 pub(crate) const DUST_LIMIT_MSAT: u64 = 546000;
 pub(crate) const HTLC_MIN_MSAT: u64 = 3_000_000;
+pub(crate) const VIRTUAL_HTLC_MIN_MSAT: u64 = 1_000;
 pub(crate) const MAX_SWAP_FEE_MSAT: u64 = HTLC_MIN_MSAT;
 pub(crate) const DEFAULT_FINAL_CLTV_EXPIRY_DELTA: u32 = 14;
 

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -104,7 +104,7 @@ use crate::bitcoind::BitcoindClient;
 use crate::chain_backend::ChainBackend;
 use crate::core_types::{
     HTLCStatus, NodeKeySource, SwapStatus, UnlockRequest, DUST_LIMIT_MSAT, FEE_RATE, HTLC_MIN_MSAT,
-    MIN_CHANNEL_CONFIRMATIONS,
+    MIN_CHANNEL_CONFIRMATIONS, VIRTUAL_HTLC_MIN_MSAT,
 };
 use crate::database::RlnDatabase;
 use crate::disk::{self, FilesystemLogger};
@@ -1162,9 +1162,16 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
     ) -> Result<AsyncOrderOutboundInvoiceResultWire, JsonRpcErrorWire> {
         let hash_index = Self::parse_u64_field(&params.hash_index, "hash_index")?;
         let amount_msat = params.amount_msat;
-        if amount_msat < HTLC_MIN_MSAT {
+        let htlc_min_msat = if self.channel_manager.list_channels().iter().any(|channel| {
+            channel.counterparty.node_id == sender_node_id && channel.trusted_no_broadcast
+        }) {
+            VIRTUAL_HTLC_MIN_MSAT
+        } else {
+            HTLC_MIN_MSAT
+        };
+        if amount_msat < htlc_min_msat {
             return Err(JsonRpcErrorWire::invalid_params(format!(
-                "amt_msat cannot be less than {HTLC_MIN_MSAT}"
+                "amt_msat cannot be less than {htlc_min_msat}"
             )));
         }
         if matches!(params.asset_amount, Some(0)) {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -101,7 +101,7 @@ use crate::{
     core_types::{
         HTLCStatus, SwapStatus, UnlockRequest as CoreUnlockRequest,
         DEFAULT_FINAL_CLTV_EXPIRY_DELTA, DUST_LIMIT_MSAT, FEE_RATE, HTLC_MIN_MSAT,
-        MAX_SWAP_FEE_MSAT, MIN_CHANNEL_CONFIRMATIONS, UTXO_SIZE_SAT,
+        MAX_SWAP_FEE_MSAT, MIN_CHANNEL_CONFIRMATIONS, UTXO_SIZE_SAT, VIRTUAL_HTLC_MIN_MSAT,
     },
     rgb::{check_rgb_proxy_endpoint, get_rgb_channel_info_optional},
 };
@@ -120,8 +120,6 @@ const OPENCHANNEL_MIN_SAT: u64 = 5506;
 const OPENCHANNEL_MAX_SAT: u64 = 16777215;
 const OPENCHANNEL_MIN_RGB_AMT: u64 = 1;
 const VIRTUAL_OPEN_MODE_TRUSTED_NO_BROADCAST: &str = "trusted_no_broadcast";
-
-const INVOICE_MIN_MSAT: u64 = HTLC_MIN_MSAT;
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct AddressResponse {
@@ -2853,9 +2851,10 @@ pub(crate) async fn keysend(
         };
 
         let amt_msat = payload.amt_msat;
-        if amt_msat < HTLC_MIN_MSAT {
+        let htlc_min_msat = unlocked_state.htlc_min_msat_for_peer(dest_pubkey);
+        if amt_msat < htlc_min_msat {
             return Err(APIError::InvalidAmount(format!(
-                "amt_msat cannot be less than {HTLC_MIN_MSAT}"
+                "amt_msat cannot be less than {htlc_min_msat}"
             )));
         }
 
@@ -3472,10 +3471,15 @@ pub(crate) async fn ln_invoice(
             None
         };
 
-        if contract_id.is_some() && payload.amt_msat.unwrap_or(0) < INVOICE_MIN_MSAT {
-            return Err(APIError::InvalidAmount(format!(
-                "amt_msat cannot be less than {INVOICE_MIN_MSAT} when transferring an RGB asset"
-            )));
+        if let Some(contract_id) = &contract_id {
+            // Only lower the floor when the asset is held in a virtual channel; a regular channel
+            // carrying this asset keeps the standard floor.
+            let invoice_min_msat = unlocked_state.htlc_min_msat_for_asset(contract_id);
+            if payload.amt_msat.unwrap_or(0) < invoice_min_msat {
+                return Err(APIError::InvalidAmount(format!(
+                    "amt_msat cannot be less than {invoice_min_msat} when transferring an RGB asset"
+                )));
+            }
         }
 
         let created_at = get_current_timestamp();
@@ -4156,7 +4160,11 @@ pub(crate) async fn open_channel(
                 } else {
                     payload.public
                 },
-                our_htlc_minimum_msat: HTLC_MIN_MSAT,
+                our_htlc_minimum_msat: if is_virtual_open {
+                    VIRTUAL_HTLC_MIN_MSAT
+                } else {
+                    HTLC_MIN_MSAT
+                },
                 minimum_depth: if is_virtual_open {
                     0
                 } else {
@@ -4297,6 +4305,7 @@ pub(crate) async fn open_channel(
                 Some(config),
                 consignment_endpoint,
                 payload.push_asset_amount,
+                is_virtual_open,
             )
             .map_err(|e| {
                 if let Some(temp_id_str) = rgb_metadata_temp_id_str.as_deref() {
@@ -4693,19 +4702,23 @@ pub(crate) async fn send_payment(
                 invoice.amount_milli_satoshis().unwrap_or(0)
             };
 
+            // A trusted never-broadcast (virtual) channel to the payee allows a sub-dust asset
+            // HTLC; otherwise the standard floor applies.
+            let send_min_msat =
+                unlocked_state.htlc_min_msat_for_peer(invoice.recover_payee_pub_key());
             let rgb_payment = match (invoice.rgb_contract_id(), invoice.rgb_amount()) {
                 (Some(rgb_contract_id), Some(rgb_amount)) => {
-                    if amt_msat < INVOICE_MIN_MSAT {
+                    if amt_msat < send_min_msat {
                         return Err(APIError::InvalidAmount(format!(
-                            "amt_msat in invoice sending an RGB asset cannot be less than {INVOICE_MIN_MSAT}"
+                            "amt_msat in invoice sending an RGB asset cannot be less than {send_min_msat}"
                         )));
                     }
                     Some((rgb_contract_id, rgb_amount))
                 },
                 (Some(rgb_contract_id), None) => {
-                    if amt_msat < INVOICE_MIN_MSAT {
+                    if amt_msat < send_min_msat {
                         return Err(APIError::InvalidAmount(format!(
-                            "amt_msat in invoice sending an RGB asset cannot be less than {INVOICE_MIN_MSAT}"
+                            "amt_msat in invoice sending an RGB asset cannot be less than {send_min_msat}"
                         )));
                     }
                     if let Some(asset_id) = payload.asset_id.as_ref() {

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -9,7 +9,7 @@ use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
     AsyncOrderOutboundInvoiceResponse,
 };
-use crate::core_types::{FEE_RATE, MIN_CHANNEL_CONFIRMATIONS};
+use crate::core_types::{FEE_RATE, MIN_CHANNEL_CONFIRMATIONS, VIRTUAL_HTLC_MIN_MSAT};
 use crate::error::APIError;
 use crate::ldk::{
     clear_rgb_payment_pending, start_ldk, write_rgb_payment_info_file, InvoiceType, PaymentInfo,
@@ -100,7 +100,6 @@ const SDK_OPENRGBCHANNEL_MIN_SAT: u64 = SDK_HTLC_MIN_MSAT / 1000 * 10 + 10;
 const SDK_OPENCHANNEL_MIN_SAT: u64 = 5506;
 const SDK_OPENCHANNEL_MAX_SAT: u64 = 16_777_215;
 const SDK_OPENCHANNEL_MIN_RGB_AMT: u64 = 1;
-const SDK_INVOICE_MIN_MSAT: u64 = SDK_HTLC_MIN_MSAT;
 const SDK_UTXO_NUM: u8 = 4;
 const SDK_UTXO_SIZE_SAT: u32 = 32_000;
 const SDK_DUST_LIMIT_MSAT: u64 = 546_000;
@@ -2480,9 +2479,10 @@ pub(crate) async fn keysend(
     };
 
     let amt_msat = request.amt_msat;
-    if amt_msat < SDK_HTLC_MIN_MSAT {
+    let htlc_min_msat = unlocked_state.htlc_min_msat_for_peer(dest_pubkey);
+    if amt_msat < htlc_min_msat {
         return Err(APIError::InvalidAmount(format!(
-            "amt_msat cannot be less than {SDK_HTLC_MIN_MSAT}"
+            "amt_msat cannot be less than {htlc_min_msat}"
         )));
     }
 
@@ -2836,7 +2836,11 @@ pub(crate) async fn open_channel(
             } else {
                 request.public
             },
-            our_htlc_minimum_msat: SDK_HTLC_MIN_MSAT,
+            our_htlc_minimum_msat: if is_virtual_open {
+                VIRTUAL_HTLC_MIN_MSAT
+            } else {
+                SDK_HTLC_MIN_MSAT
+            },
             minimum_depth: if is_virtual_open {
                 0
             } else {
@@ -2958,6 +2962,7 @@ pub(crate) async fn open_channel(
             Some(config),
             consignment_endpoint,
             request.push_asset_amount,
+            is_virtual_open,
         )
         .map_err(|e| {
             if let Some(temp_id_str) = rgb_metadata_temp_id_str.as_deref() {
@@ -3095,19 +3100,21 @@ pub(crate) async fn send_payment(
             invoice.amount_milli_satoshis().unwrap_or(0)
         };
 
+        // A trusted never-broadcast (virtual) channel to the payee allows a sub-dust asset HTLC.
+        let send_min_msat = unlocked_state.htlc_min_msat_for_peer(invoice.recover_payee_pub_key());
         let rgb_payment = match (invoice.rgb_contract_id(), invoice.rgb_amount()) {
             (Some(rgb_contract_id), Some(rgb_amount)) => {
-                if amt_msat < SDK_INVOICE_MIN_MSAT {
+                if amt_msat < send_min_msat {
                     return Err(APIError::InvalidAmount(format!(
-                            "amt_msat in invoice sending an RGB asset cannot be less than {SDK_INVOICE_MIN_MSAT}"
+                            "amt_msat in invoice sending an RGB asset cannot be less than {send_min_msat}"
                         )));
                 }
                 Some((rgb_contract_id, rgb_amount))
             }
             (Some(rgb_contract_id), None) => {
-                if amt_msat < SDK_INVOICE_MIN_MSAT {
+                if amt_msat < send_min_msat {
                     return Err(APIError::InvalidAmount(format!(
-                            "amt_msat in invoice sending an RGB asset cannot be less than {SDK_INVOICE_MIN_MSAT}"
+                            "amt_msat in invoice sending an RGB asset cannot be less than {send_min_msat}"
                         )));
                 }
                 if let Some(asset_id) = request.asset_id.as_ref() {
@@ -3683,11 +3690,16 @@ pub(crate) async fn create_ln_invoice(
         None
     };
 
-    if contract_id.is_some() && amt_msat.unwrap_or(0) < SDK_INVOICE_MIN_MSAT {
-        return Err(APIError::InvalidAmount(format!(
-            "amt_msat cannot be less than {} when transferring an RGB asset",
-            SDK_INVOICE_MIN_MSAT
-        )));
+    if let Some(contract_id) = &contract_id {
+        // Only lower the floor when the asset is held in a virtual channel; a regular channel
+        // carrying this asset keeps the standard floor.
+        let invoice_min_msat = unlocked_state.htlc_min_msat_for_asset(contract_id);
+        if amt_msat.unwrap_or(0) < invoice_min_msat {
+            return Err(APIError::InvalidAmount(format!(
+                "amt_msat cannot be less than {} when transferring an RGB asset",
+                invoice_min_msat
+            )));
+        }
     }
 
     let created_at = get_current_timestamp();

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -33,7 +33,7 @@ use tokio::io::AsyncReadExt;
 use tokio::net::{TcpListener, TcpStream};
 use tracing_test::traced_test;
 
-use crate::core_types::{HTLCStatus, SwapStatus, FEE_RATE, HTLC_MIN_MSAT};
+use crate::core_types::{HTLCStatus, SwapStatus, FEE_RATE, HTLC_MIN_MSAT, VIRTUAL_HTLC_MIN_MSAT};
 use crate::disk::LDK_LOGS_FILE;
 use crate::error::{APIError, APIErrorResponse};
 use crate::kv_store::SeaOrmKvStore;

--- a/src/test/virtual_channels.rs
+++ b/src/test/virtual_channels.rs
@@ -1428,3 +1428,137 @@ async fn virtual_close_succeeds_after_client_returns_full_btc_and_rgb() {
     )
     .await;
 }
+
+#[tokio::test]
+#[traced_test]
+#[serial_test::serial]
+async fn virtual_one_sat_htlc_routes_both_directions() {
+    initialize();
+
+    let test_storage_root = format!("{TEST_DIR_BASE}one_sat_htlc/");
+    let host_node_peer_port = next_peer_port();
+    let client_node_peer_port = next_peer_port();
+
+    let (host_node_address, _host_node_password) = start_node_with_virtual_options(
+        &format!("{test_storage_root}host_node"),
+        host_node_peer_port,
+        false,
+        true,
+        vec![],
+    )
+    .await;
+    let host_node_info = node_info(host_node_address).await;
+
+    fund_and_create_utxos(host_node_address, None).await;
+    let issued_asset_id = issue_asset_nia_with_amounts(host_node_address, vec![500, 500])
+        .await
+        .asset_id;
+
+    let negative_payload = LNInvoiceRequest {
+        amt_msat: Some(VIRTUAL_HTLC_MIN_MSAT),
+        expiry_sec: 3600,
+        asset_id: Some(issued_asset_id.clone()),
+        asset_amount: Some(1),
+        payment_hash: None,
+        description_hash: None,
+        min_final_cltv_expiry_delta: None,
+    };
+    let negative_response = reqwest::Client::new()
+        .post(format!("http://{host_node_address}/lninvoice"))
+        .json(&negative_payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_nok(
+        negative_response,
+        reqwest::StatusCode::BAD_REQUEST,
+        &format!("cannot be less than {HTLC_MIN_MSAT}"),
+        "InvalidAmount",
+    )
+    .await;
+
+    let (client_node_address, _client_node_password) = start_node_with_virtual_options(
+        &format!("{test_storage_root}client_node"),
+        client_node_peer_port,
+        false,
+        true,
+        vec![bitcoin::secp256k1::PublicKey::from_str(&host_node_info.pubkey).unwrap()],
+    )
+    .await;
+    let client_node_info = node_info(client_node_address).await;
+
+    let funded_rgb_amount = 100;
+    let opened_virtual_channel = open_virtual_channel(
+        host_node_address,
+        &client_node_info.pubkey,
+        Some(client_node_peer_port),
+        Some(100_000),
+        Some(10_000),
+        Some(funded_rgb_amount),
+        Some(&issued_asset_id),
+        None,
+    )
+    .await;
+    assert_eq!(
+        opened_virtual_channel.virtual_open_mode.as_deref(),
+        Some("trusted_no_broadcast")
+    );
+    assert!(opened_virtual_channel.ready);
+    assert!(opened_virtual_channel.is_usable);
+
+    let host_to_client_rgb_amount = 50;
+    let rgb_invoice_in = ln_invoice(
+        client_node_address,
+        Some(VIRTUAL_HTLC_MIN_MSAT),
+        Some(&issued_asset_id),
+        Some(host_to_client_rgb_amount),
+        3600,
+    )
+    .await
+    .invoice;
+
+    let decoded_in = Bolt11Invoice::from_str(&rgb_invoice_in).unwrap();
+    assert_eq!(
+        decoded_in.amount_milli_satoshis(),
+        Some(VIRTUAL_HTLC_MIN_MSAT)
+    );
+    send_payment_with_status(host_node_address, rgb_invoice_in, HTLCStatus::Succeeded).await;
+    wait_for_ln_balance(
+        host_node_address,
+        &issued_asset_id,
+        funded_rgb_amount - host_to_client_rgb_amount,
+    )
+    .await;
+    wait_for_ln_balance(
+        client_node_address,
+        &issued_asset_id,
+        host_to_client_rgb_amount,
+    )
+    .await;
+
+    let client_to_host_rgb_amount = 30;
+    let rgb_invoice_out = ln_invoice(
+        host_node_address,
+        Some(VIRTUAL_HTLC_MIN_MSAT),
+        Some(&issued_asset_id),
+        Some(client_to_host_rgb_amount),
+        3600,
+    )
+    .await
+    .invoice;
+    send_payment_with_status(client_node_address, rgb_invoice_out, HTLCStatus::Succeeded).await;
+    wait_for_ln_balance(
+        host_node_address,
+        &issued_asset_id,
+        funded_rgb_amount - host_to_client_rgb_amount + client_to_host_rgb_amount,
+    )
+    .await;
+    wait_for_ln_balance(
+        client_node_address,
+        &issued_asset_id,
+        host_to_client_rgb_amount - client_to_host_rgb_amount,
+    )
+    .await;
+
+    shutdown(&[host_node_address, client_node_address]).await;
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,7 +37,7 @@ use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
 use tokio_util::sync::CancellationToken;
 
 use crate::async_order::{AsyncOrderMessageHandler, AsyncPaymentsPreimageRoot};
-use crate::core_types::{DEFAULT_FINAL_CLTV_EXPIRY_DELTA, HTLC_MIN_MSAT};
+use crate::core_types::{DEFAULT_FINAL_CLTV_EXPIRY_DELTA, HTLC_MIN_MSAT, VIRTUAL_HTLC_MIN_MSAT};
 use crate::ldk::{ChannelIdsMap, Router, VirtualChannelDraftStore, VirtualChannelSessionStore};
 use crate::rgb::{get_rgb_channel_info_optional, RgbLibWalletWrapper};
 use crate::signer::{
@@ -260,6 +260,31 @@ impl UnlockedAppState {
         &self,
     ) -> MutexGuard<'_, VirtualChannelSessionStore> {
         self.virtual_channel_session_store.lock().unwrap()
+    }
+
+    pub(crate) fn htlc_min_msat_for_asset(&self, contract_id: &ContractId) -> u64 {
+        self.channel_manager
+            .list_channels()
+            .iter()
+            .filter(|chan_info| {
+                get_rgb_channel_info_optional(&chan_info.channel_id, false, self.kv_store.as_ref())
+                    .is_some_and(|rgb_info| rgb_info.contract_id == *contract_id)
+            })
+            .filter_map(|chan_info| chan_info.inbound_htlc_minimum_msat)
+            .min()
+            .unwrap_or(HTLC_MIN_MSAT)
+    }
+
+    pub(crate) fn htlc_min_msat_for_peer(&self, peer: PublicKey) -> u64 {
+        let has_virtual =
+            self.channel_manager.list_channels().iter().any(|channel| {
+                channel.trusted_no_broadcast && channel.counterparty.node_id == peer
+            });
+        if has_virtual {
+            VIRTUAL_HTLC_MIN_MSAT
+        } else {
+            HTLC_MIN_MSAT
+        }
     }
 
     pub(crate) fn prepare_apay_order_params(


### PR DESCRIPTION
- Update virtual-channel dust handling so trusted `no_broadcast` channels can use a 1 sat floor instead of the standard RGB HTLC minimum.
- Add helper logic to compute the minimum HTLC size by peer or by asset, with the standard floor still applying for normal channels.
- Wire the new floor into invoice creation, keysend, payment sending, and channel opening paths in both core and SDK code.
- Add a regression test that proves 1-sat RGB HTLCs route both directions over a virtual channel, while being rejected before the virtual channel exists.