### PR TITLE
Upgrade APAY Access Policy

### DIFF
--- a/.github/workflows/check-gitmodules.yml
+++ b/.github/workflows/check-gitmodules.yml
@@ -1,0 +1,76 @@
+name: Check gitmodules
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  check-gitmodules:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Enforce rust-lightning submodule source
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SUBMODULE="rust-lightning"
+          EXPECTED_PATH="rust-lightning"
+          EXPECTED_URL="https://github.com/UTEXO-Protocol/rust-lightning.git"
+          EXPECTED_BRANCH="dev"
+
+          actual_path="$(git config -f .gitmodules --get "submodule.${SUBMODULE}.path" || true)"
+          actual_url="$(git config -f .gitmodules --get "submodule.${SUBMODULE}.url" || true)"
+          actual_branch="$(git config -f .gitmodules --get "submodule.${SUBMODULE}.branch" || true)"
+
+          if [[ "$actual_path" != "$EXPECTED_PATH" ]]; then
+            echo "::error file=.gitmodules::Invalid ${SUBMODULE} path: '${actual_path}'. Expected '${EXPECTED_PATH}'"
+            exit 1
+          fi
+
+          if [[ "$actual_url" != "$EXPECTED_URL" ]]; then
+            echo "::error file=.gitmodules::Invalid ${SUBMODULE} url: '${actual_url}'. Expected '${EXPECTED_URL}'"
+            exit 1
+          fi
+
+          if [[ "$actual_branch" != "$EXPECTED_BRANCH" ]]; then
+            echo "::error file=.gitmodules::Invalid ${SUBMODULE} branch: '${actual_branch}'. Expected '${EXPECTED_BRANCH}'"
+            exit 1
+          fi
+
+          echo ".gitmodules check passed"
+
+      - name: Verify pinned submodule commit is on dev
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SUBMODULE="rust-lightning"
+          EXPECTED_URL="https://github.com/UTEXO-Protocol/rust-lightning.git"
+          EXPECTED_BRANCH="dev"
+
+          ls_tree="$(git ls-tree HEAD "$SUBMODULE" || true)"
+          read -r mode type commit path <<<"$ls_tree"
+
+          if [[ "$mode" != "160000" || "$type" != "commit" || "$path" != "$SUBMODULE" || -z "$commit" ]]; then
+            echo "::error::${SUBMODULE} is not a pinned git submodule commit"
+            exit 1
+          fi
+
+          tmpdir="$(mktemp -d)"
+          trap 'rm -rf "$tmpdir"' EXIT
+
+          git init "$tmpdir"
+          git -C "$tmpdir" remote add utexo "$EXPECTED_URL"
+          git -C "$tmpdir" fetch --no-tags --filter=blob:none utexo \
+            "+refs/heads/${EXPECTED_BRANCH}:refs/remotes/utexo/${EXPECTED_BRANCH}"
+
+          if ! git -C "$tmpdir" merge-base --is-ancestor "$commit" "refs/remotes/utexo/${EXPECTED_BRANCH}"; then
+            echo "::error::Submodule commit ${commit} is not reachable from ${EXPECTED_BRANCH}"
+            exit 1
+          fi
+
+          echo "Submodule commit is reachable from ${EXPECTED_BRANCH}"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -50,7 +50,7 @@ paths:
       tags:
         - Async Payments
       summary: Send a new order with async-payment hashes
-      description: Derive deterministic payment hashes for async payments from the unlocked wallet. Send an async_order.new JSON-RPC request to the connected invoice-host peer so it can track those hashes and process asynchronous payments.
+      description: Derive deterministic payment hashes for async payments from the unlocked wallet. Send an async_order.new JSON-RPC request to the connected invoice-host peer so it can track those hashes and process asynchronous payments. A peer connection alone is not sufficient; the recipient-client must already have a live channel with the invoice-host peer. 
       requestBody:
         content:
           application/json:
@@ -68,7 +68,7 @@ paths:
       tags:
         - Async Payments
       summary: Request an outbound LN invoice
