### PR TITLE
Add txid filtering to listtransfers and listtransactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695e433882668b55b3d7fb0ba22bf9be66a91abe30d7ca1f1a774f8b90b4db4c"
 dependencies = [
  "amplify_num",
- "bitflags",
+ "bitflags 2.13.0",
  "wasm-bindgen",
 ]
 
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -214,9 +214,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "as-any"
@@ -485,11 +485,11 @@ checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
 name = "base58ck"
-version = "0.1.100"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5dc7e09f7bb15f0062da7c03086d6b71a2c84e0af4fccbbc7d8c6559847816"
+checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
 dependencies = [
- "bitcoin_hashes 0.14.100",
+ "bitcoin_hashes 0.14.101",
 ]
 
 [[package]]
@@ -541,7 +541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c290eff038799a8ac0c5a82b6160a9ca456baa299a6f22b262c771342d2846c0"
 dependencies = [
  "bdk_core",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "miniscript",
  "serde",
 ]
@@ -552,7 +552,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3028782f6bf14a6df987244333d34e6b272b5a40a53e4879ec2dfd82275a3a"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "hashbrown 0.14.5",
  "serde",
 ]
@@ -597,7 +597,7 @@ dependencies = [
  "bdk_chain",
  "bdk_file_store",
  "bip39",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "miniscript",
  "rand_core 0.6.4",
  "serde",
@@ -645,7 +645,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes 0.14.100",
+ "bitcoin_hashes 0.12.0",
  "serde",
  "unicode-normalization",
 ]
@@ -728,16 +728,16 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.100"
+version = "0.32.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39581299241111285f3268ba75ddf372746fd041620918b145c1af9d75e91b6c"
+checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32 0.11.1",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes 0.14.100",
+ "bitcoin_hashes 0.14.101",
  "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1 0.29.1",
@@ -765,10 +765,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.100"
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin-private"
@@ -782,17 +803,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6386f1296021ac5d1a5ed9869595940fa7696dfe868198b1b71ec2c82db59343"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "hex",
  "log",
 ]
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.100"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bad157b78d0d1b22c4cbb6a35a566211fc4d14866a37f2c780652b50f3b845"
+checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
+ "bitcoin-consensus-encoding",
  "serde",
 ]
 
