### PR TITLE
Fix handling empty colorable slots

### DIFF
--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -508,6 +508,7 @@ dictionary Utxo {
 dictionary Unspent {
     Utxo utxo;
     sequence<RgbAllocation> rgb_allocations;
+    u32 pending_blinded;
 };
 
 dictionary LnInvoiceRequest {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3946,6 +3946,7 @@ components:
       required:
         - utxo
         - rgb_allocations
+        - pending_blinded
       properties:
         utxo:
           $ref: '#/components/schemas/Utxo'
@@ -3953,6 +3954,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RgbAllocation'
+        pending_blinded:
+          type: integer
+          description: >-
+            Number of pending blind receive operations reserving this UTXO. A
+            colorable UTXO with empty rgb_allocations but pending_blinded > 0 is
+            already reserved and is not allocatable.
+          example: 0
     Utxo:
       type: object
       required:

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1512,6 +1512,10 @@ impl From<UnlockRequest> for CoreUnlockRequest {
 pub(crate) struct Unspent {
     pub(crate) utxo: Utxo,
     pub(crate) rgb_allocations: Vec<RgbAllocation>,
+    /// Number of pending blind receive operations reserving this UTXO. A
+    /// colorable UTXO with empty `rgb_allocations` but `pending_blinded > 0` is
+    /// already reserved and is not allocatable.
+    pub(crate) pending_blinded: u32,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -3430,6 +3434,7 @@ pub(crate) async fn list_unspents(
                     settled: a.settled,
                 })
                 .collect(),
+            pending_blinded: unspent.pending_blinded,
         })
     }
 

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -676,6 +676,10 @@ pub(crate) struct UtxoData {
 pub(crate) struct UnspentData {
     pub(crate) utxo: UtxoData,
     pub(crate) rgb_allocations: Vec<RgbAllocationData>,
+    /// Number of pending blind receive operations reserving this UTXO. A
+    /// colorable UTXO with empty `rgb_allocations` but `pending_blinded > 0` is
+    /// already reserved and is not allocatable.
+    pub(crate) pending_blinded: u32,
 }
 
 pub(crate) struct PeerData {
@@ -4240,6 +4244,7 @@ pub(crate) async fn list_unspents(
                     settled: a.settled,
                 })
                 .collect(),
+            pending_blinded: unspent.pending_blinded,
         });
     }
     Ok(unspents)

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -1324,6 +1324,7 @@ impl SdkNode {
                             })
                         })
                         .collect::<Result<Vec<_>, RlnError>>()?,
+                    pending_blinded: u.pending_blinded,
                 })
             })
             .collect()

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -422,6 +422,7 @@ pub struct Utxo {
 pub struct Unspent {
     pub utxo: Utxo,
     pub rgb_allocations: Vec<RgbAllocation>,
+    pub pending_blinded: u32,
 }
 
 pub struct LnInvoiceRequest {


### PR DESCRIPTION
Expose the `pending_blinded` field (number of pending blind-receive reservations on a UTXO) in the `/listunspents` HTTP response, SDK, and uniffi bindings so clients can tell an allocatable empty colorable UTXO from one already reserved by a pending blinded invoice.