### PR TITLE
Add address reuse support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.24#04ed7056728445aee482e6f1b187d84b52662571"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26#117e8ca0411ebc8fd8e771f702daa0fa35ab66dd"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4172,7 +4172,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.24#04ed7056728445aee482e6f1b187d84b52662571"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26#117e8ca0411ebc8fd8e771f702daa0fa35ab66dd"
 dependencies = [
  "sea-orm-migration",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ magic-crypt = "4.0.1"
 rand = "0.8.5"
 regex = { version = "1.11", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.24", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.26", features = [
     "electrum",
     "esplora",
 ] }

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ The node currently exposes the following APIs:
 - `/restore` (POST)
 - `/revoketoken` (POST)
 - `/rgbinvoice` (POST)
+- `/rotateaddress` (POST)
 - `/sendbtc` (POST)
 - `/sendonionmessage` (POST)
 - `/sendpayment` (POST)

--- a/bindings/c-ffi/rln.h
+++ b/bindings/c-ffi/rln.h
@@ -150,6 +150,8 @@ struct CResultString rln_refresh_transfers(const struct COpaqueStruct *node,
 
 struct CResultString rln_rgb_invoice(const struct COpaqueStruct *node, const char *request_json);
 
+struct CResultString rln_rotate_address(const struct COpaqueStruct *node);
+
 struct CResultString rln_sdk_initialize(const char *request_json);
 
 /**

--- a/bindings/c-ffi/rln.hpp
+++ b/bindings/c-ffi/rln.hpp
@@ -134,6 +134,8 @@ CResultString rln_refresh_transfers(const COpaqueStruct *node, const char *reque
 
 CResultString rln_rgb_invoice(const COpaqueStruct *node, const char *request_json);
 
+CResultString rln_rotate_address(const COpaqueStruct *node);
+
 CResultString rln_sdk_initialize(const char *request_json);
 
 /// APay receiver-side registration with an LSP. Argument is the LSP's

--- a/bindings/c-ffi/src/api.rs
+++ b/bindings/c-ffi/src/api.rs
@@ -498,6 +498,12 @@ pub(crate) fn address(node: &COpaqueStruct) -> Result<String, Error> {
     json(JsonAddressInfo::from(resp))
 }
 
+pub(crate) fn rotate_address(node: &COpaqueStruct) -> Result<String, Error> {
+    let node = require_handle(node)?;
+    let resp = node.rotate_address()?;
+    json(JsonAddressInfo::from(resp))
+}
+
 pub(crate) fn btc_balance(
     node: &COpaqueStruct,
     skip_sync: bool,

--- a/bindings/c-ffi/src/json_types.rs
+++ b/bindings/c-ffi/src/json_types.rs
@@ -133,6 +133,8 @@ pub(crate) struct JsonSdkInitRequest {
     pub vss_allow_http: bool,
     #[serde(default)]
     pub vss_allow_empty_restore: bool,
+    #[serde(default)]
+    pub reuse_addresses: bool,
 }
 
 impl TryFrom<JsonSdkInitRequest> for SdkInitRequest {
@@ -155,6 +157,7 @@ impl TryFrom<JsonSdkInitRequest> for SdkInitRequest {
             vss_url: j.vss_url,
             vss_allow_http: j.vss_allow_http,
             vss_allow_empty_restore: j.vss_allow_empty_restore,
+            reuse_addresses: j.reuse_addresses,
         })
     }
 }

--- a/bindings/c-ffi/src/lib.rs
+++ b/bindings/c-ffi/src/lib.rs
@@ -442,6 +442,11 @@ pub extern "C" fn rln_address(node: &COpaqueStruct) -> CResultString {
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn rln_rotate_address(node: &COpaqueStruct) -> CResultString {
+    ffi_call!("rln_rotate_address", api::rotate_address(node))
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn rln_btc_balance(node: &COpaqueStruct, skip_sync: bool) -> CResultString {
     ffi_call!("rln_btc_balance", api::btc_balance(node, skip_sync))
 }

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -29,6 +29,8 @@ interface SdkNode {
     [Throws=RlnError]
     AddressInfo address();
     [Throws=RlnError]
+    AddressInfo rotate_address();
+    [Throws=RlnError]
     BtcBalanceInfo btc_balance(boolean skip_sync);
     [Throws=RlnError]
     SignMessageResponse sign_message(string message);
@@ -562,6 +564,7 @@ dictionary SdkInitRequest {
     string? vss_url = null;
     boolean vss_allow_http = false;
     boolean vss_allow_empty_restore = false;
+    boolean reuse_addresses = false;
 };
 
 dictionary SdkUnlockRequest {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1026,6 +1026,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RgbInvoiceResponse'
+  /rotateaddress:
+    post:
+      tags:
+        - On-chain
+      summary: Rotate the pinned Bitcoin address
+      description: Advance the pinned Bitcoin address so the next `/address` call returns a fresh one. Only available when the node is started with `--reuse-addresses`; otherwise returns an `AddressReuseDisabled` error.
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddressResponse'
   /sendbtc:
     post:
       tags:

--- a/src/args.rs
+++ b/src/args.rs
@@ -75,6 +75,16 @@ struct Args {
     /// (abort on restore failure) is the safe choice in almost all cases.
     #[arg(long, default_value_t = false)]
     vss_allow_empty_restore: bool,
+
+    /// Reuse a pinned wallet address instead of generating a fresh one on each
+    /// `/address` call.
+    ///
+    /// **Privacy:** enabling this reduces on-chain privacy since all incoming
+    /// transactions to the same keychain become linkable. Only enable when
+    /// address reuse is acceptable. The pinned address can be advanced via the
+    /// `/rotateaddress` endpoint.
+    #[arg(long, default_value_t = false)]
+    reuse_addresses: bool,
 }
 
 pub(crate) struct UserArgs {
@@ -90,6 +100,7 @@ pub(crate) struct UserArgs {
     pub(crate) lsp_bearer_token: Option<String>,
     pub(crate) vss_url: Option<String>,
     pub(crate) vss_allow_empty_restore: bool,
+    pub(crate) reuse_addresses: bool,
 }
 
 pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
@@ -130,5 +141,6 @@ pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
         lsp_bearer_token: args.lsp_bearer_token,
         vss_url: args.vss_url,
         vss_allow_empty_restore: args.vss_allow_empty_restore,
+        reuse_addresses: args.reuse_addresses,
     })
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,9 @@ pub(crate) struct APIErrorResponse {
 /// The error variants returned by APIs
 #[derive(Debug, thiserror::Error)]
 pub enum APIError {
+    #[error("Address reuse is disabled")]
+    AddressReuseDisabled,
+
     #[error("Allocations already available")]
     AllocationsAlreadyAvailable,
 
@@ -399,6 +402,7 @@ impl From<axum::extract::multipart::MultipartRejection> for APIError {
 impl From<RgbLibError> for APIError {
     fn from(error: RgbLibError) -> Self {
         match error {
+            RgbLibError::AddressReuseDisabled => APIError::AddressReuseDisabled,
             RgbLibError::AllocationsAlreadyAvailable => APIError::AllocationsAlreadyAvailable,
             RgbLibError::AssetNotFound { .. } => APIError::UnknownContractId,
             RgbLibError::BatchTransferNotFound { .. } => APIError::BatchTransferNotFound,
@@ -507,6 +511,7 @@ impl IntoResponse for APIError {
             | APIError::InvalidAmount(_)
             | APIError::InvalidAnnounceAddresses(_)
             | APIError::InvalidAnnounceAlias(_)
+            | APIError::AddressReuseDisabled
             | APIError::InvalidAssetID(_)
             | APIError::InvalidAssignment
             | APIError::InvalidAttachments(_)

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -4262,6 +4262,7 @@ pub(crate) async fn start_ldk(
         mnemonic: rgb_wallet_mnemonic,
         witness_version: WitnessVersion::Taproot,
     };
+    let reuse_addresses = static_state.reuse_addresses;
     let mut rgb_wallet = tokio::task::spawn_blocking(move || {
         RgbLibWallet::new(
             WalletData {
@@ -4270,7 +4271,7 @@ pub(crate) async fn start_ldk(
                 database_type: DatabaseType::Sqlite,
                 max_allocations_per_utxo: 1,
                 supported_schemas: vec![AssetSchema::Nia, AssetSchema::Cfa, AssetSchema::Uda],
-                reuse_addresses: false,
+                reuse_addresses,
             },
             keys,
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,8 +69,8 @@ use crate::routes::{
     list_channels, list_payments, list_peers, list_swaps, list_transactions, list_transfers,
     list_unspents, ln_invoice, lock, maker_execute, maker_init, network_info, node_info,
     open_channel, post_asset_media, refresh_transfers, restore, revoke_token, rgb_invoice,
-    send_btc, send_onion_message, send_payment, send_rgb, shutdown, sign_message, sync, taker,
-    unlock,
+    rotate_address, send_btc, send_onion_message, send_payment, send_rgb, shutdown, sign_message,
+    sync, taker, unlock,
 };
 #[cfg(feature = "vss")]
 use crate::routes::{vss_backup, vss_backup_info, vss_clear_fence};
@@ -178,6 +178,7 @@ pub(crate) async fn app(args: UserArgs) -> Result<(Router, Arc<AppState>), AppEr
         .route("/restore", post(restore))
         .route("/revoketoken", post(revoke_token))
         .route("/rgbinvoice", post(rgb_invoice))
+        .route("/rotateaddress", post(rotate_address))
         .route("/sendbtc", post(send_btc))
         .route("/sendonionmessage", post(send_onion_message))
         .route("/sendpayment", post(send_payment))

--- a/src/node.rs
+++ b/src/node.rs
@@ -20,6 +20,7 @@ pub struct NodeConfig {
     pub lsp_bearer_token: Option<String>,
     pub vss_url: Option<String>,
     pub vss_allow_empty_restore: bool,
+    pub reuse_addresses: bool,
 }
 
 #[derive(Clone)]
@@ -52,6 +53,7 @@ impl NodeHandle {
             lsp_bearer_token: config.lsp_bearer_token,
             vss_url: config.vss_url,
             vss_allow_empty_restore: config.vss_allow_empty_restore,
+            reuse_addresses: config.reuse_addresses,
         };
         let state = start_daemon(&args).await?;
         Ok(Self { state })

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -14,7 +14,7 @@ use lightning::sign::ChangeDestinationSource;
 use lightning::util::async_poll::AsyncResult;
 use lightning::util::persist::KVStoreSync;
 use rgb_lib::{
-    bdk_wallet::SignOptions,
+    bdk_wallet::{KeychainKind, SignOptions},
     bitcoin::psbt::Psbt as BitcoinPsbt,
     wallet::{
         rust_only::{check_proxy_url, ColoringInfo},
@@ -199,6 +199,10 @@ impl UnlockedAppState {
 
     pub(crate) fn rgb_get_address(&self) -> Result<String, RgbLibError> {
         self.rgb_wallet_wrapper.get_address()
+    }
+
+    pub(crate) fn rgb_rotate_address(&self) -> Result<String, RgbLibError> {
+        self.rgb_wallet_wrapper.rotate_address()
     }
 
     pub(crate) fn rgb_get_asset_balance(
@@ -649,6 +653,10 @@ impl RgbLibWalletWrapper {
 
     pub(crate) fn get_address(&self) -> Result<String, RgbLibError> {
         self.get_rgb_wallet().get_address()
+    }
+
+    pub(crate) fn rotate_address(&self) -> Result<String, RgbLibError> {
+        self.get_rgb_wallet().rotate_address(KeychainKind::Internal)
     }
 
     pub(crate) fn get_asset_balance(

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1597,6 +1597,17 @@ pub(crate) async fn address(
     Ok(Json(AddressResponse { address }))
 }
 
+pub(crate) async fn rotate_address(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<AddressResponse>, APIError> {
+    let guard = state.check_unlocked().await?;
+    let unlocked_state = guard.as_ref().unwrap();
+
+    let address = unlocked_state.rgb_rotate_address()?;
+
+    Ok(Json(AddressResponse { address }))
+}
+
 pub(crate) async fn async_order_new(
     State(state): State<Arc<AppState>>,
     WithRejection(Json(payload), _): WithRejection<Json<AsyncOrderNewRequest>, APIError>,

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1150,6 +1150,15 @@ pub(crate) async fn address(state: Arc<AppState>) -> Result<AddressData, APIErro
     })
 }
 
+pub(crate) async fn rotate_address(state: Arc<AppState>) -> Result<AddressData, APIError> {
+    let guard = check_unlocked(&state).await?;
+    let unlocked_state = guard.as_ref().unwrap();
+
+    Ok(AddressData {
+        address: unlocked_state.rgb_rotate_address()?,
+    })
+}
+
 pub(crate) async fn async_order_new(
     state: Arc<AppState>,
     request: AsyncOrderNewRequest,
@@ -4324,6 +4333,7 @@ mod tests {
                 database: RwLock::new(Arc::new(database)),
                 vss_url: None,
                 vss_allow_empty_restore: false,
+                reuse_addresses: false,
             }),
             cancel_token: CancellationToken::new(),
             unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/test/address_reuse.rs
+++ b/src/test/address_reuse.rs
@@ -1,0 +1,295 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/address_reuse/";
+const FUND_SATS: u64 = 100_000_000;
+#[cfg(feature = "vss")]
+const VSS_URL: &str = "http://localhost:8081/vss";
+
+async fn rotate_address_res(node_address: SocketAddr) -> Response {
+    reqwest::Client::new()
+        .post(format!("http://{node_address}/rotateaddress"))
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn rotate_address(node_address: SocketAddr) -> String {
+    let res = rotate_address_res(node_address).await;
+    check_response_is_ok(res)
+        .await
+        .json::<AddressResponse>()
+        .await
+        .unwrap()
+        .address
+}
+
+fn fund_and_mine(address: String, sats: u64) {
+    fund_wallet(address, sats);
+    mine(false);
+}
+
+async fn settled_btc(node_address: SocketAddr) -> u64 {
+    btc_balance(node_address).await.vanilla.settled
+}
+
+/// With reuse on, `/address` pins a single address and BTC sent to it
+/// repeatedly accumulates on that same address.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn reuse_enabled_pins_address_and_accumulates_funds() {
+    initialize();
+
+    let test_dir = format!("{TEST_DIR_BASE}reuse_on");
+    let (node_addr, _, _) =
+        start_node_with_reuse_addresses(&test_dir, NODE1_PEER_PORT, true, false, None).await;
+
+    let pinned = address(node_addr).await;
+    assert_eq!(pinned, address(node_addr).await, "address must stay pinned");
+
+    fund_and_mine(pinned.clone(), FUND_SATS);
+    assert!(settled_btc(node_addr).await >= FUND_SATS);
+
+    // The pin is unchanged after receiving, and a second payment to the same
+    // address accumulates rather than landing on a fresh one.
+    assert_eq!(address(node_addr).await, pinned);
+    fund_and_mine(pinned.clone(), FUND_SATS);
+    assert!(
+        settled_btc(node_addr).await >= 2 * FUND_SATS,
+        "funds sent to the reused address must accumulate"
+    );
+}
+
+/// With reuse off (default), `/address` returns a fresh address each call.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn reuse_disabled_returns_fresh_addresses() {
+    initialize();
+
+    let test_dir = format!("{TEST_DIR_BASE}reuse_off");
+    let (node_addr, _, _) =
+        start_node_with_reuse_addresses(&test_dir, NODE1_PEER_PORT, false, false, None).await;
+
+    assert_ne!(address(node_addr).await, address(node_addr).await);
+}
+
+/// `/rotateaddress` advances the pin to a new address that subsequent
+/// `/address` calls return, and which can receive funds.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn rotate_advances_pin_and_new_address_receives_funds() {
+    initialize();
+
+    let test_dir = format!("{TEST_DIR_BASE}rotate_on");
+    let (node_addr, _, _) =
+        start_node_with_reuse_addresses(&test_dir, NODE1_PEER_PORT, true, false, None).await;
+
+    let pinned = address(node_addr).await;
+    fund_and_mine(pinned.clone(), FUND_SATS);
+    assert!(settled_btc(node_addr).await >= FUND_SATS);
+
+    let rotated = rotate_address(node_addr).await;
+    assert_ne!(rotated, pinned);
+    assert_eq!(
+        rotated,
+        address(node_addr).await,
+        "the pin must move to the rotated address"
+    );
+
+    fund_and_mine(rotated, FUND_SATS);
+    assert!(
+        settled_btc(node_addr).await >= 2 * FUND_SATS,
+        "funds sent to the rotated address must be spendable"
+    );
+}
+
+/// `/rotateaddress` is rejected when reuse is disabled.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn rotate_disabled_errors() {
+    initialize();
+
+    let test_dir = format!("{TEST_DIR_BASE}rotate_off");
+    let (node_addr, _, _) =
+        start_node_with_reuse_addresses(&test_dir, NODE1_PEER_PORT, false, false, None).await;
+
+    let res = rotate_address_res(node_addr).await;
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::BAD_REQUEST,
+        "Address reuse is disabled",
+        "AddressReuseDisabled",
+    )
+    .await;
+}
+
+/// The pinned address and its balance survive a restart that keeps local state.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn reuse_pinned_address_and_balance_survive_restart() {
+    initialize();
+
+    let test_dir = format!("{TEST_DIR_BASE}restart");
+    let (node_addr, _, _) =
+        start_node_with_reuse_addresses(&test_dir, NODE1_PEER_PORT, true, false, None).await;
+
+    let pinned = address(node_addr).await;
+    fund_and_mine(pinned.clone(), FUND_SATS);
+    let balance = settled_btc(node_addr).await;
+    assert!(balance >= FUND_SATS);
+
+    shutdown(&[node_addr]).await;
+    let (node_addr, _, _) =
+        start_node_with_reuse_addresses(&test_dir, NODE1_PEER_PORT, true, true, None).await;
+
+    assert_eq!(
+        address(node_addr).await,
+        pinned,
+        "pinned address must be stable across a restart"
+    );
+    assert!(
+        settled_btc(node_addr).await >= balance,
+        "balance must be retained across a restart"
+    );
+}
+
+/// The pinned address is deterministic from the seed: after wiping all local
+/// state and re-initializing from the same mnemonic, `/address` returns the
+/// same pinned address and the on-chain funds are recovered.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn reuse_pinned_address_recovers_from_seed() {
+    initialize();
+
+    let test_dir = format!("{TEST_DIR_BASE}seed_recovery");
+    let (node_addr, _, mnemonic) =
+        start_node_with_reuse_addresses(&test_dir, NODE1_PEER_PORT, true, false, None).await;
+
+    let pinned = address(node_addr).await;
+    fund_and_mine(pinned.clone(), FUND_SATS);
+    let balance = settled_btc(node_addr).await;
+    assert!(balance >= FUND_SATS);
+
+    // Wipe local state and recover from the seed alone.
+    shutdown(&[node_addr]).await;
+    let (node_addr, _, _) =
+        start_node_with_reuse_addresses(&test_dir, NODE1_PEER_PORT, true, false, Some(&mnemonic))
+            .await;
+
+    assert_eq!(
+        address(node_addr).await,
+        pinned,
+        "pinned address must be re-derived from the seed after a wipe"
+    );
+    assert!(
+        settled_btc(node_addr).await >= balance,
+        "on-chain funds must be recovered from the seed after a wipe"
+    );
+}
+
+/// The rotated pin is persisted and survives a restart that keeps local state.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn rotate_persists_across_restart() {
+    initialize();
+
+    let test_dir = format!("{TEST_DIR_BASE}rotate_restart");
+    let (node_addr, _, _) =
+        start_node_with_reuse_addresses(&test_dir, NODE1_PEER_PORT, true, false, None).await;
+
+    let base = address(node_addr).await;
+    let rotated = rotate_address(node_addr).await;
+    assert_ne!(rotated, base);
+    assert_eq!(rotated, address(node_addr).await);
+
+    shutdown(&[node_addr]).await;
+    let (node_addr, _, _) =
+        start_node_with_reuse_addresses(&test_dir, NODE1_PEER_PORT, true, true, None).await;
+
+    assert_eq!(
+        address(node_addr).await,
+        rotated,
+        "rotated pin must persist across a restart"
+    );
+}
+
+/// End-to-end VSS recovery with reuse enabled: a reuse node issues an asset,
+/// is wiped, and restarts from the same seed + VSS. The pinned address, the
+/// on-chain funds and the RGB asset must all come back.
+#[cfg(feature = "vss")]
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[traced_test]
+async fn reuse_address_and_assets_recover_via_vss() {
+    if !vss_server_available() {
+        eprintln!("SKIP: VSS server not available at {VSS_URL}");
+        return;
+    }
+    initialize();
+
+    let test_dir = format!("{TEST_DIR_BASE}vss");
+    let (node_addr, _, mnemonic) =
+        start_node_with_vss(&test_dir, NODE1_PEER_PORT, false, VSS_URL, None, true).await;
+
+    // Rotate first so recovery has to restore a non-default pin from VSS.
+    let base = address(node_addr).await;
+    let pinned = rotate_address(node_addr).await;
+    assert_ne!(pinned, base);
+    fund_and_create_utxos(node_addr, None).await;
+
+    let asset_id = issue_asset_nia(node_addr).await.asset_id;
+    assert_eq!(
+        asset_balance_spendable(node_addr, &asset_id).await,
+        ISSUE_AMT
+    );
+
+    // Blocking RGB backup: the asset's VSS backup is durable once issue returns.
+    assert_eq!(
+        vss_backup_info(node_addr).await["backup_exists"],
+        serde_json::json!(true),
+        "rgb backup must exist after issue"
+    );
+
+    let pre_wipe_btc = settled_btc(node_addr).await;
+
+    wipe_node_dir(node_addr, &test_dir).await;
+    let (node_addr, _, _) = start_node_with_vss(
+        &test_dir,
+        NODE1_PEER_PORT,
+        true,
+        VSS_URL,
+        Some(&mnemonic),
+        true,
+    )
+    .await;
+
+    assert_eq!(
+        address(node_addr).await,
+        pinned,
+        "rotated pin must be recovered with reuse + VSS"
+    );
+    assert!(
+        settled_btc(node_addr).await >= pre_wipe_btc,
+        "on-chain funds must be recovered after VSS restore"
+    );
+    assert_eq!(
+        asset_balance_spendable(node_addr, &asset_id).await,
+        ISSUE_AMT,
+        "asset balance must be recovered from VSS"
+    );
+}
+
+#[cfg(feature = "vss")]
+fn vss_server_available() -> bool {
+    std::net::TcpStream::connect_timeout(
+        &"127.0.0.1:8081".parse().unwrap(),
+        std::time::Duration::from_secs(2),
+    )
+    .is_ok()
+}

--- a/src/test/auth_db_persistence.rs
+++ b/src/test/auth_db_persistence.rs
@@ -31,6 +31,7 @@ fn build_state(storage_dir_path: PathBuf, database: DatabaseConnection) -> AppSt
             lsp_bearer_token: None,
             vss_url: None,
             vss_allow_empty_restore: false,
+            reuse_addresses: false,
         }),
         cancel_token: CancellationToken::new(),
         unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/test/lib_sdk/helpers.rs
+++ b/src/test/lib_sdk/helpers.rs
@@ -266,6 +266,7 @@ fn make_node_inner(
         vss_url,
         vss_allow_http: true,
         vss_allow_empty_restore: false,
+        reuse_addresses: false,
     })
     .expect("create SDK node")
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -113,6 +113,7 @@ impl Default for UserArgs {
             lsp_bearer_token: None,
             vss_url: None,
             vss_allow_empty_restore: false,
+            reuse_addresses: false,
         }
     }
 }
@@ -359,12 +360,60 @@ async fn start_node_with_virtual_options(
     (node_address, password)
 }
 
+/// Start a node with the `--reuse-addresses` flag, returning `(addr, password, mnemonic)`.
+///
+/// Mnemonic semantics mirror [`start_node_with_vss`]:
+/// - `mnemonic = None` on a fresh start: `init` generates a random seed and returns it.
+/// - `mnemonic = Some(seed)`: `init` with that exact seed — used for post-wipe seed recovery.
+/// - `mnemonic = None` with `keep_node_dir`: plain restart keeping local state, no `init`.
+async fn start_node_with_reuse_addresses(
+    node_test_dir: &str,
+    node_peer_port: u16,
+    reuse_addresses: bool,
+    keep_node_dir: bool,
+    mnemonic: Option<&str>,
+) -> (SocketAddr, String, String) {
+    if !keep_node_dir && Path::new(&node_test_dir).is_dir() {
+        std::fs::remove_dir_all(node_test_dir).unwrap();
+    }
+    let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
+    let node_address = listener.local_addr().unwrap();
+    std::fs::create_dir_all(node_test_dir).unwrap();
+    let args = UserArgs {
+        storage_dir_path: node_test_dir.into(),
+        ldk_peer_listening_port: node_peer_port,
+        reuse_addresses,
+        ..Default::default()
+    };
+    let (router, app_state) = app(args).await.unwrap();
+    register_app_state(node_address, Arc::clone(&app_state));
+    tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(shutdown_signal(app_state))
+            .await
+            .unwrap();
+    });
+
+    let password = format!("{node_test_dir}.{node_peer_port}");
+    let used_mnemonic = if keep_node_dir && mnemonic.is_none() {
+        String::new()
+    } else {
+        init(node_address, &password, mnemonic.map(|m| m.to_string()))
+            .await
+            .mnemonic
+    };
+    unlock(node_address, &password).await;
+    wait_for_peer_port_ready(node_peer_port).await;
+    (node_address, password, used_mnemonic)
+}
+
 #[cfg(feature = "vss")]
 async fn start_daemon_with_vss(
     node_test_dir: &str,
     node_peer_port: u16,
     keep_node_dir: bool,
     vss_url: Option<String>,
+    reuse_addresses: bool,
 ) -> SocketAddr {
     if !keep_node_dir && Path::new(&node_test_dir).is_dir() {
         std::fs::remove_dir_all(node_test_dir).unwrap();
@@ -376,6 +425,7 @@ async fn start_daemon_with_vss(
         storage_dir_path: node_test_dir.into(),
         ldk_peer_listening_port: node_peer_port,
         vss_url,
+        reuse_addresses,
         ..Default::default()
     };
     let (router, app_state) = app(args).await.unwrap();
@@ -405,6 +455,7 @@ async fn start_node_with_vss(
     keep_node_dir: bool,
     vss_url: &str,
     mnemonic: Option<&str>,
+    reuse_addresses: bool,
 ) -> (SocketAddr, String, String) {
     println!("starting vss node with peer port {node_peer_port}");
     let node_address = start_daemon_with_vss(
@@ -412,6 +463,7 @@ async fn start_node_with_vss(
         node_peer_port,
         keep_node_dir,
         Some(vss_url.into()),
+        reuse_addresses,
     )
     .await;
 
@@ -2810,6 +2862,7 @@ pub fn set_mock_fee(fee: u32) {
     crate::fee_mock::set_mock_fee_for_tests(Some(fee));
 }
 
+mod address_reuse;
 mod auth_db_persistence;
 mod authentication;
 mod backup_and_restore;

--- a/src/test/remote_first_recovery.rs
+++ b/src/test/remote_first_recovery.rs
@@ -32,10 +32,24 @@ async fn remote_first_recovery_inner() {
 
     // Fresh per-run seeds (returned by init) so VSS state never leaks between
     // runs; node1's seed is reused on the post-wipe restart.
-    let (node1_addr, _, mnemonic_1) =
-        start_node_with_vss(&test_dir_node1, NODE1_PEER_PORT, false, VSS_URL, None).await;
-    let (node2_addr, _, _) =
-        start_node_with_vss(&test_dir_node2, NODE2_PEER_PORT, false, VSS_URL, None).await;
+    let (node1_addr, _, mnemonic_1) = start_node_with_vss(
+        &test_dir_node1,
+        NODE1_PEER_PORT,
+        false,
+        VSS_URL,
+        None,
+        false,
+    )
+    .await;
+    let (node2_addr, _, _) = start_node_with_vss(
+        &test_dir_node2,
+        NODE2_PEER_PORT,
+        false,
+        VSS_URL,
+        None,
+        false,
+    )
+    .await;
 
     fund_and_create_utxos(node1_addr, None).await;
     fund_and_create_utxos(node2_addr, None).await;
@@ -99,6 +113,7 @@ async fn remote_first_recovery_inner() {
         true,
         VSS_URL,
         Some(&mnemonic_1),
+        false,
     )
     .await;
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -37,6 +37,7 @@ pub fn mock_locked_app_state() -> TestAppState {
             lsp_bearer_token: None,
             vss_url: None,
             vss_allow_empty_restore: false,
+            reuse_addresses: false,
         }),
         cancel_token: CancellationToken::new(),
         unlocked_app_state: Arc::new(TokioMutex::new(None)),

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -103,6 +103,7 @@ fn handle_from_request(request: SdkInitRequest) -> Result<NodeHandle, RlnError> 
         lsp_bearer_token: request.lsp_bearer_token,
         vss_url: request.vss_url,
         vss_allow_empty_restore: request.vss_allow_empty_restore,
+        reuse_addresses: request.reuse_addresses,
     };
     block_on_app(NodeHandle::new(config))
 }
@@ -988,6 +989,14 @@ impl SdkNode {
         })
     }
 
+    pub fn rotate_address(&self) -> Result<AddressInfo, RlnError> {
+        let state = self.handle.app_state();
+        let info = block_on_sdk(sdk::rotate_address(state))?;
+        Ok(AddressInfo {
+            address: info.address,
+        })
+    }
+
     pub fn btc_balance(&self, skip_sync: bool) -> Result<BtcBalanceInfo, RlnError> {
         let state = self.handle.app_state();
         let bal = block_on_sdk(sdk::btc_balance(state, skip_sync))?;
@@ -1605,6 +1614,11 @@ pub fn sdk_network_info() -> Result<NetworkInfo, RlnError> {
 pub fn sdk_address() -> Result<AddressInfo, RlnError> {
     let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
     SdkNode { handle }.address()
+}
+
+pub fn sdk_rotate_address() -> Result<AddressInfo, RlnError> {
+    let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
+    SdkNode { handle }.rotate_address()
 }
 
 pub fn sdk_btc_balance(skip_sync: bool) -> Result<BtcBalanceInfo, RlnError> {

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -110,6 +110,7 @@ mod uniffi_smoke_tests {
                 lsp_bearer_token: None,
                 vss_url: None,
                 vss_allow_empty_restore: false,
+                reuse_addresses: false,
             }),
             cancel_token: CancellationToken::new(),
             unlocked_app_state: Arc::new(TokioMutex::new(None)),
@@ -395,6 +396,7 @@ mod uniffi_smoke_tests {
             vss_url: Some("http://example.com/vss".to_string()),
             vss_allow_http: false,
             vss_allow_empty_restore: false,
+            reuse_addresses: false,
         });
         assert!(matches!(res, Err(RlnError::InvalidRequest)));
     }

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -679,6 +679,7 @@ pub struct SdkInitRequest {
     pub vss_url: Option<String>,
     pub vss_allow_http: bool,
     pub vss_allow_empty_restore: bool,
+    pub reuse_addresses: bool,
 }
 
 pub struct SendRgbRequest {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -145,6 +145,9 @@ pub(crate) struct StaticState {
     /// continues with empty local state instead of aborting unlock.
     #[cfg_attr(not(feature = "vss"), allow(dead_code))]
     pub(crate) vss_allow_empty_restore: bool,
+    /// When true, the RGB wallet returns a pinned address instead of a fresh
+    /// one on each `/address` call. Set from the `--reuse-addresses` flag.
+    pub(crate) reuse_addresses: bool,
 }
 
 impl StaticState {
@@ -662,6 +665,7 @@ pub(crate) async fn start_daemon(args: &UserArgs) -> Result<Arc<AppState>, AppEr
         lsp_bearer_token: args.lsp_bearer_token.clone(),
         vss_url: args.vss_url.clone(),
         vss_allow_empty_restore: args.vss_allow_empty_restore,
+        reuse_addresses: args.reuse_addresses,
     });
 
     let app_state = Arc::new(AppState {


### PR DESCRIPTION
Exposes rgb-lib's address-reuse mode in the node.

- New `--reuse-addresses` startup flag: when set, `/address` returns a pinned address instead of a fresh one each call (privacy trade-off; off by default).
- New `POST /rotateaddress` endpoint: advances the pinned address; returns `AddressReuseDisabled` (400) when reuse is off.
- The rotated pin is persisted, so it survives restart and VSS recovery.

Threaded through the CLI args, `NodeConfig`/`StaticState`, and the uniffi/c-ffi bindings; documented in the README and OpenAPI spec. Covered by e2e tests for the happy paths, funding, restart, seed recovery, and VSS recovery.
