### PR TITLE
Remote-first VSS persistence + recovery from seed

### DIFF
--- a/src/async_kv_store.rs
+++ b/src/async_kv_store.rs
@@ -1,0 +1,154 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use bitcoin::io;
+use lightning::util::async_poll::AsyncResult;
+use lightning::util::persist::{KVStore, KVStoreSync};
+
+use crate::kv_store::SeaOrmKvStore;
+use crate::vss_kv_store::{vss_key, VssKvStore};
+
+/// Remote-first async `KVStore`: a write resolves only after VSS durably stores
+/// it, then mirrors to the local store best-effort; a VSS failure fails the write
+/// (no silent local-only `Ok`). The local mirror goes through the synchronous
+/// `KVStoreSync` path (the node's dedicated DB runtime) so it never re-enters the
+/// calling runtime. Per-key writes/removes are serialized to preserve ordering.
+/// `remote == None` degrades to local-only (VSS not configured).
+pub struct RemoteFirstKvStore {
+    local: Arc<SeaOrmKvStore>,
+    remote: Option<Arc<VssKvStore>>,
+    key_locks: Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+}
+
+impl RemoteFirstKvStore {
+    pub fn new(local: Arc<SeaOrmKvStore>, remote: Option<Arc<VssKvStore>>) -> Self {
+        Self {
+            local,
+            remote,
+            key_locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn key_lock(&self, vss_key: &str) -> Arc<tokio::sync::Mutex<()>> {
+        self.key_locks
+            .lock()
+            .unwrap()
+            .entry(vss_key.to_string())
+            .or_default()
+            .clone()
+    }
+}
+
+impl KVStore for RemoteFirstKvStore {
+    fn read(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+    ) -> AsyncResult<'static, Vec<u8>, io::Error> {
+        let local = Arc::clone(&self.local);
+        let remote = self.remote.clone();
+        let (primary, secondary, key) = (
+            primary_namespace.to_string(),
+            secondary_namespace.to_string(),
+            key.to_string(),
+        );
+        Box::pin(async move {
+            // Local fast path; fall back to VSS only when the local copy is missing.
+            match KVStoreSync::read(&*local, &primary, &secondary, &key) {
+                Ok(value) => Ok(value),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => match remote {
+                    Some(remote) => remote.read_async(&primary, &secondary, &key).await,
+                    None => Err(e),
+                },
+                Err(e) => Err(e),
+            }
+        })
+    }
+
+    fn write(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        buf: Vec<u8>,
+    ) -> AsyncResult<'static, (), io::Error> {
+        let local = Arc::clone(&self.local);
+        let remote = self.remote.clone();
+        let lock = self.key_lock(&vss_key(primary_namespace, secondary_namespace, key));
+        let (primary, secondary, key) = (
+            primary_namespace.to_string(),
+            secondary_namespace.to_string(),
+            key.to_string(),
+        );
+        Box::pin(async move {
+            let _guard = lock.lock().await;
+            if let Some(remote) = &remote {
+                // VSS first (durable before ack), then mirror locally best-effort.
+                remote
+                    .write_async(&primary, &secondary, &key, buf.clone())
+                    .await?;
+                if let Err(e) = KVStoreSync::write(&*local, &primary, &secondary, &key, buf) {
+                    tracing::warn!(
+                        primary = %primary,
+                        secondary = %secondary,
+                        key = %key,
+                        error = %e,
+                        "remote-first: local mirror write failed after VSS durably stored"
+                    );
+                }
+            } else {
+                KVStoreSync::write(&*local, &primary, &secondary, &key, buf)?;
+            }
+            Ok(())
+        })
+    }
+
+    fn remove(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        _lazy: bool,
+    ) -> AsyncResult<'static, (), io::Error> {
+        let local = Arc::clone(&self.local);
+        let remote = self.remote.clone();
+        let lock = self.key_lock(&vss_key(primary_namespace, secondary_namespace, key));
+        let (primary, secondary, key) = (
+            primary_namespace.to_string(),
+            secondary_namespace.to_string(),
+            key.to_string(),
+        );
+        Box::pin(async move {
+            let _guard = lock.lock().await;
+            if let Some(remote) = &remote {
+                remote.remove_async(&primary, &secondary, &key).await?;
+                if let Err(e) = KVStoreSync::remove(&*local, &primary, &secondary, &key, false) {
+                    tracing::warn!(
+                        primary = %primary,
+                        secondary = %secondary,
+                        key = %key,
+                        error = %e,
+                        "remote-first: local mirror remove failed after VSS durably removed"
+                    );
+                }
+            } else {
+                KVStoreSync::remove(&*local, &primary, &secondary, &key, false)?;
+            }
+            Ok(())
+        })
+    }
+
+    fn list(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+    ) -> AsyncResult<'static, Vec<String>, io::Error> {
+        let local = Arc::clone(&self.local);
+        let (primary, secondary) = (
+            primary_namespace.to_string(),
+            secondary_namespace.to_string(),
+        );
+        Box::pin(async move { KVStoreSync::list(&*local, &primary, &secondary) })
+    }
+}

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -41,13 +41,26 @@ use lightning::routing::gossip;
 use lightning::routing::gossip::NodeId;
 use lightning::routing::router::DefaultRouter;
 use lightning::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringFeeParameters};