-      description: Request an outbound invoice from the connected recipient peer for an async payment claim session.
+      description: Request an outbound invoice from the connected recipient-client peer for an async payment claim session. A peer connection alone is not enough; the invoice-host must already have a live channel with the recipient-client peer.
       requestBody:
         content:
           application/json:

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -2619,25 +2619,27 @@ mod tests {
     fn async_order_rejects_untrusted_peers_without_response() {
         let handler = AsyncOrderMessageHandler::new(Arc::new(DenyAllAccess));
         let test_peer = test_peer_pubkey(9);
-        let request_id = new_jsonrpc_request_id();
-        let request_payload = new_order_request_payload(
-            &request_id,
-            &[(
-                1,
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            )],
-        );
+        let cases = [
+            new_order_request_payload(
+                &new_jsonrpc_request_id(),
+                &[(
+                    1,
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                )],
+            ),
+            request_invoice_payload(
+                &new_jsonrpc_request_id(),
+                ASYNC_ORDER_REQUEST_INVOICE_METHOD,
+                &test_request_invoice_params(),
+            ),
+        ];
 
-        handler
-            .handle_custom_message(
-                AsyncOrderMessage {
-                    payload: request_payload,
-                },
-                test_peer,
-            )
-            .unwrap();
-
-        assert!(handler.get_and_clear_pending_msg().is_empty());
+        for payload in cases {
+            handler
+                .handle_custom_message(AsyncOrderMessage { payload }, test_peer)
+                .unwrap();
+            assert!(handler.get_and_clear_pending_msg().is_empty());
+        }
     }
 
     #[tokio::test]

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1098,37 +1098,43 @@ pub(crate) type OutputSweeper = ldk_sweep::OutputSweeper<
     Arc<RgbOutputSpender>,
 >;
 
-struct VirtualChannelAccess {
-    trusted_no_broadcast: bool,
-    virtual_peer_pubkeys: Vec<PublicKey>,
+trait LiveChannelLookup: Send + Sync {
+    fn peer_has_live_channel(&self, peer: &PublicKey) -> bool;
+}
+
+struct UsablePeerChannelLookup {
     channel_manager: Arc<ChannelManager>,
 }
 
-impl VirtualChannelAccess {
-    fn new(static_state: &StaticState, channel_manager: Arc<ChannelManager>) -> Self {
-        Self {
-            trusted_no_broadcast: static_state.enable_virtual_channels_v0,
-            virtual_peer_pubkeys: static_state.virtual_peer_pubkeys.clone(),
-            channel_manager,
-        }
-    }
-
-    fn is_virtual_peer(&self, peer: &PublicKey) -> bool {
-        self.virtual_peer_pubkeys.is_empty()
-            || self
-                .virtual_peer_pubkeys
-                .iter()
-                .any(|virtual_peer| virtual_peer == peer)
+impl LiveChannelLookup for UsablePeerChannelLookup {
+    fn peer_has_live_channel(&self, peer: &PublicKey) -> bool {
+        self.channel_manager
+            .list_usable_channels()
+            .iter()
+            .any(|channel| channel.counterparty.node_id == *peer)
     }
 }
 
-impl AsyncOrderAccessControl for VirtualChannelAccess {
+struct LiveChannelAccess {
+    lookup: Arc<dyn LiveChannelLookup>,
+}
+
+impl LiveChannelAccess {
+    fn new(channel_manager: Arc<ChannelManager>) -> Self {
+        Self {
+            lookup: Arc::new(UsablePeerChannelLookup { channel_manager }),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_lookup(lookup: Arc<dyn LiveChannelLookup>) -> Self {
+        Self { lookup }
+    }
+}
+
+impl AsyncOrderAccessControl for LiveChannelAccess {
     fn allows_peer(&self, peer: &PublicKey) -> bool {
-        self.trusted_no_broadcast
-            && self.is_virtual_peer(peer)
-            && self.channel_manager.list_channels().iter().any(|channel| {
-                channel.counterparty.node_id == *peer && channel.trusted_no_broadcast
-            })
+        self.lookup.peer_has_live_channel(peer)
     }
 }
 
@@ -4436,18 +4442,15 @@ pub(crate) async fn start_ldk(
         .as_secs();
     rand::thread_rng().fill_bytes(&mut ephemeral_bytes);
 
-    let virtual_channel_access = Arc::new(VirtualChannelAccess::new(
-        static_state,
-        channel_manager.clone(),
-    ));
+    let live_channel_access = Arc::new(LiveChannelAccess::new(channel_manager.clone()));
     let async_order_handler = match static_state.lsp_base_url.as_ref() {
         Some(lsp_base_url) => Arc::new(AsyncOrderMessageHandler::new_with_lsp_client(
-            virtual_channel_access,
+            live_channel_access,
             lsp_base_url.clone(),
             static_state.lsp_bearer_token.clone(),
             Handle::current(),
         )),
-        None => Arc::new(AsyncOrderMessageHandler::new(virtual_channel_access)),
+        None => Arc::new(AsyncOrderMessageHandler::new(live_channel_access)),
     };
     let async_payments_preimage_root = Arc::new(
         match internal_mnemonic.as_ref() {
@@ -5148,11 +5151,59 @@ mod tests {
     use lightning::rgb_utils::RgbInfo;
     use rln_migration::{Migrator, MigratorTrait};
     use sea_orm::{ConnectOptions, Database};
-    use std::str::FromStr;
+    use std::{collections::HashSet, str::FromStr, sync::Mutex};
 
     fn test_contract_id() -> rgb_lib::ContractId {
         rgb_lib::ContractId::from_str("rgb:EIkAVQvq-WbAb5JG-CYxbUER-oqDNwne-ZNxBDID-p0cpf9U")
             .unwrap()
+    }
+
+    fn test_peer_pubkey(tag: u8) -> PublicKey {
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let mut key_bytes = [0u8; 32];
+        key_bytes[31] = tag.max(1);
+        let secret_key = bitcoin::secp256k1::SecretKey::from_slice(&key_bytes).unwrap();
+        PublicKey::from_secret_key(&secp, &secret_key)
+    }
+
+    struct MockPeerChannelLookup {
+        live_peers: Mutex<HashSet<PublicKey>>,
+    }
+
+    impl MockPeerChannelLookup {
+        fn new(peers: impl IntoIterator<Item = PublicKey>) -> Self {
+            Self {
+                live_peers: Mutex::new(peers.into_iter().collect()),
+            }
+        }
+    }
+
+    impl LiveChannelLookup for MockPeerChannelLookup {
+        fn peer_has_live_channel(&self, peer: &PublicKey) -> bool {
+            self.live_peers.lock().unwrap().contains(peer)
+        }
+    }
+
+    #[test]
+    fn live_channel_access_follows_peer_lookup() {
+        let allowed_peer = test_peer_pubkey(1);
+        let denied_peer = test_peer_pubkey(2);
+        let lookup = Arc::new(MockPeerChannelLookup::new([allowed_peer]));
+        let access = LiveChannelAccess::new_with_lookup(lookup);
+
+        assert!(access.allows_peer(&allowed_peer));
+        assert!(!access.allows_peer(&denied_peer));
+    }
+
+    #[test]
+    fn live_channel_access_loses_access_when_last_channel_is_removed() {
+        let peer = test_peer_pubkey(3);
+        let lookup = Arc::new(MockPeerChannelLookup::new([peer]));
+        let access = LiveChannelAccess::new_with_lookup(lookup.clone());
+
+        assert!(access.allows_peer(&peer));
+        lookup.live_peers.lock().unwrap().clear();
+        assert!(!access.allows_peer(&peer));
     }
 
     fn build_kv_store() -> Arc<dyn KVStoreSync + Send + Sync> {

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1102,16 +1102,20 @@ trait LiveChannelLookup: Send + Sync {
     fn peer_has_live_channel(&self, peer: &PublicKey) -> bool;
 }
 
+pub(crate) fn peer_has_live_channel(channel_manager: &ChannelManager, peer: &PublicKey) -> bool {
+    channel_manager
+        .list_usable_channels()
+        .iter()
+        .any(|channel| channel.counterparty.node_id == *peer)
+}
+
 struct UsablePeerChannelLookup {
     channel_manager: Arc<ChannelManager>,
 }
 
 impl LiveChannelLookup for UsablePeerChannelLookup {
     fn peer_has_live_channel(&self, peer: &PublicKey) -> bool {
-        self.channel_manager
-            .list_usable_channels()
-            .iter()
-            .any(|channel| channel.counterparty.node_id == *peer)
+        peer_has_live_channel(&self.channel_manager, peer)
     }
 }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -80,7 +80,7 @@ use crate::core_types::async_order::{
     AsyncOrderOutboundInvoiceResponse,
 };
 use crate::ldk::{
-    clear_rgb_payment_pending, start_ldk, stop_ldk, LdkBackgroundServices,
+    clear_rgb_payment_pending, peer_has_live_channel, start_ldk, stop_ldk, LdkBackgroundServices,
     VirtualChannelSessionStatus,
 };
 #[cfg(feature = "vss")]
@@ -1613,7 +1613,12 @@ pub(crate) async fn async_order_new(
         .is_none()
     {
         return Err(APIError::InvalidPeerInfo(s!(
-            "/apay/new requires a connected host peer"
+            "/apay/new requires a connected invoice-host peer"
+        )));
+    }
+    if !peer_has_live_channel(&unlocked_state.channel_manager, &host_node_id) {
+        return Err(APIError::InvalidPeerInfo(s!(
+            "/apay/new requires a live channel with the invoice-host peer"
         )));
     }
 
@@ -1717,7 +1722,12 @@ pub(crate) async fn async_order_outbound_invoice(
         .is_none()
     {
         return Err(APIError::InvalidPeerInfo(s!(
-            "/apay/outboundinvoice requires a connected recipient peer"
+            "/apay/outboundinvoice requires a connected recipient-client peer"
+        )));
+    }
+    if !peer_has_live_channel(&unlocked_state.channel_manager, &peer_node_id) {
+        return Err(APIError::InvalidPeerInfo(s!(
+            "/apay/outboundinvoice requires a live channel with the recipient-client peer"
         )));
     }
 

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -12,8 +12,8 @@ use crate::core_types::async_order::{
 use crate::core_types::{FEE_RATE, MIN_CHANNEL_CONFIRMATIONS, VIRTUAL_HTLC_MIN_MSAT};
 use crate::error::APIError;
 use crate::ldk::{
-    clear_rgb_payment_pending, start_ldk, write_rgb_payment_info_file, InvoiceType, PaymentInfo,
-    VirtualChannelSessionStatus,
+    clear_rgb_payment_pending, peer_has_live_channel, start_ldk, write_rgb_payment_info_file,
+    InvoiceType, PaymentInfo, VirtualChannelSessionStatus,
 };
 #[cfg(feature = "vss")]
 use crate::ldk::{derive_vss_identity, derive_vss_identity_from_key_source};
@@ -1166,7 +1166,12 @@ pub(crate) async fn async_order_new(
         .is_none()
     {
         return Err(APIError::InvalidPeerInfo(s!(
-            "/apay/new requires a connected host peer"
+            "/apay/new requires a connected invoice-host peer"
+        )));
+    }
+    if !peer_has_live_channel(&unlocked_state.channel_manager, &host_node_id) {
+        return Err(APIError::InvalidPeerInfo(s!(
+            "/apay/new requires a live channel with the invoice-host peer"
         )));
     }
 
@@ -1267,7 +1272,12 @@ pub(crate) async fn async_order_outbound_invoice(
         .is_none()
     {
         return Err(APIError::InvalidPeerInfo(s!(
-            "/apay/outboundinvoice requires a connected recipient peer"
+            "/apay/outboundinvoice requires a connected recipient-client peer"
+        )));
+    }
+    if !peer_has_live_channel(&unlocked_state.channel_manager, &peer_node_id) {
+        return Err(APIError::InvalidPeerInfo(s!(
+            "/apay/outboundinvoice requires a live channel with the recipient-client peer"
         )));
     }
 

--- a/src/test/lib_sdk/apay.rs
+++ b/src/test/lib_sdk/apay.rs
@@ -1,0 +1,87 @@
+use crate::helpers::*;
+use serial_test::serial;
+use std::{fs, time::Duration};
+
+#[test]
+#[serial]
+fn apay_new_requires_a_live_channel() {
+    ensure_regtest_available();
+
+    let test_dir = test_dir("sdk_apay_peer_gate");
+    if test_dir.exists() {
+        fs::remove_dir_all(&test_dir).expect("remove previous lib_sdk test dir");
+    }
+    fs::create_dir_all(&test_dir).expect("create lib_sdk test dir");
+    let node_a_dir = test_dir.join("node_a");
+    let node_b_dir = test_dir.join("node_b");
+
+    let node_a = make_node(&node_a_dir, NODE_A_DAEMON_PORT, NODE_A_PEER_PORT);
+    let node_b = make_node(&node_b_dir, NODE_B_DAEMON_PORT, NODE_B_PEER_PORT);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        node_a
+            .init("nodeApass".to_string(), None)
+            .expect("node A init");
+        node_b
+            .init("nodeBpass".to_string(), None)
+            .expect("node B init");
+
+        node_a
+            .unlock(unlock_request("nodeApass"))
+            .expect("node A unlock");
+        node_b
+            .unlock(unlock_request("nodeBpass"))
+            .expect("node B unlock");
+
+        ensure_funded(&node_a, 200_000, "node A");
+        ensure_funded(&node_b, 200_000, "node B");
+
+        let node_b_pubkey = node_b.node_info().expect("node B node_info").pubkey;
+        let peer_uri = format!("{node_b_pubkey}@127.0.0.1:{NODE_B_PEER_PORT}");
+
+        node_a
+            .connectpeer(peer_uri.clone())
+            .expect("node A connectpeer");
+
+        node_a
+            .apay_new(node_b_pubkey.to_string())
+            .expect_err("apay_new must fail before a live channel exists");
+
+        let _open_channel = node_a
+            .openchannel(SdkOpenChannelRequest {
+                peer_pubkey_and_opt_addr: peer_uri,
+                capacity_sat: OPEN_CHANNEL_CAPACITY_SAT,
+                push_msat: OPEN_CHANNEL_PUSH_MSAT,
+                public: true,
+                with_anchors: true,
+                fee_base_msat: None,
+                fee_proportional_millionths: None,
+                temporary_channel_id: None,
+                asset_id: None,
+                asset_amount: None,
+                push_asset_amount: None,
+                virtual_open_mode: None,
+            })
+            .expect("node A openchannel");
+
+        let channel_id = wait_for_channel_open(
+            &node_a,
+            |channel| channel.peer_pubkey == node_b_pubkey && channel.asset_id.is_none(),
+            Duration::from_secs(180),
+        );
+        wait_for_channel_ready(&node_b, channel_id, Duration::from_secs(180));
+
+        let response = node_a
+            .apay_new(node_b_pubkey.to_string())
+            .expect("apay_new over live channel");
+        assert_eq!(response.host_node_id, node_b_pubkey.to_string());
+        assert!(!response.hashes.is_empty());
+    }));
+
+    node_a.shutdown();
+    node_b.shutdown();
+
+    if let Err(err) = result {
+        std::panic::resume_unwind(err);
+    }
+}

--- a/src/test/lib_sdk/mod.rs
+++ b/src/test/lib_sdk/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod helpers;
 
+mod apay;
 mod close_coop_other_side;
 mod close_coop_standard;
 mod close_coop_vanilla;


### PR DESCRIPTION
- `/apay/new` and `/apay/outboundinvoice` now require a connected peer with a live usable channel. A peer connection alone is not enough.
- The SDK and HTTP route preflights match the control-plane behavior in `async_order`.
- Untrusted async-order peer messages are ignored without tearing down the connection.
- Adds a regression test proving `apay_new` fails before the channel is opened and succeeds once the channel is live.
- Updates the async payments OpenAPI text to reflect the live-channel requirement.
- Adds CI validation for the `rust-lightning` submodule path, URL, branch, and pinned commit reachability on `utexo/dev`.