@@ -807,14 +829,20 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.100"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.2.2",
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -831,11 +859,11 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
 dependencies = [
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "rustls-webpki 0.103.13",
  "tokio",
  "tokio-rustls",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -919,15 +947,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
 dependencies = [
  "serde_core",
 ]
@@ -966,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1001,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1207,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "crc-any"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73"
+checksum = "46db9f663dfb869b80fcf59e32d7a80fc6c464a4f6328f3f06a00f5e36d05f8c"
 dependencies = [
  "debug-helper",
 ]
@@ -1395,9 +1423,41 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "debug-helper"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
+checksum = "80a4af69c60438a1a82af89d362f4729fd38db7b73f305a237636fad31ceb2bf"
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "delegate"
@@ -1552,7 +1612,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
 dependencies = [
- "bitcoin_hashes 0.14.100",
+ "bitcoin_hashes 0.14.101",
  "tokio",
 ]
 
@@ -1623,11 +1683,11 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7b1f8783238bb18e6e137875b0a66f3dffe6c7ea84066e05d033cf180b150f"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -1640,11 +1700,11 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5059f13888a90486e7268bbce59b175f5f76b1c55e5b9c568ceaa42d2b8507c"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -1683,9 +1743,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1693,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1735,7 +1795,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f19e3ea99dbfbef0c1ec26d83e69de0c579f6aa6aaac4f44597805fcc27e97af"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "hex-conservative 0.2.2",
  "log",
  "minreq",
@@ -2028,16 +2088,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -2300,11 +2358,11 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -2455,12 +2513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,10 +2621,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -2582,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2652,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2669,12 +2722,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -2694,7 +2741,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.8.1",
@@ -2713,18 +2760,18 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffe63f56b10d214be1ade8698ee80af82d981237cae3e581e7a631f5f4959f3"
+checksum = "c560d6c22b76ee0375c4fafcadd84dac7fcd9748af4d6626556c32b1a9753a0c"
 dependencies = [
  "bech32 0.11.1",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
- "lightning-invoice 0.33.2",
- "lightning-types 0.2.0",
- "possiblyrandom 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lightning-invoice 0.33.3",
+ "lightning-types 0.2.1",
+ "possiblyrandom 0.2.1",
 ]
 
 [[package]]
@@ -2733,7 +2780,7 @@ version = "0.2.2"
 dependencies = [
  "bech32 0.11.1",
  "bincode",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "dnssec-prover",
  "futures",
  "hashbrown 0.13.2",
@@ -2752,9 +2799,9 @@ dependencies = [
 name = "lightning-background-processor"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "bitcoin-io",
- "bitcoin_hashes 0.14.100",
+ "bitcoin_hashes 0.14.101",
  "lightning 0.2.2",
  "lightning-liquidity",
  "lightning-rapid-gossip-sync",
@@ -2765,7 +2812,7 @@ dependencies = [
 name = "lightning-block-sync"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "chunked_transfer",
  "lightning 0.2.2",
  "serde_json",
@@ -2784,13 +2831,13 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
-version = "0.33.2"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
+checksum = "b39b494954ed8f1d774d86473224fadf9f0dfcca38c2d16a7dbdf2b5800c8943"
 dependencies = [
  "bech32 0.11.1",
- "bitcoin 0.32.100",
- "lightning-types 0.2.0",
+ "bitcoin 0.32.101",
+ "lightning-types 0.2.1",
 ]
 
 [[package]]
@@ -2798,7 +2845,7 @@ name = "lightning-invoice"
 version = "0.34.0"
 dependencies = [
  "bech32 0.11.1",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "lightning-types 0.3.1",
  "rgb-lib",
  "serde",
@@ -2808,7 +2855,7 @@ dependencies = [
 name = "lightning-liquidity"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "chrono",
  "lightning 0.2.2",
  "lightning-invoice 0.34.0",
@@ -2842,7 +2889,7 @@ dependencies = [
 name = "lightning-net-tokio"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "lightning 0.2.2",
  "tokio",
 ]
@@ -2851,7 +2898,7 @@ dependencies = [
 name = "lightning-persister"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "lightning 0.2.2",
  "tokio",
  "windows-sys 0.48.0",
@@ -2861,9 +2908,9 @@ dependencies = [
 name = "lightning-rapid-gossip-sync"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "bitcoin-io",
- "bitcoin_hashes 0.14.100",
+ "bitcoin_hashes 0.14.101",
  "lightning 0.2.2",
 ]
 
@@ -2871,7 +2918,7 @@ dependencies = [
 name = "lightning-transaction-sync"
 version = "0.2.1"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "electrum-client 0.24.1",
  "esplora-client",
  "lightning 0.2.2",
@@ -2880,18 +2927,18 @@ dependencies = [
 
 [[package]]
 name = "lightning-types"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
+checksum = "16acfbf632be138618a255b353b1c4577f06cf85972aff1cf59f46554528751f"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
 ]
 
 [[package]]
 name = "lightning-types"
 version = "0.3.1"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
 ]
 
 [[package]]
@@ -2923,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -3029,7 +3076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8343cc1ef1408bd9bdbf69f7aef47017dfab7e6349ec26fddf62e0e9fb5a4cf"
 dependencies = [
  "bech32 0.11.1",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "serde",
 ]
 
@@ -3101,7 +3148,7 @@ name = "musig2"
 version = "0.1.0"
 source = "git+https://github.com/arik-so/rust-musig2?rev=6f95a05718cbb44d8fe3fa6021aea8117aa38d50#6f95a05718cbb44d8fe3fa6021aea8117aa38d50"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
 ]
 
 [[package]]
@@ -3127,7 +3174,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3257,7 +3304,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3542,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "possiblyrandom"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
+checksum = "9c564dbf654befd49035528299f1208a40508f6e07efb11c163444e304e4484f"
 dependencies = [
  "getrandom 0.2.17",
 ]
@@ -3581,16 +3628,6 @@ checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -3689,7 +3726,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph 0.6.5",
- "prettyplease 0.1.25",
+ "prettyplease",
  "prost 0.11.9",
  "prost-types 0.11.9",
  "regex",
@@ -3758,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3768,7 +3805,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -3778,9 +3815,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -3789,7 +3826,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3814,9 +3851,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3860,8 +3897,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3915,7 +3952,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3924,7 +3961,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4011,7 +4048,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4029,7 +4066,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -4060,7 +4097,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -4131,7 +4168,7 @@ dependencies = [
  "amplify",
  "baid64",
  "base85",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "chrono",
  "daggy",
  "getrandom 0.2.17",
@@ -4171,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26#117e8ca0411ebc8fd8e771f702daa0fa35ab66dd"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27#d8dba807d5028635143ffc8098e1b59086b646a0"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4192,7 +4229,7 @@ dependencies = [
  "rgb-schemas",
  "rgb-strict-encoding",
  "rgb-strict-types",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "scrypt",
  "sea-orm",
  "sea-query",
@@ -4216,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26#117e8ca0411ebc8fd8e771f702daa0fa35ab66dd"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27#d8dba807d5028635143ffc8098e1b59086b646a0"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -4234,7 +4271,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "biscuit-auth",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "bitcoin-bech32",
  "chacha20 0.9.1",
  "chacha20poly1305",
@@ -4267,7 +4304,7 @@ dependencies = [
  "rgb-lib",
  "rgb-psbt-utils",
  "rln-migration",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "scrypt",
  "sea-orm",
  "serde",
@@ -4357,7 +4394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cca0a8d70dd2d5b2a218ef7fd03e88b3ea69a926f3a9139c08c82d5f49fca236"
 dependencies = [
  "amplify",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "rgb-strict-encoding-derive",
  "serde",
  "wasm-bindgen",
@@ -4485,7 +4522,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4498,7 +4535,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -4519,9 +4556,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4566,7 +4603,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
@@ -4879,7 +4916,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.100",
+ "bitcoin_hashes 0.12.0",
  "rand 0.8.6",
  "secp256k1-sys 0.10.1",
  "serde",
@@ -4909,7 +4946,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4952,7 +4989,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8db02c046447759ef62beeede660c4b7abae023a961bd5a8935aa7d4207edd1a"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "bitcoin-consensus-derive",
  "chunked-buffer",
  "hex",
@@ -5186,7 +5223,7 @@ version = "0.1.0-alpha"
 source = "git+https://github.com/UTEXO-Protocol/rln-external-signer.git?branch=main#594d8c08e812aa9d237a177391ea6f56b7c58e8f"
 dependencies = [
  "base64 0.22.1",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "chacha20 0.9.1",
  "chacha20poly1305",
  "hex",
@@ -5357,7 +5394,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5416,7 +5453,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -5459,7 +5496,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "crc",
@@ -5619,7 +5656,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5647,7 +5684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5731,9 +5768,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5751,9 +5788,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5827,7 +5864,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.40",
+ "rustls 0.23.41",
  "tokio",
 ]
 
@@ -5939,7 +5976,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -6091,7 +6128,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a947ef834df674b09aa786d18133904e9b388b8e7b29eb565a505aa949078a"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "bytes",
  "log",
  "serde",
@@ -6331,11 +6368,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "serde_core",
 ]
 
@@ -6363,7 +6400,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7a66fafe84eddfc3e6bd6ea189211668500b726be9111e66261cf6a4332c25"
 dependencies = [
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "hex",
 ]
 
@@ -6375,7 +6412,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "backtrace",
- "bitcoin 0.32.100",
+ "bitcoin 0.32.101",
  "bitcoin-consensus-derive",
  "bitcoin-push-decoder",
  "bolt-derive",
@@ -6383,8 +6420,8 @@ dependencies = [
  "hashbrown 0.13.2",
  "hex",
  "itertools 0.10.5",
- "lightning 0.1.8",
- "lightning-invoice 0.33.2",
+ "lightning 0.1.11",
+ "lightning-invoice 0.33.3",
  "log",
  "scopeguard",
  "serde",
@@ -6458,8 +6495,8 @@ source = "git+https://github.com/lightningdevkit/vss-client?rev=ad63805047561dcf
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "bitcoin 0.32.100",
- "bitcoin_hashes 0.14.100",
+ "bitcoin 0.32.101",
+ "bitcoin_hashes 0.14.101",
  "bitreq",
  "chacha20-poly1305",
  "log",
@@ -6500,16 +6537,7 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6520,9 +6548,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6534,9 +6562,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6544,9 +6572,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6554,9 +6582,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6567,33 +6595,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -6628,22 +6634,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6661,9 +6655,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6680,14 +6674,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7066,97 +7060,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap",
- "prettyplease 0.2.37",
- "syn 2.0.118",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease 0.2.37",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ magic-crypt = "4.0.1"
 rand = "0.8.5"
 regex = { version = "1.11", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.26", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.27", features = [
     "electrum",
     "esplora",
 ] }

--- a/bindings/c-ffi/Cargo.lock
+++ b/bindings/c-ffi/Cargo.lock
@@ -4140,7 +4140,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#0d46c9a51765b41044b37682828a52a1676761f2"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27#d8dba807d5028635143ffc8098e1b59086b646a0"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4185,7 +4185,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?branch=dev#0d46c9a51765b41044b37682828a52a1676761f2"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27#d8dba807d5028635143ffc8098e1b59086b646a0"
 dependencies = [
  "sea-orm-migration",
  "tokio",

--- a/bindings/c-ffi/rln.h
+++ b/bindings/c-ffi/rln.h
@@ -120,7 +120,13 @@ struct CResultString rln_list_swaps(const struct COpaqueStruct *node);
 
 struct CResultString rln_list_transactions(const struct COpaqueStruct *node, bool skip_sync);
 
+struct CResultString rln_list_transactions_by_txid(const struct COpaqueStruct *node,
+                                                   const char *txid,
+                                                   bool skip_sync);
+
 struct CResultString rln_list_transfers(const struct COpaqueStruct *node, const char *asset_id);
+
+struct CResultString rln_list_transfers_by_txid(const struct COpaqueStruct *node, const char *txid);
 
 struct CResultString rln_list_unspents(const struct COpaqueStruct *node, bool skip_sync);
 

--- a/bindings/c-ffi/rln.hpp
+++ b/bindings/c-ffi/rln.hpp
@@ -106,7 +106,13 @@ CResultString rln_list_swaps(const COpaqueStruct *node);
 
 CResultString rln_list_transactions(const COpaqueStruct *node, bool skip_sync);
 
+CResultString rln_list_transactions_by_txid(const COpaqueStruct *node,
+                                            const char *txid,
+                                            bool skip_sync);
+
 CResultString rln_list_transfers(const COpaqueStruct *node, const char *asset_id);
+
+CResultString rln_list_transfers_by_txid(const COpaqueStruct *node, const char *txid);
 
 CResultString rln_list_unspents(const COpaqueStruct *node, bool skip_sync);
 

--- a/bindings/c-ffi/src/api.rs
+++ b/bindings/c-ffi/src/api.rs
@@ -374,6 +374,15 @@ pub(crate) fn list_transfers(
     json(transfers.into_iter().map(JsonTransfer::from).collect::<Vec<_>>())
 }
 
+pub(crate) fn list_transfers_by_txid(
+    node: &COpaqueStruct,
+    txid: *const c_char,
+) -> Result<String, Error> {
+    let node = require_handle(node)?;
+    let transfers = node.list_transfers_by_txid(ptr_to_string(txid))?;
+    json(transfers.into_iter().map(JsonTransfer::from).collect::<Vec<_>>())
+}
+
 pub(crate) fn list_unspents(
     node: &COpaqueStruct,
     skip_sync: bool,
@@ -572,6 +581,16 @@ pub(crate) fn list_transactions(
 ) -> Result<String, Error> {
     let node = require_handle(node)?;
     let txs = node.list_transactions(skip_sync)?;
+    json(txs.into_iter().map(JsonTransaction::from).collect::<Vec<_>>())
+}
+
+pub(crate) fn list_transactions_by_txid(
+    node: &COpaqueStruct,
+    txid: *const c_char,
+    skip_sync: bool,
+) -> Result<String, Error> {
+    let node = require_handle(node)?;
+    let txs = node.list_transactions_by_txid(ptr_to_string(txid), skip_sync)?;
     json(txs.into_iter().map(JsonTransaction::from).collect::<Vec<_>>())
 }
 

--- a/bindings/c-ffi/src/lib.rs
+++ b/bindings/c-ffi/src/lib.rs
@@ -342,6 +342,17 @@ pub extern "C" fn rln_list_transfers(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn rln_list_transfers_by_txid(
+    node: &COpaqueStruct,
+    txid: *const c_char,
+) -> CResultString {
+    ffi_call!(
+        "rln_list_transfers_by_txid",
+        api::list_transfers_by_txid(node, txid)
+    )
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn rln_list_unspents(node: &COpaqueStruct, skip_sync: bool) -> CResultString {
     ffi_call!("rln_list_unspents", api::list_unspents(node, skip_sync))
 }
@@ -502,6 +513,18 @@ pub extern "C" fn rln_list_transactions(
     skip_sync: bool,
 ) -> CResultString {
     ffi_call!("rln_list_transactions", api::list_transactions(node, skip_sync))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rln_list_transactions_by_txid(
+    node: &COpaqueStruct,
+    txid: *const c_char,
+    skip_sync: bool,
+) -> CResultString {
+    ffi_call!(
+        "rln_list_transactions_by_txid",
+        api::list_transactions_by_txid(node, txid, skip_sync)
+    )
 }
 
 #[unsafe(no_mangle)]

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -25,6 +25,8 @@ interface SdkNode {
     [Throws=RlnError]
     sequence<Transaction> list_transactions(boolean skip_sync);
     [Throws=RlnError]
+    sequence<Transaction> list_transactions_by_txid(string txid, boolean skip_sync);
+    [Throws=RlnError]
     NetworkInfo network_info();
     [Throws=RlnError]
     AddressInfo address();
@@ -108,6 +110,8 @@ interface SdkNode {
     InvoiceStatus invoice_status(Bolt11Invoice invoice);
     [Throws=RlnError]
     sequence<Transfer> list_transfers(ContractId asset_id);
+    [Throws=RlnError]
+    sequence<Transfer> list_transfers_by_txid(string txid);
     [Throws=RlnError]
     sequence<Unspent> list_unspents(boolean skip_sync);
     [Throws=RlnError]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2733,6 +2733,11 @@ components:
             - 'null'
           format: uint64
           description: Maximum number to return. Defaults to 100 when absent or zero.
+        txid:
+          type:
+            - string
+            - 'null'
+          description: Return only the on-chain transaction with this txid.
     ListTransactionsResponse:
       type: object
       required:
@@ -2756,12 +2761,22 @@ components:
             index_offset to fetch the next, older page.
     ListTransfersRequest:
       type: object
-      required:
-        - asset_id
+      description: >-
+        Provide either asset_id (list that asset's transfers) or txid (list the
+        transfers committed by that on-chain transaction, across all assets).
       properties:
         asset_id:
-          type: string
+          type:
+            - string
+            - 'null'
           example: rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ8
+        txid:
+          type:
+            - string
+            - 'null'
+          description: >-
+            Return the transfers committed by the on-chain transaction with this
+            txid. Takes precedence over asset_id when both are given.
         index_offset:
           type:
             - integer

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -338,6 +338,13 @@ impl UnlockedAppState {
         self.rgb_wallet_wrapper.list_transfers(asset_id)
     }
 
+    pub(crate) fn rgb_list_transfers_by_txid(
+        &self,
+        txid: String,
+    ) -> Result<Vec<Transfer>, RgbLibError> {
+        self.rgb_wallet_wrapper.list_transfers_by_txid(txid)
+    }
+
     pub(crate) fn rgb_list_unspents(
         &self,
         settled_only: bool,
@@ -797,6 +804,13 @@ impl RgbLibWalletWrapper {
 
     pub(crate) fn list_transfers(&self, asset_id: String) -> Result<Vec<Transfer>, RgbLibError> {
         self.get_rgb_wallet().list_transfers(Some(asset_id))
+    }
+
+    pub(crate) fn list_transfers_by_txid(
+        &self,
+        txid: String,
+    ) -> Result<Vec<Transfer>, RgbLibError> {
+        self.get_rgb_wallet().list_transfers_by_txid(txid)
     }
 
     pub(crate) fn list_unspents(

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -871,6 +871,7 @@ pub(crate) struct ListTransactionsRequest {
     pub(crate) skip_sync: bool,
     pub(crate) index_offset: Option<u64>,
     pub(crate) max_transactions: Option<u64>,
+    pub(crate) txid: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -882,7 +883,8 @@ pub(crate) struct ListTransactionsResponse {
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct ListTransfersRequest {
-    pub(crate) asset_id: String,
+    pub(crate) asset_id: Option<String>,
+    pub(crate) txid: Option<String>,
     pub(crate) index_offset: Option<u64>,
     pub(crate) max_transfers: Option<u64>,
     pub(crate) status: Option<TransferStatus>,
@@ -3329,6 +3331,10 @@ pub(crate) async fn list_transactions(
         })
     }
 
+    if let Some(txid) = &payload.txid {
+        transactions.retain(|t| &t.txid == txid);
+    }
+
     // No stable index; order newest-first (unconfirmed first, then by height)
     // and derive a descending index so the cursor walks a consistent snapshot.
     transactions.sort_by(|a, b| {
@@ -3362,8 +3368,18 @@ pub(crate) async fn list_transfers(
     let guard = state.check_unlocked().await?;
     let unlocked_state = guard.as_ref().unwrap();
 
+    let raw_transfers = match (payload.txid, payload.asset_id) {
+        (Some(txid), _) => unlocked_state.rgb_list_transfers_by_txid(txid)?,
+        (None, Some(asset_id)) => unlocked_state.rgb_list_transfers(asset_id)?,
+        (None, None) => {
+            return Err(APIError::InvalidRequest(s!(
+                "either asset_id or txid must be provided"
+            )));
+        }
+    };
+
     let mut transfers = vec![];
-    for transfer in unlocked_state.rgb_list_transfers(payload.asset_id)? {
+    for transfer in raw_transfers {
         transfers.push(Transfer {
             idx: transfer.idx,
             created_at: transfer.created_at,

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -4166,6 +4166,68 @@ pub(crate) async fn list_swaps(state: Arc<AppState>) -> Result<SwapListData, API
     })
 }
 
+fn to_transaction_data(tx: rgb_lib::wallet::Transaction) -> TransactionData {
+    TransactionData {
+        transaction_type: match tx.transaction_type {
+            rgb_lib::wallet::TransactionType::RgbSend => TransactionType::RgbSend,
+            rgb_lib::wallet::TransactionType::Drain => TransactionType::Drain,
+            rgb_lib::wallet::TransactionType::CreateUtxos => TransactionType::CreateUtxos,
+            rgb_lib::wallet::TransactionType::SendBtc => TransactionType::SendBtc,
+            rgb_lib::wallet::TransactionType::Incoming => TransactionType::Incoming,
+        },
+        txid: tx.txid,
+        received: tx.received,
+        sent: tx.sent,
+        fee: tx.fee,
+        confirmation_time: tx.confirmation_time.map(|ct| BlockTime {
+            height: ct.height,
+            timestamp: ct.timestamp,
+        }),
+    }
+}
+
+fn to_transfer_data(transfer: rgb_lib::wallet::Transfer) -> TransferData {
+    TransferData {
+        idx: transfer.idx,
+        created_at: transfer.created_at,
+        updated_at: transfer.updated_at,
+        status: match transfer.status {
+            rgb_lib::TransferStatus::Initiated => TransferStatus::Initiated,
+            rgb_lib::TransferStatus::WaitingCounterparty => TransferStatus::WaitingCounterparty,
+            rgb_lib::TransferStatus::WaitingSafeHeight => TransferStatus::WaitingSafeHeight,
+            rgb_lib::TransferStatus::WaitingConfirmations => TransferStatus::WaitingConfirmations,
+            rgb_lib::TransferStatus::Settled => TransferStatus::Settled,
+            rgb_lib::TransferStatus::Failed => TransferStatus::Failed,
+        },
+        requested_assignment: transfer.requested_assignment,
+        assignments: transfer.assignments,
+        kind: match transfer.kind {
+            rgb_lib::wallet::TransferKind::Issuance => TransferKind::Issuance,
+            rgb_lib::wallet::TransferKind::ReceiveBlind => TransferKind::ReceiveBlind,
+            rgb_lib::wallet::TransferKind::ReceiveWitness => TransferKind::ReceiveWitness,
+            rgb_lib::wallet::TransferKind::Send => TransferKind::Send,
+            rgb_lib::wallet::TransferKind::Inflation => TransferKind::Inflation,
+            rgb_lib::wallet::TransferKind::Burn => TransferKind::Burn,
+        },
+        txid: transfer.txid,
+        recipient_id: transfer.recipient_id,
+        receive_utxo: transfer.receive_utxo.map(|u| u.to_string()),
+        change_utxo: transfer.change_utxo.map(|u| u.to_string()),
+        expiration: transfer.expiration_timestamp.map(|t| t as i64),
+        transport_endpoints: transfer
+            .transport_endpoints
+            .iter()
+            .map(|tte| TransferTransportEndpointData {
+                endpoint: tte.endpoint.clone(),
+                transport_type: match tte.transport_type {
+                    rgb_lib::TransportType::JsonRpc => TransportType::JsonRpc,
+                },
+                used: tte.used,
+            })
+            .collect(),
+    }
+}
+
 pub(crate) async fn list_transactions(
     state: Arc<AppState>,
     skip_sync: bool,
@@ -4173,28 +4235,27 @@ pub(crate) async fn list_transactions(
     let guard = check_unlocked(&state).await?;
     let unlocked_state = guard.as_ref().unwrap();
 
-    let mut transactions = vec![];
-    for tx in unlocked_state.rgb_list_transactions(skip_sync)? {
-        transactions.push(TransactionData {
-            transaction_type: match tx.transaction_type {
-                rgb_lib::wallet::TransactionType::RgbSend => TransactionType::RgbSend,
-                rgb_lib::wallet::TransactionType::Drain => TransactionType::Drain,
-                rgb_lib::wallet::TransactionType::CreateUtxos => TransactionType::CreateUtxos,
-                rgb_lib::wallet::TransactionType::SendBtc => TransactionType::SendBtc,
-                rgb_lib::wallet::TransactionType::Incoming => TransactionType::Incoming,
-            },
-            txid: tx.txid,
-            received: tx.received,
-            sent: tx.sent,
-            fee: tx.fee,
-            confirmation_time: tx.confirmation_time.map(|ct| BlockTime {
-                height: ct.height,
-                timestamp: ct.timestamp,
-            }),
-        });
-    }
+    Ok(unlocked_state
+        .rgb_list_transactions(skip_sync)?
+        .into_iter()
+        .map(to_transaction_data)
+        .collect())
+}
 
-    Ok(transactions)
+pub(crate) async fn list_transactions_by_txid(
+    state: Arc<AppState>,
+    txid: String,
+    skip_sync: bool,
+) -> Result<Vec<TransactionData>, APIError> {
+    let guard = check_unlocked(&state).await?;
+    let unlocked_state = guard.as_ref().unwrap();
+
+    Ok(unlocked_state
+        .rgb_list_transactions(skip_sync)?
+        .into_iter()
+        .map(to_transaction_data)
+        .filter(|tx| tx.txid == txid)
+        .collect())
 }
 
 pub(crate) async fn list_transfers(
@@ -4204,51 +4265,25 @@ pub(crate) async fn list_transfers(
     let guard = check_unlocked(&state).await?;
     let unlocked_state = guard.as_ref().unwrap();
 
-    let mut transfers = vec![];
-    for transfer in unlocked_state.rgb_list_transfers(asset_id)? {
-        transfers.push(TransferData {
-            idx: transfer.idx,
-            created_at: transfer.created_at,
-            updated_at: transfer.updated_at,
-            status: match transfer.status {
-                rgb_lib::TransferStatus::Initiated => TransferStatus::Initiated,
-                rgb_lib::TransferStatus::WaitingCounterparty => TransferStatus::WaitingCounterparty,
-                rgb_lib::TransferStatus::WaitingSafeHeight => TransferStatus::WaitingSafeHeight,
-                rgb_lib::TransferStatus::WaitingConfirmations => {
-                    TransferStatus::WaitingConfirmations
-                }
-                rgb_lib::TransferStatus::Settled => TransferStatus::Settled,
-                rgb_lib::TransferStatus::Failed => TransferStatus::Failed,
-            },
-            requested_assignment: transfer.requested_assignment,
-            assignments: transfer.assignments,
-            kind: match transfer.kind {
-                rgb_lib::wallet::TransferKind::Issuance => TransferKind::Issuance,
-                rgb_lib::wallet::TransferKind::ReceiveBlind => TransferKind::ReceiveBlind,
-                rgb_lib::wallet::TransferKind::ReceiveWitness => TransferKind::ReceiveWitness,
-                rgb_lib::wallet::TransferKind::Send => TransferKind::Send,
-                rgb_lib::wallet::TransferKind::Inflation => TransferKind::Inflation,
-                rgb_lib::wallet::TransferKind::Burn => TransferKind::Burn,
-            },
-            txid: transfer.txid,
-            recipient_id: transfer.recipient_id,
-            receive_utxo: transfer.receive_utxo.map(|u| u.to_string()),
-            change_utxo: transfer.change_utxo.map(|u| u.to_string()),
-            expiration: transfer.expiration_timestamp.map(|t| t as i64),
-            transport_endpoints: transfer
-                .transport_endpoints
-                .iter()
-                .map(|tte| TransferTransportEndpointData {
-                    endpoint: tte.endpoint.clone(),
-                    transport_type: match tte.transport_type {
-                        rgb_lib::TransportType::JsonRpc => TransportType::JsonRpc,
-                    },
-                    used: tte.used,
-                })
-                .collect(),
-        });
-    }
-    Ok(transfers)
+    Ok(unlocked_state
+        .rgb_list_transfers(asset_id)?
+        .into_iter()
+        .map(to_transfer_data)
+        .collect())
+}
+
+pub(crate) async fn list_transfers_by_txid(
+    state: Arc<AppState>,
+    txid: String,
+) -> Result<Vec<TransferData>, APIError> {
+    let guard = check_unlocked(&state).await?;
+    let unlocked_state = guard.as_ref().unwrap();
+
+    Ok(unlocked_state
+        .rgb_list_transfers_by_txid(txid)?
+        .into_iter()
+        .map(to_transfer_data)
+        .collect())
 }
 
 pub(crate) async fn list_unspents(

--- a/src/test/lib_sdk/payment.rs
+++ b/src/test/lib_sdk/payment.rs
@@ -520,6 +520,30 @@ fn success() {
         assert!(xfer_3.change_utxo.is_none());
         assert!(xfer_3.expiration.is_none());
         assert!(!xfer_3.transport_endpoints.is_empty());
+
+        // txid-based binding lookups resolve the same on-chain transaction
+        let send_txid = xfer_2.txid.as_ref().expect("send txid").to_string();
+        let by_txid = node_a
+            .list_transfers_by_txid(send_txid.clone())
+            .expect("node A list_transfers_by_txid");
+        assert!(!by_txid.is_empty());
+        assert!(by_txid.iter().all(|t| t.txid == xfer_2.txid));
+        assert!(by_txid.iter().any(|t| t.idx == xfer_2.idx));
+
+        let txs_by_txid = node_a
+            .list_transactions_by_txid(send_txid.clone(), false)
+            .expect("node A list_transactions_by_txid");
+        assert_eq!(txs_by_txid.len(), 1);
+        assert_eq!(txs_by_txid[0].txid.to_string(), send_txid);
+        assert!(matches!(
+            txs_by_txid[0].transaction_type,
+            TransactionType::RgbSend
+        ));
+
+        assert!(node_a
+            .list_transfers_by_txid("0".repeat(64))
+            .expect("node A list_transfers_by_txid unknown")
+            .is_empty());
     }));
 
     node_a.shutdown();

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1372,6 +1372,7 @@ async fn list_transactions_full(
         skip_sync: false,
         index_offset,
         max_transactions,
+        txid: None,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node_address}/listtransactions"))
@@ -1408,7 +1409,8 @@ async fn list_transfers_full(
 ) -> ListTransfersResponse {
     println!("listing transfers for asset {asset_id} on node {node_address}");
     let payload = ListTransfersRequest {
-        asset_id: asset_id.to_string(),
+        asset_id: Some(asset_id.to_string()),
+        txid: None,
         index_offset: filter.index_offset,
         max_transfers: filter.max_transfers,
         status: filter.status,
@@ -1426,6 +1428,53 @@ async fn list_transfers_full(
         .json::<ListTransfersResponse>()
         .await
         .unwrap()
+}
+
+async fn list_transfers_by_txid(node_address: SocketAddr, txid: &str) -> Vec<Transfer> {
+    println!("listing transfers for txid {txid} on node {node_address}");
+    let payload = ListTransfersRequest {
+        asset_id: None,
+        txid: Some(txid.to_string()),
+        index_offset: None,
+        max_transfers: None,
+        status: None,
+        created_after: None,
+        created_before: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/listtransfers"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<ListTransfersResponse>()
+        .await
+        .unwrap()
+        .transfers
+}
+
+async fn list_transactions_by_txid(node_address: SocketAddr, txid: &str) -> Vec<Transaction> {
+    println!("listing transactions for txid {txid} on node {node_address}");
+    let payload = ListTransactionsRequest {
+        skip_sync: false,
+        index_offset: None,
+        max_transactions: None,
+        txid: Some(txid.to_string()),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/listtransactions"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<ListTransactionsResponse>()
+        .await
+        .unwrap()
+        .transactions
 }
 
 async fn list_unspents(node_address: SocketAddr) -> Vec<Unspent> {

--- a/src/test/pagination_filters.rs
+++ b/src/test/pagination_filters.rs
@@ -192,3 +192,120 @@ async fn transactions_pagination() {
     }
     assert_eq!(seen.len(), total);
 }
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn by_txid() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}by_txid/node1");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}by_txid/node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+
+    // two sends produce two distinct on-chain txids
+    for amount in [100u64, 50] {
+        let recipient_id = rgb_invoice(node2_addr, None, false).await.recipient_id;
+        send_asset(
+            node1_addr,
+            &asset_id,
+            Assignment::Fungible(amount),
+            recipient_id,
+            None,
+        )
+        .await;
+        mine(false);
+        refresh_transfers(node2_addr).await;
+        refresh_transfers(node1_addr).await;
+    }
+
+    // group the sender's transfers by their on-chain txid
+    let all = list_transfers(node1_addr, &asset_id).await;
+    let mut idx_by_txid: HashMap<String, Vec<i32>> = HashMap::new();
+    for t in &all {
+        if let Some(txid) = &t.txid {
+            idx_by_txid.entry(txid.clone()).or_default().push(t.idx);
+        }
+    }
+    assert!(
+        idx_by_txid.len() >= 2,
+        "expected at least two distinct txids, got {}",
+        idx_by_txid.len()
+    );
+
+    // for every distinct txid, by-txid returns exactly that txid's transfers (and
+    // nothing from the other txids); the BTC tx lookup returns only matching txs
+    let mut saw_btc_match = false;
+    for (txid, mut expected) in idx_by_txid.clone() {
+        expected.sort_unstable();
+        let mut got: Vec<i32> = list_transfers_by_txid(node1_addr, &txid)
+            .await
+            .iter()
+            .map(|t| t.idx)
+            .collect();
+        got.sort_unstable();
+        assert_eq!(got, expected, "transfers by txid {txid} mismatch");
+
+        let txs = list_transactions_by_txid(node1_addr, &txid).await;
+        assert!(txs.iter().all(|t| t.txid == txid));
+        if txs.len() == 1 {
+            saw_btc_match = true;
+        }
+    }
+    assert!(
+        saw_btc_match,
+        "expected at least one txid to resolve to exactly one wallet tx"
+    );
+
+    // receiver side: its receive transfers are reachable by the same txid
+    let rcv = list_transfers(node2_addr, &asset_id).await;
+    let rcv_txid = rcv
+        .iter()
+        .filter_map(|t| t.txid.clone())
+        .next()
+        .expect("receiver should have a transfer with a txid");
+    let rcv_by_txid = list_transfers_by_txid(node2_addr, &rcv_txid).await;
+    assert!(!rcv_by_txid.is_empty());
+    assert!(rcv_by_txid
+        .iter()
+        .all(|t| t.txid.as_deref() == Some(rcv_txid.as_str())));
+
+    // unknown txid yields empty results on both endpoints
+    let unknown = "0".repeat(64);
+    assert!(list_transfers_by_txid(node1_addr, &unknown)
+        .await
+        .is_empty());
+    assert!(list_transactions_by_txid(node1_addr, &unknown)
+        .await
+        .is_empty());
+
+    // neither asset_id nor txid is a bad request
+    let payload = ListTransfersRequest {
+        asset_id: None,
+        txid: None,
+        index_offset: None,
+        max_transfers: None,
+        status: None,
+        created_after: None,
+        created_before: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/listtransfers"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::BAD_REQUEST,
+        "either asset_id or txid",
+        "InvalidRequest",
+    )
+    .await;
+}

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -283,6 +283,62 @@ fn map_token(data: crate::sdk::Token) -> Token {
     }
 }
 
+fn map_transaction(tx: crate::sdk::TransactionData) -> Result<Transaction, RlnError> {
+    let txid = Txid::from_str(&tx.txid).map_err(|_| RlnError::Internal)?;
+    let transaction_type = match tx.transaction_type {
+        crate::sdk::TransactionType::RgbSend => TransactionType::RgbSend,
+        crate::sdk::TransactionType::Drain => TransactionType::Drain,
+        crate::sdk::TransactionType::CreateUtxos => TransactionType::CreateUtxos,
+        crate::sdk::TransactionType::SendBtc => TransactionType::SendBtc,
+        crate::sdk::TransactionType::Incoming => TransactionType::Incoming,
+    };
+    Ok(Transaction {
+        transaction_type,
+        txid,
+        received: tx.received,
+        sent: tx.sent,
+        fee: tx.fee,
+        confirmation_time: tx.confirmation_time.map(|ct| BlockTime {
+            height: ct.height,
+            timestamp: ct.timestamp,
+        }),
+    })
+}
+
+fn map_transfer(t: crate::sdk::TransferData) -> Result<Transfer, RlnError> {
+    let txid = t
+        .txid
+        .map(|v| Txid::from_str(&v).map_err(|_| RlnError::Internal))
+        .transpose()?;
+    Ok(Transfer {
+        idx: t.idx,
+        created_at: t.created_at,
+        updated_at: t.updated_at,
+        status: format!("{:?}", t.status),
+        requested_assignment: t.requested_assignment.map(|a| format!("{:?}", a)),
+        assignments: t
+            .assignments
+            .into_iter()
+            .map(|a| format!("{:?}", a))
+            .collect(),
+        kind: format!("{:?}", t.kind),
+        txid,
+        recipient_id: t.recipient_id,
+        receive_utxo: t.receive_utxo,
+        change_utxo: t.change_utxo,
+        expiration: t.expiration,
+        transport_endpoints: t
+            .transport_endpoints
+            .into_iter()
+            .map(|e| TransferTransportEndpoint {
+                endpoint: e.endpoint,
+                transport_type: format!("{:?}", e.transport_type),
+                used: e.used,
+            })
+            .collect(),
+    })
+}
+
 impl SdkNode {
     pub fn create(request: SdkInitRequest) -> Result<Self, RlnError> {
         let handle = handle_from_request(request)?;
@@ -947,29 +1003,17 @@ impl SdkNode {
     pub fn list_transactions(&self, skip_sync: bool) -> Result<Vec<Transaction>, RlnError> {
         let state = self.handle.app_state();
         let txs = block_on_sdk(sdk::list_transactions(state, skip_sync))?;
-        txs.into_iter()
-            .map(|tx| {
-                let txid = Txid::from_str(&tx.txid).map_err(|_| RlnError::Internal)?;
-                let transaction_type = match tx.transaction_type {
-                    crate::sdk::TransactionType::RgbSend => TransactionType::RgbSend,
-                    crate::sdk::TransactionType::Drain => TransactionType::Drain,
-                    crate::sdk::TransactionType::CreateUtxos => TransactionType::CreateUtxos,
-                    crate::sdk::TransactionType::SendBtc => TransactionType::SendBtc,
-                    crate::sdk::TransactionType::Incoming => TransactionType::Incoming,
-                };
-                Ok(Transaction {
-                    transaction_type,
-                    txid,
-                    received: tx.received,
-                    sent: tx.sent,
-                    fee: tx.fee,
-                    confirmation_time: tx.confirmation_time.map(|ct| BlockTime {
-                        height: ct.height,
-                        timestamp: ct.timestamp,
-                    }),
-                })
-            })
-            .collect()
+        txs.into_iter().map(map_transaction).collect()
+    }
+
+    pub fn list_transactions_by_txid(
+        &self,
+        txid: String,
+        skip_sync: bool,
+    ) -> Result<Vec<Transaction>, RlnError> {
+        let state = self.handle.app_state();
+        let txs = block_on_sdk(sdk::list_transactions_by_txid(state, txid, skip_sync))?;
+        txs.into_iter().map(map_transaction).collect()
     }
 
     pub fn network_info(&self) -> Result<NetworkInfo, RlnError> {
@@ -1270,41 +1314,13 @@ impl SdkNode {
     pub fn list_transfers(&self, asset_id: ContractId) -> Result<Vec<Transfer>, RlnError> {
         let state = self.handle.app_state();
         let resp = block_on_sdk(sdk::list_transfers(state, asset_id.to_string()))?;
-        resp.into_iter()
-            .map(|t| {
-                let txid = t
-                    .txid
-                    .map(|v| Txid::from_str(&v).map_err(|_| RlnError::Internal))
-                    .transpose()?;
-                Ok(Transfer {
-                    idx: t.idx,
-                    created_at: t.created_at,
-                    updated_at: t.updated_at,
-                    status: format!("{:?}", t.status),
-                    requested_assignment: t.requested_assignment.map(|a| format!("{:?}", a)),
-                    assignments: t
-                        .assignments
-                        .into_iter()
-                        .map(|a| format!("{:?}", a))
-                        .collect(),
-                    kind: format!("{:?}", t.kind),
-                    txid,
-                    recipient_id: t.recipient_id,
-                    receive_utxo: t.receive_utxo,
-                    change_utxo: t.change_utxo,
-                    expiration: t.expiration,
-                    transport_endpoints: t
-                        .transport_endpoints
-                        .into_iter()
-                        .map(|e| TransferTransportEndpoint {
-                            endpoint: e.endpoint,
-                            transport_type: format!("{:?}", e.transport_type),
-                            used: e.used,
-                        })
-                        .collect(),
-                })
-            })
-            .collect()
+        resp.into_iter().map(map_transfer).collect()
+    }
+
+    pub fn list_transfers_by_txid(&self, txid: String) -> Result<Vec<Transfer>, RlnError> {
+        let state = self.handle.app_state();
+        let resp = block_on_sdk(sdk::list_transfers_by_txid(state, txid))?;
+        resp.into_iter().map(map_transfer).collect()
     }
 
     pub fn list_unspents(&self, skip_sync: bool) -> Result<Vec<Unspent>, RlnError> {


### PR DESCRIPTION
Adds the ability to look up on-chain activity by transaction id. listtransfers now accepts an optional txid, returning the RGB transfers committed by that transaction across all assets, alongside the existing asset_id, and listtransactions accepts an optional txid to fetch a single BTC transaction. The capability is exposed through every layer: HTTP, the SDK, the UniFFI bindings, and the C-FFI bindings, with openapi.yaml updated to match.

Note: 
It relies on a small rgb-lib addition (list_transfers_by_txid), so until that lands upstream the dependency is temporarily patched to the fork branch: https://github.com/UTEXO-Protocol/rgb-lib/pull/53

Tests: 
- Covered by regtest end-to-end tests: querying by each distinct txid returns exactly that transaction's transfers, the receiver side resolves the same txid, an unknown txid returns empty, and a request with neither asset_id nor txid is rejected.