-use lightning::sign::{KeysManager, NodeSigner, OutputSpender, SpendableOutputDescriptor};
+use lightning::sign::{KeysManager, OutputSpender, SpendableOutputDescriptor};
+// Used by the non-VSS ChainMonitor encryptor closure and the signer unit tests.
+#[cfg(feature = "vss")]
+use lightning::chain::chainmonitor::AsyncPersister;
+#[cfg(any(not(feature = "vss"), test))]
+use lightning::sign::NodeSigner;
+#[cfg(feature = "vss")]
+use lightning::sign::PeerStorageKey;
 use lightning::types::payment::{PaymentHash, PaymentPreimage};
 use lightning::util::config::UserConfig;
 use lightning::util::hash_tables::hash_map::Entry;
 use lightning::util::hash_tables::{new_hash_map, HashMap as LdkHashMap};
+#[cfg(feature = "vss")]
+use lightning::util::native_async::FutureSpawner;
+#[cfg(not(feature = "vss"))]
+use lightning::util::persist::MonitorUpdatingPersister;
+#[cfg(feature = "vss")]
+use lightning::util::persist::MonitorUpdatingPersisterAsync;
 use lightning::util::persist::{
-    KVStoreSync, KVStoreSyncWrapper, MonitorUpdatingPersister, CHANNEL_MANAGER_PERSISTENCE_KEY,
+    KVStoreSync, KVStoreSyncWrapper, CHANNEL_MANAGER_PERSISTENCE_KEY,
     CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE, CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
     OUTPUT_SWEEPER_PERSISTENCE_KEY, OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
     OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
@@ -100,6 +113,8 @@ use tokio::runtime::Handle;
 use tokio::sync::watch::Sender;
 use tokio::task::JoinHandle;
 
+#[cfg(feature = "vss")]
+use crate::async_kv_store::RemoteFirstKvStore;
 use crate::bitcoind::BitcoindClient;
 use crate::chain_backend::ChainBackend;
 use crate::core_types::{
@@ -973,22 +988,51 @@ impl UnlockedAppState {
     }
 }
 
+/// `FutureSpawner` backed by `tokio::spawn`, used to drive async monitor
+/// persistence completions for `MonitorUpdatingPersisterAsync`.
+#[cfg(feature = "vss")]
+pub(crate) struct TokioFutureSpawner;
+
+#[cfg(feature = "vss")]
+impl FutureSpawner for TokioFutureSpawner {
+    fn spawn<T: std::future::Future<Output = ()> + Send + 'static>(&self, future: T) {
+        tokio::spawn(future);
+    }
+}
+
+/// The `ChainMonitor` persister generic: with VSS, the async
+/// `MonitorUpdatingPersisterAsync` (wrapped as `AsyncPersister`, returning
+/// `InProgress`); without VSS, the synchronous `MonitorUpdatingPersister`.
+#[cfg(feature = "vss")]
+pub(crate) type MonitorPersister = AsyncPersister<
+    Arc<RemoteFirstKvStore>,
+    TokioFutureSpawner,
+    Arc<FilesystemLogger>,
+    ActiveSignerRef,
+    ActiveSignerRef,
+    Arc<ChainBackend>,
+    Arc<ChainBackend>,
+>;
+
+#[cfg(not(feature = "vss"))]
+pub(crate) type MonitorPersister = Arc<
+    MonitorUpdatingPersister<
+        Arc<SyncedKvStore>,
+        Arc<FilesystemLogger>,
+        ActiveSignerRef,
+        ActiveSignerRef,
+        Arc<ChainBackend>,
+        Arc<ChainBackend>,
+    >,
+>;
+
 pub(crate) type ChainMonitor = chainmonitor::ChainMonitor<
     DynRlnChannelSigner,
     Arc<dyn Filter + Send + Sync>,
     Arc<ChainBackend>,
     Arc<ChainBackend>,
     Arc<FilesystemLogger>,
-    Arc<
-        MonitorUpdatingPersister<
-            Arc<SyncedKvStore>,
-            Arc<FilesystemLogger>,
-            ActiveSignerRef,
-            ActiveSignerRef,
-            Arc<ChainBackend>,
-            Arc<ChainBackend>,
-        >,
-    >,
+    MonitorPersister,
     ActiveSignerRef,
 >;
 
@@ -3674,8 +3718,11 @@ pub(crate) async fn start_ldk(
         None
     };
 
+    // Monitors persist remote-first through `monitor_kv_store` (async, VSS-durable
+    // before ack); ChannelManager and aux state keep the local-first `kv_store`
+    // sync facade. Both share the same local DB and (when configured) VSS store.
     #[cfg(feature = "vss")]
-    let kv_store = if let (Some(ref vss_url), Some(ref identity)) =
+    let (kv_store, monitor_kv_store) = if let (Some(ref vss_url), Some(ref identity)) =
         (&static_state.vss_url, &vss_identity)
     {
         tracing::info!(store_id = %identity.pubkey_hex, "Initializing VSS KV store");
@@ -3695,6 +3742,10 @@ pub(crate) async fn start_ldk(
             .acquire_fence()
             .map_err(|e| APIError::FailedVssInit(e.to_string()))?;
 
+        let monitor_kv_store = Arc::new(RemoteFirstKvStore::new(
+            Arc::clone(&local_kv_store),
+            Some(Arc::clone(&vss_kv_store)),
+        ));
         let synced = Arc::new(SyncedKvStore::with_vss(local_kv_store, vss_kv_store));
 
         // Auto-restore from VSS if local DB has no channel manager data.
@@ -3729,9 +3780,11 @@ pub(crate) async fn start_ldk(
             }
         }
 
-        synced
+        (synced, monitor_kv_store)
     } else {
-        Arc::new(SyncedKvStore::local_only(local_kv_store))
+        let monitor_kv_store = Arc::new(RemoteFirstKvStore::new(Arc::clone(&local_kv_store), None));
+        let synced = Arc::new(SyncedKvStore::local_only(local_kv_store));
+        (synced, monitor_kv_store)
     };
 
     #[cfg(not(feature = "vss"))]
@@ -3956,20 +4009,56 @@ pub(crate) async fn start_ldk(
     let entropy_source: Arc<dyn crate::signer::RlnEntropySource> = Arc::new(SystemEntropySource);
     let ldk_entropy_source = Arc::new(LightningEntropySource::new(Arc::clone(&entropy_source)));
 
-    let persister = Arc::new(MonitorUpdatingPersister::new(
-        Arc::clone(&kv_store),
-        Arc::clone(&logger),
-        1000,
-        Arc::clone(&keys_manager),
-        Arc::clone(&keys_manager),
-        Arc::clone(&chain_backend),
-        Arc::clone(&chain_backend),
-    ));
-
     // Initialize the ChainMonitor — esplora threads tx_sync as the Filter source.
-    let peer_storage_signer = Arc::clone(&keys_manager);
-    let chain_monitor: Arc<ChainMonitor> =
-        Arc::new(chainmonitor::ChainMonitor::new_with_peer_storage_encryptor(
+    //
+    // With VSS: monitors persist remote-first via `MonitorUpdatingPersisterAsync`
+    // + `ChainMonitor::new_async_beta` (a write returns `InProgress` and completes
+    // once VSS durably acks). Without VSS: the original synchronous persister.
+    #[cfg(feature = "vss")]
+    let (chain_monitor, mut channelmonitors): (Arc<ChainMonitor>, _) = {
+        let persister = MonitorUpdatingPersisterAsync::new(
+            Arc::clone(&monitor_kv_store),
+            TokioFutureSpawner,
+            Arc::clone(&logger),
+            1000,
+            Arc::clone(&keys_manager),
+            Arc::clone(&keys_manager),
+            Arc::clone(&chain_backend),
+            Arc::clone(&chain_backend),
+        );
+        // Read before moving the persister into the ChainMonitor.
+        let channelmonitors = persister
+            .read_all_channel_monitors_with_updates()
+            .await
+            .unwrap();
+        let chain_monitor = Arc::new(chainmonitor::ChainMonitor::new_async_beta(
+            chain_source.clone(),
+            Arc::clone(&broadcaster),
+            Arc::clone(&logger),
+            Arc::clone(&fee_estimator),
+            persister,
+            Arc::clone(&keys_manager),
+            // `peer_storage` is compiled out in this build (cfg never set), so the
+            // key is ignored. Pass a placeholder rather than the signer's key —
+            // external-signer mode panics on `get_peer_storage_key`.
+            PeerStorageKey { inner: [0u8; 32] },
+        ));
+        (chain_monitor, channelmonitors)
+    };
+
+    #[cfg(not(feature = "vss"))]
+    let (chain_monitor, mut channelmonitors): (Arc<ChainMonitor>, _) = {
+        let persister = Arc::new(MonitorUpdatingPersister::new(
+            Arc::clone(&kv_store),
+            Arc::clone(&logger),
+            1000,
+            Arc::clone(&keys_manager),
+            Arc::clone(&keys_manager),
+            Arc::clone(&chain_backend),
+            Arc::clone(&chain_backend),
+        ));
+        let peer_storage_signer = Arc::clone(&keys_manager);
+        let chain_monitor = Arc::new(chainmonitor::ChainMonitor::new_with_peer_storage_encryptor(
             chain_source.clone(),
             Arc::clone(&broadcaster),
             Arc::clone(&logger),
@@ -3980,9 +4069,9 @@ pub(crate) async fn start_ldk(
                 peer_storage_signer.encrypt_peer_storage_payload(plaintext, random_bytes)
             }),
         ));
-
-    // Read ChannelMonitor state from disk
-    let mut channelmonitors = persister.read_all_channel_monitors_with_updates().unwrap();
+        let channelmonitors = persister.read_all_channel_monitors_with_updates().unwrap();
+        (chain_monitor, channelmonitors)
+    };
 
     // Initialize routing ProbabilisticScorer
     let network_graph_path = ldk_data_dir.join("network_graph");
@@ -4197,12 +4286,17 @@ pub(crate) async fn start_ldk(
             identity.signing_key,
         )
         .with_encryption(true)
-        .with_auto_backup(true);
+        .with_auto_backup(true)
+        // Blocking: each RGB op waits until its VSS backup is durable.
+        .with_backup_mode(rgb_lib::wallet::vss::VssBackupMode::Blocking);
 
-        match rgb_wallet.configure_vss_backup(vss_config) {
-            Ok(()) => tracing::info!("VSS auto-backup enabled for RGB wallet"),
-            Err(e) => tracing::warn!("Failed to configure VSS backup for RGB wallet: {e}"),
-        }
+        // Fail closed: a misconfigured backup must not silently run local-only.
+        rgb_wallet.configure_vss_backup(vss_config).map_err(|e| {
+            APIError::FailedVssInit(format!(
+                "Failed to configure VSS backup for RGB wallet: {e}"
+            ))
+        })?;
+        tracing::info!("VSS auto-backup (blocking) enabled for RGB wallet");
     }
     save_config(
         &static_state.db(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 
 mod apay_merkle;
 mod args;
+#[cfg(feature = "vss")]
+mod async_kv_store;
 mod async_order;
 mod auth;
 mod backup;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 mod apay_merkle;
 mod args;
+#[cfg(feature = "vss")]
+mod async_kv_store;
 mod async_order;
 mod auth;
 mod backup;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -40,6 +40,8 @@ use crate::kv_store::SeaOrmKvStore;
 use crate::ldk::{
     InboundPaymentInfoStorage, InvoiceType, IGNORE_INBOUND_CHANNELS_ON_NODE, INBOUND_PAYMENTS_KEY,
 };
+#[cfg(feature = "vss")]
+use crate::routes::VssClearFenceRequest;
 use crate::routes::{
     AddressResponse, AssetBalanceRequest, AssetBalanceResponse, AssetCFA, AssetIFA, AssetNIA,
     AssetUDA, Assignment, BackupRequest, BtcBalanceRequest, BtcBalanceResponse,
@@ -355,6 +357,124 @@ async fn start_node_with_virtual_options(
 
     println!("node on peer port {node_peer_port} started with address {node_address:?}");
     (node_address, password)
+}
+
+#[cfg(feature = "vss")]
+async fn start_daemon_with_vss(
+    node_test_dir: &str,
+    node_peer_port: u16,
+    keep_node_dir: bool,
+    vss_url: Option<String>,
+) -> SocketAddr {
+    if !keep_node_dir && Path::new(&node_test_dir).is_dir() {
+        std::fs::remove_dir_all(node_test_dir).unwrap();
+    }
+    let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let node_address = listener.local_addr().unwrap();
+    std::fs::create_dir_all(node_test_dir).unwrap();
+    let args = UserArgs {
+        storage_dir_path: node_test_dir.into(),
+        ldk_peer_listening_port: node_peer_port,
+        vss_url,
+        ..Default::default()
+    };
+    let (router, app_state) = app(args).await.unwrap();
+    register_app_state(node_address, Arc::clone(&app_state));
+    tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(shutdown_signal(app_state))
+            .await
+            .unwrap();
+    });
+    node_address
+}
+
+/// Start a node with VSS replication enabled, returning `(addr, password, mnemonic)`.
+///
+/// - `mnemonic = Some(seed)`: `init` with that exact seed — used for a post-wipe
+///   restart so the recovered node reuses the same (seed-derived) VSS identity.
+/// - `mnemonic = None` on a fresh start: `init` generates a random seed (unique
+///   per run, so VSS state never leaks between test runs) and it is returned for
+///   the caller to reuse on the restart.
+/// - `mnemonic = None` with `keep_node_dir`: plain restart keeping local state,
+///   no `init` (returns an empty mnemonic).
+#[cfg(feature = "vss")]
+async fn start_node_with_vss(
+    node_test_dir: &str,
+    node_peer_port: u16,
+    keep_node_dir: bool,
+    vss_url: &str,
+    mnemonic: Option<&str>,
+) -> (SocketAddr, String, String) {
+    println!("starting vss node with peer port {node_peer_port}");
+    let node_address = start_daemon_with_vss(
+        node_test_dir,
+        node_peer_port,
+        keep_node_dir,
+        Some(vss_url.into()),
+    )
+    .await;
+
+    let password = format!("{node_test_dir}.{node_peer_port}");
+
+    let used_mnemonic = if keep_node_dir && mnemonic.is_none() {
+        String::new()
+    } else {
+        let resp = init(node_address, &password, mnemonic.map(|m| m.to_string())).await;
+        // Take over our own store_id: a same-seed restart inherits the previous
+        // incarnation's fence (nothing releases it on shutdown). No-op on a first
+        // start.
+        clear_vss_fence(node_address, &password).await;
+        resp.mnemonic
+    };
+
+    unlock(node_address, &password).await;
+    wait_for_peer_port_ready(node_peer_port).await;
+
+    println!("vss node on peer port {node_peer_port} started with address {node_address:?}");
+    (node_address, password, used_mnemonic)
+}
+
+#[cfg(feature = "vss")]
+async fn vss_backup_info(node_address: SocketAddr) -> serde_json::Value {
+    let res = reqwest::Client::new()
+        .get(format!("http://{node_address}/vssbackupinfo"))
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()
+}
+
+#[cfg(feature = "vss")]
+async fn clear_vss_fence(node_address: SocketAddr, password: &str) {
+    let payload = VssClearFenceRequest {
+        password: password.to_string(),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/vssclearfence"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<EmptyResponse>()
+        .await
+        .unwrap();
+}
+
+/// Gracefully stop a node and wipe its entire storage dir (DB, channel state,
+/// rgb wallet).
+#[cfg(feature = "vss")]
+async fn wipe_node_dir(node_address: SocketAddr, node_test_dir: &str) {
+    shutdown(&[node_address]).await;
+    if Path::new(node_test_dir).is_dir() {
+        std::fs::remove_dir_all(node_test_dir).unwrap();
+    }
 }
 
 async fn address(node_address: SocketAddr) -> String {
@@ -2731,8 +2851,13 @@ mod openchannel_push_asset_amount;
 mod pagination_filters;
 mod payment;
 mod refuse_high_fees;
+#[cfg(feature = "vss")]
+mod remote_first_kv;
+#[cfg(feature = "vss")]
+mod remote_first_recovery;
 mod restart;
 mod restore_swaps_db_pool;
+mod rgb_payment_htlc_persistence;
 mod send_receive;
 mod swap_assets_liquidity_both_ways;
 mod swap_reverse_same_channel;

--- a/src/test/remote_first_kv.rs
+++ b/src/test/remote_first_kv.rs
@@ -1,0 +1,123 @@
+//! Unit tests for the remote-first async `KVStore` (`RemoteFirstKvStore`).
+//!
+//! Requires a running VSS server: `docker compose --profile vss up -d`
+//! Run with: `cargo test --features vss remote_first_kv -- --nocapture`
+
+#[cfg(feature = "vss")]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use bitcoin::secp256k1::{rand::rngs::OsRng, Secp256k1, SecretKey};
+    use hex::DisplayHex;
+    use lightning::util::persist::{KVStore, KVStoreSync};
+    use sea_orm::{ConnectOptions, Database};
+
+    use crate::async_kv_store::RemoteFirstKvStore;
+    use crate::kv_store::SeaOrmKvStore;
+    use crate::vss_kv_store::VssKvStore;
+
+    const VSS_URL: &str = "http://localhost:8081/vss";
+
+    fn generate_test_keys() -> (SecretKey, String) {
+        let secp = Secp256k1::new();
+        let (secret_key, public_key) = secp.generate_keypair(&mut OsRng);
+        let store_id = format!("rln_test_{}", public_key.serialize()[0..8].as_hex());
+        (secret_key, store_id)
+    }
+
+    fn vss_server_available() -> bool {
+        std::net::TcpStream::connect_timeout(
+            &"127.0.0.1:8081".parse().unwrap(),
+            Duration::from_secs(2),
+        )
+        .is_ok()
+    }
+
+    fn create_test_sqlite() -> Arc<sea_orm::DatabaseConnection> {
+        use rln_migration::MigratorTrait;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.keep();
+        let db_path = path.join("test_rln_db");
+        let conn_str = format!("sqlite:{}?mode=rwc", db_path.display());
+        let mut opt = ConnectOptions::new(conn_str);
+        opt.max_connections(1)
+            .connect_timeout(Duration::from_secs(5));
+        let db = crate::runtime::block_on(Database::connect(opt)).expect("test db");
+        crate::runtime::block_on(rln_migration::Migrator::up(&db, None)).expect("migration");
+        Arc::new(db)
+    }
+
+    /// A successful write must land durably in VSS *and* be mirrored locally,
+    /// and be readable back through the store.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn remote_first_write_is_durable_in_vss() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let (signing_key, store_id) = generate_test_keys();
+        let local = Arc::new(SeaOrmKvStore::from_connection(create_test_sqlite()));
+        let remote = Arc::new(
+            VssKvStore::new(VSS_URL.to_string(), store_id.clone(), signing_key).expect("vss store"),
+        );
+        let store = RemoteFirstKvStore::new(Arc::clone(&local), Some(Arc::clone(&remote)));
+
+        let (ns, sub, key) = ("monitors", "", "chan1");
+        let data = b"monitor-state-v1".to_vec();
+
+        store
+            .write(ns, sub, key, data.clone())
+            .await
+            .expect("write");
+
+        // Durable in VSS: a fresh client over the same store_id reads it back.
+        let fresh = VssKvStore::new(VSS_URL.to_string(), store_id, signing_key).expect("fresh vss");
+        assert_eq!(
+            fresh.read_async(ns, sub, key).await.expect("vss read"),
+            data,
+            "value must be durable in VSS after write returns"
+        );
+
+        // Mirrored locally for fast reads.
+        assert_eq!(
+            KVStoreSync::read(&*local, ns, sub, key).expect("local read"),
+            data,
+            "value must be mirrored to the local store"
+        );
+
+        // Readable through the store.
+        assert_eq!(store.read(ns, sub, key).await.expect("read"), data);
+    }
+
+    /// If the VSS write fails, the whole write must resolve `Err` — never a
+    /// silent local-only `Ok`. The local store must be left untouched.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn remote_first_write_fails_when_vss_unreachable() {
+        let (signing_key, store_id) = generate_test_keys();
+        let local = Arc::new(SeaOrmKvStore::from_connection(create_test_sqlite()));
+        // Point the remote at a closed port so every VSS write errors.
+        let remote = Arc::new(
+            VssKvStore::new("http://127.0.0.1:1/vss".to_string(), store_id, signing_key)
+                .expect("vss store"),
+        );
+        let store = RemoteFirstKvStore::new(Arc::clone(&local), Some(remote));
+
+        let (ns, sub, key) = ("monitors", "", "chan1");
+
+        let err = store
+            .write(ns, sub, key, b"should-not-persist".to_vec())
+            .await
+            .expect_err("write must fail when VSS is unreachable");
+        eprintln!("expected write failure: {err}");
+
+        // No silent local-only write: local must still be empty for this key.
+        let local_read = KVStoreSync::read(&*local, ns, sub, key);
+        assert!(
+            matches!(&local_read, Err(e) if e.kind() == bitcoin::io::ErrorKind::NotFound),
+            "local store must not contain the key after a failed remote-first write, got {local_read:?}"
+        );
+    }
+}

--- a/src/test/remote_first_recovery.rs
+++ b/src/test/remote_first_recovery.rs
@@ -1,0 +1,195 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/remote_first_recovery/";
+const VSS_URL: &str = "http://localhost:8081/vss";
+
+/// End-to-end recovery-from-seed: a node with VSS issues an asset, opens a
+/// colored channel and sends a payment; its storage dir is wiped; it restarts
+/// with the same seed + VSS URL and must recover asset balances, the channel
+/// and the RGB stash from VSS alone.
+// Mirror the node's multi-threaded runtime (`#[tokio::main]`); synchronous VSS
+// calls need more than one worker thread.
+#[cfg(feature = "vss")]
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[traced_test]
+async fn remote_first_recovery() {
+    // Bound the run so a hang surfaces as a failure rather than blocking forever.
+    tokio::time::timeout(
+        std::time::Duration::from_secs(240),
+        remote_first_recovery_inner(),
+    )
+    .await
+    .expect("remote_first_recovery timed out");
+}
+
+#[cfg(feature = "vss")]
+async fn remote_first_recovery_inner() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}node2");
+
+    // Fresh per-run seeds (returned by init) so VSS state never leaks between
+    // runs; node1's seed is reused on the post-wipe restart.
+    let (node1_addr, _, mnemonic_1) =
+        start_node_with_vss(&test_dir_node1, NODE1_PEER_PORT, false, VSS_URL, None).await;
+    let (node2_addr, _, _) =
+        start_node_with_vss(&test_dir_node2, NODE2_PEER_PORT, false, VSS_URL, None).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    assert_eq!(
+        asset_balance_spendable(node1_addr, &asset_id).await,
+        ISSUE_AMT
+    );
+
+    // Blocking RGB backup: the issue op must not return until its VSS backup is
+    // durable, so the backup exists and is not stale once the call completes.
+    let info = vss_backup_info(node1_addr).await;
+    assert_eq!(
+        info["backup_exists"],
+        serde_json::json!(true),
+        "rgb backup must exist after issue"
+    );
+    assert_eq!(
+        info["backup_required"],
+        serde_json::json!(false),
+        "rgb backup must be current (not lagging) after a blocking-backup op"
+    );
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    connect_peer(
+        node1_addr,
+        &node2_pubkey,
+        &format!("127.0.0.1:{NODE2_PEER_PORT}"),
+    )
+    .await;
+
+    let channel = open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        None,
+        None,
+        Some(600),
+        Some(&asset_id),
+    )
+    .await;
+    assert_eq!(asset_balance_spendable(node1_addr, &asset_id).await, 400);
+
+    let channel_id = channel.channel_id.clone();
+    keysend(node1_addr, &node2_pubkey, None, Some(&asset_id), Some(100)).await;
+    assert_eq!(
+        channel_rgb_amounts(node1_addr, &channel_id).await,
+        (Some(500), Some(100)),
+        "keysend must move 100 of the asset over the channel"
+    );
+
+    let pre_wipe_balance = asset_balance_spendable(node1_addr, &asset_id).await;
+
+    wipe_node_dir(node1_addr, &test_dir_node1).await;
+
+    // Restart from the same seed + VSS URL; recovery must come from VSS alone.
+    let (node1_addr, _, _) = start_node_with_vss(
+        &test_dir_node1,
+        NODE1_PEER_PORT,
+        true,
+        VSS_URL,
+        Some(&mnemonic_1),
+    )
+    .await;
+
+    // On-chain asset balance recovered.
+    assert_eq!(
+        asset_balance_spendable(node1_addr, &asset_id).await,
+        pre_wipe_balance,
+        "asset balance must match pre-wipe value after recovery"
+    );
+
+    // Issued asset listed again and its stash file is present.
+    assert!(
+        list_assets(node1_addr)
+            .await
+            .nia
+            .unwrap_or_default()
+            .iter()
+            .any(|a| a.asset_id == asset_id),
+        "issued asset must be listed after recovery"
+    );
+    assert!(
+        glob_stash_dat(&test_dir_node1),
+        "rgb/stash.dat must exist after recovery"
+    );
+
+    // Channel recovered with its post-keysend balance: the latest state, not a
+    // stale snapshot.
+    assert_eq!(
+        channel_rgb_amounts(node1_addr, &channel_id).await,
+        (Some(500), Some(100)),
+        "recovered channel must reflect the keysend made before the wipe"
+    );
+
+    // The recovered channel and RGB wallet are operational: reconnect and route a
+    // fresh payment over the same channel, then check the balance moved.
+    connect_peer(
+        node1_addr,
+        &node2_pubkey,
+        &format!("127.0.0.1:{NODE2_PEER_PORT}"),
+    )
+    .await;
+    wait_for_channel_usable(node1_addr, &channel_id).await;
+    keysend(node1_addr, &node2_pubkey, None, Some(&asset_id), Some(50)).await;
+    assert_eq!(
+        channel_rgb_amounts(node1_addr, &channel_id).await,
+        (Some(450), Some(150)),
+        "a payment over the recovered channel must move the asset"
+    );
+}
+
+#[cfg(feature = "vss")]
+async fn channel_rgb_amounts(
+    node_address: SocketAddr,
+    channel_id: &str,
+) -> (Option<u64>, Option<u64>) {
+    let channel = list_channels(node_address)
+        .await
+        .into_iter()
+        .find(|c| c.channel_id == channel_id)
+        .unwrap_or_else(|| panic!("channel {channel_id} not found on {node_address}"));
+    (channel.asset_local_amount, channel.asset_remote_amount)
+}
+
+#[cfg(feature = "vss")]
+async fn wait_for_channel_usable(node_address: SocketAddr, channel_id: &str) {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        if list_channels(node_address)
+            .await
+            .iter()
+            .any(|c| c.channel_id == channel_id && c.ready && c.is_usable)
+        {
+            return;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 30.0 {
+            panic!("channel {channel_id} did not become usable on {node_address}");
+        }
+    }
+}
+
+#[cfg(feature = "vss")]
+fn glob_stash_dat(node_test_dir: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir(node_test_dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let stash = entry.path().join("rgb").join("stash.dat");
+        if stash.is_file() {
+            return true;
+        }
+    }
+    false
+}

--- a/src/test/rgb_payment_htlc_persistence.rs
+++ b/src/test/rgb_payment_htlc_persistence.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/rgb_payment_htlc_persistence/";
+
+// A channel can hold an RGB HTLC in flight, and that state must survive a node
+// restart. This pays a hodl invoice to keep an RGB HTLC pending across a restart
+// of both nodes — the receiver holds a pending inbound HTLC and the sender a
+// pending outbound one — then checks the channel re-establishes and the held
+// payment can still be settled.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn restart_with_pending_rgb_htlc_recovers_channel() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}node2");
+
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    fund_and_create_utxos(node1_addr, None).await;
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    let channel = open_channel_with_retry(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(500000),
+        Some(0),
+        Some(100),
+        Some(&asset_id),
+        None,
+        5,
+    )
+    .await;
+    let channel_id = channel.channel_id.clone();
+    let node1_balance = asset_balance_offchain_outbound(node1_addr, &asset_id).await;
+    let node2_balance = asset_balance_offchain_outbound(node2_addr, &asset_id).await;
+
+    // Pay a hodl invoice so an RGB HTLC stays pending: receiver holds it
+    // (Claimable) and sender keeps it in flight (Pending).
+    let (preimage, payment_hash) = random_preimage_and_hash();
+    let LNInvoiceResponse { invoice } = ln_invoice_hodl(
+        node2_addr,
+        Some(HTLC_MIN_MSAT),
+        Some(&asset_id),
+        Some(10),
+        600,
+        Some(payment_hash.clone()),
+    )
+    .await;
+    send_payment_with_status(node1_addr, invoice, HTLCStatus::Pending).await;
+    wait_for_ln_payment(node2_addr, &payment_hash, HTLCStatus::Claimable).await;
+
+    // Restart both nodes: each ChannelManager is serialized with a pending HTLC
+    // in this channel and must deserialize on unlock.
+    shutdown(&[node1_addr, node2_addr]).await;
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, true).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, true).await;
+
+    wait_for_channel_ready(node1_addr, &channel_id).await;
+    wait_for_channel_ready(node2_addr, &channel_id).await;
+
+    // The held HTLC survived the restart; settling it completes the payment and
+    // moves the asset across the recovered channel.
+    wait_for_ln_payment(node2_addr, &payment_hash, HTLCStatus::Claimable).await;
+    claim_hodl_invoice(node2_addr, payment_hash.clone(), preimage).await;
+    wait_for_ln_payment(node1_addr, &payment_hash, HTLCStatus::Succeeded).await;
+    wait_for_ln_payment(node2_addr, &payment_hash, HTLCStatus::Succeeded).await;
+    wait_for_ln_balance(node1_addr, &asset_id, node1_balance - 10).await;
+    wait_for_ln_balance(node2_addr, &asset_id, node2_balance + 10).await;
+
+    shutdown(&[node1_addr, node2_addr]).await;
+}
+
+async fn wait_for_channel_ready(node_address: SocketAddr, channel_id: &str) {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        if list_channels(node_address)
+            .await
+            .iter()
+            .any(|c| c.channel_id == channel_id && c.ready)
+        {
+            return;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 30.0 {
+            panic!("channel {channel_id} did not become ready on {node_address}");
+        }
+    }
+}

--- a/src/vss_kv_store.rs
+++ b/src/vss_kv_store.rs
@@ -21,6 +21,16 @@ use vss_client::util::retry::{
 type VssRetryPolicy =
     MaxTotalDelayRetryPolicy<MaxAttemptsRetryPolicy<ExponentialBackoffRetryPolicy<VssError>>>;
 
+/// Dedicated runtime for driving synchronous VSS calls (see [`VssKvStore::block_on`]).
+static VSS_RUNTIME: std::sync::LazyLock<tokio::runtime::Runtime> = std::sync::LazyLock::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .thread_name("vss-runtime")
+        .enable_all()
+        .build()
+        .expect("Failed to create VSS tokio runtime")
+});
+
 /// Result of a single VSS get-object during a paged `download_all`. `Ok(None)`
 /// means the key disappeared between list and get (race; benign).
 type FetchResult = Result<Option<(String, Vec<u8>)>, VssError>;
@@ -102,15 +112,24 @@ impl VssKvStore {
         })
     }
 
-    /// Runs an async future to completion using the ambient Tokio runtime
-    /// (which must be multi-threaded — `#[tokio::main]` in `src/main.rs`
-    /// satisfies this).
+    /// Runs a VSS future to completion on a dedicated runtime via a separate
+    /// thread, blocking only the calling thread. It must not re-enter the caller's
+    /// runtime: re-entrancy would let tasks holding LDK locks interleave on the
+    /// blocked worker and deadlock.
     fn block_on<F>(&self, future: F) -> F::Output
     where
         F: std::future::Future + Send,
         F::Output: Send,
     {
-        tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
+        if tokio::runtime::Handle::try_current().is_ok() {
+            std::thread::scope(|s| {
+                s.spawn(|| VSS_RUNTIME.block_on(future))
+                    .join()
+                    .expect("VSS runtime thread panicked")
+            })
+        } else {
+            VSS_RUNTIME.block_on(future)
+        }
     }
 
     /// Encrypt a value for storage on VSS using the inline wire format
@@ -331,6 +350,90 @@ impl VssKvStore {
                 tracing::warn!(error = %e, "VSS fence periodic check failed");
             }
         }
+    }
+
+    /// Async counterparts of the `KVStoreSync` methods, `.await`ed directly (no
+    /// `block_on`) so a monitor write can run on the LDK async event loop. They
+    /// skip the periodic fence re-check; `acquire_fence` at startup still holds.
+    pub async fn read_async(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+    ) -> Result<Vec<u8>, io::Error> {
+        let vss_key = vss_key(primary_namespace, secondary_namespace, key);
+        let request = GetObjectRequest {
+            store_id: self.store_id.clone(),
+            key: vss_key.clone(),
+        };
+        match self.client.get_object(&request).await {
+            Ok(resp) => {
+                if let Some(kv) = resp.value {
+                    self.decrypt_value(kv.value)
+                } else {
+                    Err(io::Error::new(io::ErrorKind::NotFound, "Key not found"))
+                }
+            }
+            Err(VssError::NoSuchKeyError(_)) => {
+                Err(io::Error::new(io::ErrorKind::NotFound, "Key not found"))
+            }
+            Err(e) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("VSS read failed: {e}"),
+            )),
+        }
+    }
+
+    pub async fn write_async(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        buf: Vec<u8>,
+    ) -> Result<(), io::Error> {
+        let vss_key = vss_key(primary_namespace, secondary_namespace, key);
+        tracing::trace!(vss_key, value_len = buf.len(), "VssKvStore write_async");
+        let stored = self.encrypt_value(buf)?;
+        let request = PutObjectRequest {
+            store_id: self.store_id.clone(),
+            global_version: None,
+            transaction_items: vec![KeyValue {
+                key: vss_key.clone(),
+                version: -1,
+                value: stored,
+            }],
+            delete_items: vec![],
+        };
+        self.client.put_object(&request).await.map_err(|e| {
+            tracing::error!(vss_key, error = %e, "VssKvStore write_async failed");
+            io::Error::new(io::ErrorKind::Other, format!("VSS write failed: {e}"))
+        })?;
+        Ok(())
+    }
+
+    pub async fn remove_async(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+    ) -> Result<(), io::Error> {
+        let vss_key = vss_key(primary_namespace, secondary_namespace, key);
+        tracing::trace!(vss_key, "VssKvStore remove_async");
+        let request = PutObjectRequest {
+            store_id: self.store_id.clone(),
+            global_version: None,
+            transaction_items: vec![],
+            delete_items: vec![KeyValue {
+                key: vss_key.clone(),
+                version: -1,
+                value: vec![],
+            }],
+        };
+        self.client.put_object(&request).await.map_err(|e| {
+            tracing::error!(vss_key, error = %e, "VssKvStore remove_async failed");
+            io::Error::new(io::ErrorKind::Other, format!("VSS remove failed: {e}"))
+        })?;
+        Ok(())
     }
 
     /// Downloads all key-value pairs from VSS for this store_id, decrypting


### PR DESCRIPTION
Make a node able to rebuild its full state; RGB assets, colored channels, the RGB stash and channel balances, from **VSS + its seed alone**, after losing all local storage.

Channel-monitor persistence becomes **remote-first**: a monitor write is durable in VSS *before* it is acknowledged (instead of writing locally and replicating to VSS best-effort). The RGB wallet's VSS backup is switched to blocking and fail-closed. On startup with empty local state, the node restores from VSS and takes over its own VSS store.

The previous local-first path could acknowledge a write whose VSS replication later failed, leaving the remote copy stale, so a wiped node could recover an out-of-date state. Remote-first guarantees the remote copy is current, which is what a stateless/TEE-style deployment needs.

## Notes

- Monitors persist asynchronously via LDK's async-monitor API; ChannelManager and auxiliary state keep the existing local-first path.
- Depends on a fix in the `rust-lightning` submodule (serialize `rgb_payment` for pending HTLCs), the submodule pointer is bumped in this PR.
- Trade-off: each monitor update now waits on a VSS round-trip.

## Testing

End-to-end test: issue an asset, open a colored channel, send a keysend payment, wipe the node's storage, restart from the same seed + VSS, and assert assets, channel and stash all recover. A second test asserts the same survives an ungraceful crash. Plus unit tests for the remote-first store and a no-regression run of the existing restart/payment/close suites.
