### PR TITLE
Feat: Asset Link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,7 +2790,7 @@ dependencies = [
  "lightning-types 0.3.1",
  "musig2",
  "possiblyrandom 0.2.0",
- "rgb-lib",
+ "rgb-lib 0.3.0-beta.6 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26)",
  "serde",
  "tokio",
 ]
@@ -2847,7 +2847,7 @@ dependencies = [
  "bech32 0.11.1",
  "bitcoin 0.32.101",
  "lightning-types 0.3.1",
- "rgb-lib",
+ "rgb-lib 0.3.0-beta.6 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26)",
  "serde",
 ]
 
@@ -4249,6 +4249,48 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26#117e8ca0411ebc8fd8e771f702daa0fa35ab66dd"
+dependencies = [
+ "amplify",
+ "base64 0.22.1",
+ "bdk_electrum",
+ "bdk_esplora",
+ "bdk_wallet",
+ "chacha20poly1305",
+ "file-format",
+ "generic-array",
+ "hex",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rgb-invoicing",
+ "rgb-lib-migration 0.3.0-beta.4 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26)",
+ "rgb-ops",
+ "rgb-psbt-utils",
+ "rgb-schemas",
+ "rgb-strict-encoding",
+ "rgb-strict-types",
+ "rustls 0.23.41",
+ "scrypt",
+ "sea-orm",
+ "sea-query",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-async",
+ "slog-term",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "typenum",
+ "url",
+ "walkdir",
+ "zip 8.6.0",
+]
+
+[[package]]
+name = "rgb-lib"
+version = "0.3.0-beta.6"
 source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27#d8dba807d5028635143ffc8098e1b59086b646a0"
 dependencies = [
  "amplify",
@@ -4264,7 +4306,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.13.4",
  "rgb-invoicing",
- "rgb-lib-migration",
+ "rgb-lib-migration 0.3.0-beta.4 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27)",
  "rgb-ops",
  "rgb-psbt-utils",
  "rgb-schemas",
@@ -4289,6 +4331,15 @@ dependencies = [
  "vss-client-ng",
  "walkdir",
  "zip 8.6.0",
+]
+
+[[package]]
+name = "rgb-lib-migration"
+version = "0.3.0-beta.4"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26#117e8ca0411ebc8fd8e771f702daa0fa35ab66dd"
+dependencies = [
+ "sea-orm-migration",
+ "tokio",
 ]
 
 [[package]]
@@ -4344,7 +4395,7 @@ dependencies = [
  "rcgen",
  "regex",
  "reqwest 0.12.28",
- "rgb-lib",
+ "rgb-lib 0.3.0-beta.6 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27)",
  "rgb-psbt-utils",
  "rln-migration",
  "rustls 0.23.41",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
  "amplify_num",
  "amplify_syn",
  "ascii",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "stringly_conversions",
  "wasm-bindgen",
@@ -95,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695e433882668b55b3d7fb0ba22bf9be66a91abe30d7ca1f1a774f8b90b4db4c"
 dependencies = [
  "amplify_num",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "wasm-bindgen",
 ]
 
@@ -177,7 +177,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -188,14 +188,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -214,9 +214,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "as-any"
@@ -256,7 +256,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -293,18 +293,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -330,9 +330,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -340,14 +340,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -541,7 +542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c290eff038799a8ac0c5a82b6160a9ca456baa299a6f22b262c771342d2846c0"
 dependencies = [
  "bdk_core",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "miniscript",
  "serde",
 ]
@@ -552,7 +553,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3028782f6bf14a6df987244333d34e6b272b5a40a53e4879ec2dfd82275a3a"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "hashbrown 0.14.5",
  "serde",
 ]
@@ -597,7 +598,7 @@ dependencies = [
  "bdk_chain",
  "bdk_file_store",
  "bip39",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "miniscript",
  "rand_core 0.6.4",
  "serde",
@@ -669,7 +670,7 @@ dependencies = [
  "pkcs8 0.9.0",
  "prost 0.10.4",
  "prost-types 0.10.1",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_core 0.6.4",
  "regex",
  "serde_json",
@@ -728,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.101"
+version = "0.32.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
+checksum = "bb0ce8bd5baaa0d303a19915a6d93afed161f528654e42da2a7a97d05c59499a"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
@@ -761,26 +762,25 @@ checksum = "0468a0cbe4fb594b40940e107694c4edfc316a9d83bbeeff14ba1acbdfd291c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bitcoin-consensus-encoding"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
 dependencies = [
  "bitcoin-internals",
+ "hex-conservative 1.2.0",
+ "serde",
 ]
 
 [[package]]
 name = "bitcoin-internals"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
-dependencies = [
- "hex-conservative 0.3.2",
-]
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin-io"
@@ -803,7 +803,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6386f1296021ac5d1a5ed9869595940fa7696dfe868198b1b71ec2c82db59343"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "hex",
  "log",
 ]
@@ -846,9 +846,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -859,11 +859,11 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
 dependencies = [
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "rustls-webpki 0.103.13",
  "tokio",
  "tokio-rustls",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -915,7 +915,7 @@ checksum = "a6836000a836c3fc91ad5db2c95552c556b8347a6f6782a8f77a00d3fd989122"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -947,15 +947,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1012,9 +1012,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1118,14 +1118,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1259,27 +1259,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1334,7 +1334,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1377,7 +1377,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1390,7 +1390,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1401,7 +1401,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1412,7 +1412,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1429,9 +1429,9 @@ checksum = "80a4af69c60438a1a82af89d362f4729fd38db7b73f305a237636fad31ceb2bf"
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -1439,15 +1439,14 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1456,7 +1455,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1467,7 +1466,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1507,7 +1506,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1528,7 +1527,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1603,7 +1602,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1683,11 +1682,11 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c7b1f8783238bb18e6e137875b0a66f3dffe6c7ea84066e05d033cf180b150f"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -1700,11 +1699,11 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5059f13888a90486e7268bbce59b175f5f76b1c55e5b9c568ceaa42d2b8507c"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -1786,7 +1785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1795,7 +1794,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f19e3ea99dbfbef0c1ec26d83e69de0c579f6aa6aaac4f44597805fcc27e97af"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "hex-conservative 0.2.2",
  "log",
  "minreq",
@@ -1833,9 +1832,9 @@ checksum = "a35a73237400bde66c82e38387343f90d7182a2f2f22729e096a2abd57d75db9"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -1951,9 +1950,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1966,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1976,15 +1975,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2004,38 +2003,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2093,9 +2092,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2250,6 +2251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2304,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2329,9 +2339,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2358,11 +2368,11 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2553,13 +2563,13 @@ dependencies = [
 
 [[package]]
 name = "inherent"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+checksum = "bee2c455ca60511a054699102d40ce7153621cb2429558f9eaa600e4499b5984"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -2586,7 +2596,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2621,11 +2631,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
 dependencies = [
  "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -2634,14 +2645,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.29"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2656,7 +2677,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -2671,7 +2692,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2690,16 +2711,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -2737,14 +2758,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.8.1",
+ "redox_syscall 0.9.0",
 ]
 
 [[package]]
@@ -2765,7 +2786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c560d6c22b76ee0375c4fafcadd84dac7fcd9748af4d6626556c32b1a9753a0c"
 dependencies = [
  "bech32 0.11.1",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
@@ -2780,7 +2801,7 @@ version = "0.2.2"
 dependencies = [
  "bech32 0.11.1",
  "bincode",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "dnssec-prover",
  "futures",
  "hashbrown 0.13.2",
@@ -2799,7 +2820,7 @@ dependencies = [
 name = "lightning-background-processor"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "bitcoin-io",
  "bitcoin_hashes 0.14.101",
  "lightning 0.2.2",
@@ -2812,7 +2833,7 @@ dependencies = [
 name = "lightning-block-sync"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "chunked_transfer",
  "lightning 0.2.2",
  "serde_json",
@@ -2836,7 +2857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39b494954ed8f1d774d86473224fadf9f0dfcca38c2d16a7dbdf2b5800c8943"
 dependencies = [
  "bech32 0.11.1",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "lightning-types 0.2.1",
 ]
 
@@ -2845,7 +2866,7 @@ name = "lightning-invoice"
 version = "0.34.0"
 dependencies = [
  "bech32 0.11.1",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "lightning-types 0.3.1",
  "rgb-lib 0.3.0-beta.6 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26)",
  "serde",
@@ -2855,7 +2876,7 @@ dependencies = [
 name = "lightning-liquidity"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "chrono",
  "lightning 0.2.2",
  "lightning-invoice 0.34.0",
@@ -2871,7 +2892,7 @@ version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2882,14 +2903,14 @@ checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "lightning-net-tokio"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "lightning 0.2.2",
  "tokio",
 ]
@@ -2898,7 +2919,7 @@ dependencies = [
 name = "lightning-persister"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "lightning 0.2.2",
  "tokio",
  "windows-sys 0.48.0",
@@ -2908,7 +2929,7 @@ dependencies = [
 name = "lightning-rapid-gossip-sync"
 version = "0.2.0"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "bitcoin-io",
  "bitcoin_hashes 0.14.101",
  "lightning 0.2.2",
@@ -2918,7 +2939,7 @@ dependencies = [
 name = "lightning-transaction-sync"
 version = "0.2.1"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "electrum-client 0.24.1",
  "esplora-client",
  "lightning 0.2.2",
@@ -2931,14 +2952,14 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16acfbf632be138618a255b353b1c4577f06cf85972aff1cf59f46554528751f"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
 ]
 
 [[package]]
 name = "lightning-types"
 version = "0.3.1"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
 ]
 
 [[package]]
@@ -3034,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -3076,7 +3097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8343cc1ef1408bd9bdbf69f7aef47017dfab7e6349ec26fddf62e0e9fb5a4cf"
 dependencies = [
  "bech32 0.11.1",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "serde",
 ]
 
@@ -3105,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -3148,7 +3169,7 @@ name = "musig2"
 version = "0.1.0"
 source = "git+https://github.com/arik-so/rust-musig2?rev=6f95a05718cbb44d8fe3fa6021aea8117aa38d50#6f95a05718cbb44d8fe3fa6021aea8117aa38d50"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
 ]
 
 [[package]]
@@ -3174,7 +3195,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3206,14 +3227,14 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3230,7 +3251,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -3252,11 +3273,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3304,7 +3324,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3320,7 +3340,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3387,7 +3407,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3577,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -3668,14 +3688,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3688,7 +3708,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -3781,7 +3801,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3815,9 +3835,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3825,21 +3845,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3847,23 +3868,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3882,9 +3903,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3893,9 +3914,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3903,9 +3924,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20 0.10.1",
  "getrandom 0.4.3",
@@ -3957,6 +3978,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3993,16 +4023,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4018,29 +4048,29 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4050,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4089,7 +4119,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4107,7 +4137,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -4138,7 +4168,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -4209,14 +4239,14 @@ dependencies = [
  "amplify",
  "baid64",
  "base85",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "chrono",
  "daggy",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "hex-conservative 0.2.2",
  "mime",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rgb-aluvm",
  "rgb-strict-encoding",
  "rgb-strict-types",
@@ -4239,7 +4269,7 @@ dependencies = [
  "fluent-uri",
  "indexmap",
  "percent-encoding",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rgb-consensus",
  "rgb-strict-encoding",
  "rgb-strict-types",
@@ -4291,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#98d40e07281cdfd37cfc84a56ddff9a38f5ce25d"
+source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#20d87dc4b5786137a8b296dcdd3d6a2d48948396"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4303,7 +4333,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest 0.13.4",
  "rgb-invoicing",
  "rgb-lib-migration 0.3.0-beta.4 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27)",
@@ -4312,7 +4342,7 @@ dependencies = [
  "rgb-schemas",
  "rgb-strict-encoding",
  "rgb-strict-types",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "scrypt",
  "sea-orm",
  "sea-query",
@@ -4323,7 +4353,7 @@ dependencies = [
  "slog-async",
  "slog-term",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "typenum",
@@ -4345,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#98d40e07281cdfd37cfc84a56ddff9a38f5ce25d"
+source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#20d87dc4b5786137a8b296dcdd3d6a2d48948396"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -4363,7 +4393,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "biscuit-auth",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "bitcoin-bech32",
  "chacha20 0.9.1",
  "chacha20poly1305",
@@ -4391,14 +4421,14 @@ dependencies = [
  "magic-crypt",
  "once_cell",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rcgen",
  "regex",
  "reqwest 0.12.28",
  "rgb-lib 0.3.0-beta.6 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27)",
  "rgb-psbt-utils",
  "rln-migration",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "rustls-pemfile",
  "scrypt",
  "sea-orm",
@@ -4407,7 +4437,7 @@ dependencies = [
  "serial_test",
  "signer-external",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tokio-rustls",
@@ -4446,7 +4476,7 @@ dependencies = [
  "getrandom 0.3.4",
  "indexmap",
  "nonasync",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rgb-aluvm",
  "rgb-ascii-armor",
  "rgb-consensus",
@@ -4492,7 +4522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cca0a8d70dd2d5b2a218ef7fd03e88b3ea69a926f3a9139c08c82d5f49fca236"
 dependencies = [
  "amplify",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "rgb-strict-encoding-derive",
  "serde",
  "wasm-bindgen",
@@ -4500,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-strict-encoding-derive"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8c0f56bb95ced46dbb953e982dd9b834c435b99563ee438855beb751e2132c"
+checksum = "33367536cfef03cb582cd9f8f25e193c2298d3ec3112eb59018a376b465f1ed9"
 dependencies = [
  "amplify_syn",
  "heck 0.5.0",
@@ -4595,15 +4625,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4620,7 +4650,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4633,11 +4663,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4654,9 +4684,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4691,9 +4721,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4710,14 +4740,14 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4750,9 +4780,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -4810,7 +4840,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4837,15 +4867,14 @@ dependencies = [
 
 [[package]]
 name = "sea-bae"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+checksum = "260bbc7148a8d6818ac5032a1b9970da1a68bdd723d45b12d59f7c1bf3565e24"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4872,7 +4901,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing",
  "url",
@@ -4908,7 +4937,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -4963,8 +4992,8 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
- "thiserror 2.0.18",
+ "syn 2.0.119",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4989,7 +5018,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5024,7 +5053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes 0.14.101",
- "rand 0.8.6",
+ "rand 0.8.7",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -5053,7 +5082,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5082,9 +5111,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -5096,7 +5125,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8db02c046447759ef62beeede660c4b7abae023a961bd5a8935aa7d4207edd1a"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "bitcoin-consensus-derive",
  "chunked-buffer",
  "hex",
@@ -5104,29 +5133,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -5203,7 +5232,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5251,14 +5280,14 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -5330,14 +5359,14 @@ version = "0.1.0-alpha"
 source = "git+https://github.com/UTEXO-Protocol/rln-external-signer.git?branch=main#0fb005ec4b927ddbe13e1646d247b5bb11e8ffed"
 dependencies = [
  "base64 0.22.1",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "chacha20 0.9.1",
  "chacha20poly1305",
  "hex",
  "poly1305",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "vls-core",
  "vls-protocol",
@@ -5347,9 +5376,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -5428,19 +5457,19 @@ checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -5501,12 +5530,12 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5524,7 +5553,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5547,7 +5576,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tokio",
  "url",
 ]
@@ -5560,7 +5589,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -5582,7 +5611,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "sha1",
@@ -5590,7 +5619,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "whoami",
 ]
@@ -5603,7 +5632,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "crc",
@@ -5621,14 +5650,14 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "whoami",
 ]
@@ -5653,7 +5682,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
 ]
@@ -5728,9 +5757,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5754,7 +5794,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5763,7 +5803,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5794,7 +5834,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5803,7 +5843,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5826,11 +5866,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -5841,25 +5881,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -5875,9 +5915,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5895,9 +5935,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5915,9 +5955,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5930,9 +5970,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5946,13 +5986,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5971,7 +6011,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.41",
+ "rustls 0.23.42",
  "tokio",
 ]
 
@@ -6083,7 +6123,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -6129,7 +6169,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing-subscriber",
 ]
@@ -6142,7 +6182,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6202,7 +6242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6223,7 +6263,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.8.7",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -6235,7 +6275,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a947ef834df674b09aa786d18133904e9b388b8e7b29eb565a505aa949078a"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "bytes",
  "log",
  "serde",
@@ -6348,7 +6388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6378,7 +6418,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.118",
+ "syn 2.0.119",
  "toml 0.5.11",
  "uniffi_meta",
 ]
@@ -6475,9 +6515,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6509,7 +6549,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7a66fafe84eddfc3e6bd6ea189211668500b726be9111e66261cf6a4332c25"
 dependencies = [
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "hex",
 ]
 
@@ -6521,7 +6561,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "backtrace",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "bitcoin-consensus-derive",
  "bitcoin-push-decoder",
  "bolt-derive",
@@ -6622,14 +6662,14 @@ source = "git+https://github.com/lightningdevkit/vss-client?rev=ad63805047561dcf
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "bitcoin 0.32.101",
+ "bitcoin 0.32.102",
  "bitcoin_hashes 0.14.101",
  "bitreq",
  "chacha20-poly1305",
  "log",
  "prost 0.11.9",
  "prost-build",
- "rand 0.8.6",
+ "rand 0.8.7",
  "tokio",
 ]
 
@@ -6716,7 +6756,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -6782,9 +6822,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6801,14 +6841,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6866,7 +6906,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6896,7 +6936,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6907,7 +6947,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6974,15 +7014,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -7014,28 +7045,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -7051,12 +7065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7067,12 +7075,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7087,22 +7089,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7117,12 +7107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7133,12 +7117,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7153,12 +7131,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7169,12 +7141,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -7231,28 +7197,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7272,7 +7238,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -7312,7 +7278,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7327,7 +7293,7 @@ dependencies = [
  "displaydoc",
  "indexmap",
  "memchr",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "zstd",
 ]
@@ -7347,9 +7313,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,9 +953,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -4269,7 +4269,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#684db9aeb862e4457bd3d246c055b0c57d67f071"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.31#4450094e6fe046a8ea68cded4f1813f6ec72d815"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4314,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#684db9aeb862e4457bd3d246c055b0c57d67f071"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.31#4450094e6fe046a8ea68cded4f1813f6ec72d815"
 dependencies = [
  "sea-orm-migration",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1118,14 +1118,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1157,15 +1157,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1669,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -1815,11 +1806,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2569,7 +2559,7 @@ checksum = "bee2c455ca60511a054699102d40ce7153621cb2429558f9eaa600e4499b5984"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2631,9 +2621,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -2655,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -2746,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.188"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -4063,7 +4053,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4279,7 +4269,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#20d87dc4b5786137a8b296dcdd3d6a2d48948396"
+source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#684db9aeb862e4457bd3d246c055b0c57d67f071"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4324,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#20d87dc4b5786137a8b296dcdd3d6a2d48948396"
+source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#684db9aeb862e4457bd3d246c055b0c57d67f071"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -4670,9 +4660,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5097,7 +5087,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5717,9 +5707,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5841,7 +5831,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5966,9 +5956,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,9 +2107,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "goblin"
@@ -2746,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
 
 [[package]]
 name = "libm"
@@ -2811,7 +2811,7 @@ dependencies = [
  "lightning-types 0.3.1",
  "musig2",
  "possiblyrandom 0.2.0",
- "rgb-lib 0.3.0-beta.6 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26)",
+ "rgb-lib",
  "serde",
  "tokio",
 ]
@@ -2868,7 +2868,7 @@ dependencies = [
  "bech32 0.11.1",
  "bitcoin 0.32.102",
  "lightning-types 0.3.1",
- "rgb-lib 0.3.0-beta.6 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26)",
+ "rgb-lib",
  "serde",
 ]
 
@@ -4279,48 +4279,6 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26#117e8ca0411ebc8fd8e771f702daa0fa35ab66dd"
-dependencies = [
- "amplify",
- "base64 0.22.1",
- "bdk_electrum",
- "bdk_esplora",
- "bdk_wallet",
- "chacha20poly1305",
- "file-format",
- "generic-array",
- "hex",
- "rand 0.10.1",
- "reqwest 0.13.4",
- "rgb-invoicing",
- "rgb-lib-migration 0.3.0-beta.4 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26)",
- "rgb-ops",
- "rgb-psbt-utils",
- "rgb-schemas",
- "rgb-strict-encoding",
- "rgb-strict-types",
- "rustls 0.23.41",
- "scrypt",
- "sea-orm",
- "sea-query",
- "serde",
- "serde_json",
- "slog",
- "slog-async",
- "slog-term",
- "tempfile",
- "thiserror 2.0.18",
- "time",
- "tokio",
- "typenum",
- "url",
- "walkdir",
- "zip 8.6.0",
-]
-
-[[package]]
-name = "rgb-lib"
-version = "0.3.0-beta.6"
 source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#20d87dc4b5786137a8b296dcdd3d6a2d48948396"
 dependencies = [
  "amplify",
@@ -4336,7 +4294,7 @@ dependencies = [
  "rand 0.10.2",
  "reqwest 0.13.4",
  "rgb-invoicing",
- "rgb-lib-migration 0.3.0-beta.4 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27)",
+ "rgb-lib-migration",
  "rgb-ops",
  "rgb-psbt-utils",
  "rgb-schemas",
@@ -4361,15 +4319,6 @@ dependencies = [
  "vss-client-ng",
  "walkdir",
  "zip 8.6.0",
-]
-
-[[package]]
-name = "rgb-lib-migration"
-version = "0.3.0-beta.4"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.26#117e8ca0411ebc8fd8e771f702daa0fa35ab66dd"
-dependencies = [
- "sea-orm-migration",
- "tokio",
 ]
 
 [[package]]
@@ -4425,7 +4374,7 @@ dependencies = [
  "rcgen",
  "regex",
  "reqwest 0.12.28",
- "rgb-lib 0.3.0-beta.6 (git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27)",
+ "rgb-lib",
  "rgb-psbt-utils",
  "rln-migration",
  "rustls 0.23.42",
@@ -6040,13 +5989,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27#d8dba807d5028635143ffc8098e1b59086b646a0"
+source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#98d40e07281cdfd37cfc84a56ddff9a38f5ce25d"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27#d8dba807d5028635143ffc8098e1b59086b646a0"
+source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#98d40e07281cdfd37cfc84a56ddff9a38f5ce25d"
 dependencies = [
  "sea-orm-migration",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ magic-crypt = "4.0.1"
 rand = "0.8.5"
 regex = { version = "1.11", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
-rgb-lib = { git = "https://github.com/txalkan/rgb-lib.git", branch = "feat/asset-link", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.31", features = [
     "electrum",
     "esplora",
 ] }
@@ -136,10 +136,6 @@ tracing-test = "0.2.5"
 
 [build-dependencies]
 uniffi = { version = "0.28.3", features = ["build"], optional = true }
-
-[patch."https://github.com/UTEXO-Protocol/rgb-lib.git"]
-rgb-lib = { git = "https://github.com/txalkan/rgb-lib.git", branch = "feat/asset-link" }
-rgb-lib-migration = { git = "https://github.com/txalkan/rgb-lib.git", branch = "feat/asset-link", package = "rgb-lib-migration" }
 
 [patch.crates-io]
 lightning = { path = "./rust-lightning/lightning" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ magic-crypt = "4.0.1"
 rand = "0.8.5"
 regex = { version = "1.11", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.27", features = [
+rgb-lib = { git = "https://github.com/txalkan/rgb-lib.git", branch = "feat/asset-link", features = [
     "electrum",
     "esplora",
 ] }
@@ -136,6 +136,10 @@ tracing-test = "0.2.5"
 
 [build-dependencies]
 uniffi = { version = "0.28.3", features = ["build"], optional = true }
+
+[patch."https://github.com/UTEXO-Protocol/rgb-lib.git"]
+rgb-lib = { git = "https://github.com/txalkan/rgb-lib.git", branch = "feat/asset-link" }
+rgb-lib-migration = { git = "https://github.com/txalkan/rgb-lib.git", branch = "feat/asset-link", package = "rgb-lib-migration" }
 
 [patch.crates-io]
 lightning = { path = "./rust-lightning/lightning" }

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The node currently exposes the following APIs:
 - `/apay/new` (POST)
 - `/apay/outboundinvoice` (POST)
 - `/assetbalance` (POST)
+- `/assetlink` (POST)
 - `/assetmetadata` (POST)
 - `/backup` (POST)
 - `/btcbalance` (POST)

--- a/bindings/c-ffi/Cargo.lock
+++ b/bindings/c-ffi/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
  "amplify_num",
  "amplify_syn",
  "ascii",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "stringly_conversions",
  "wasm-bindgen",
@@ -95,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695e433882668b55b3d7fb0ba22bf9be66a91abe30d7ca1f1a774f8b90b4db4c"
 dependencies = [
  "amplify_num",
- "bitflags",
+ "bitflags 2.13.1",
  "wasm-bindgen",
 ]
 
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "amplify_num"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bcb75a2982047f733547042fc3968c0f460dfcf7d90b90dea3b2744580e9ad"
+checksum = "afed304556696656d2d71495e1e5f2c4b524a3fb6eb0f2f3778ffc482a40b8a8"
 dependencies = [
  "serde",
  "wasm-bindgen",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -214,9 +214,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "as-any"
@@ -256,7 +256,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -293,18 +293,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -324,15 +324,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -340,14 +340,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -482,11 +483,10 @@ checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
 dependencies = [
- "bitcoin-internals",
  "bitcoin_hashes",
 ]
 
@@ -667,7 +667,7 @@ dependencies = [
  "pkcs8 0.9.0",
  "prost 0.10.4",
  "prost-types 0.10.1",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_core 0.6.4",
  "regex",
  "serde_json",
@@ -712,14 +712,13 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "bb0ce8bd5baaa0d303a19915a6d93afed161f528654e42da2a7a97d05c59499a"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32 0.11.1",
- "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
@@ -746,23 +745,34 @@ checksum = "0468a0cbe4fb594b40940e107694c4edfc316a9d83bbeeff14ba1acbdfd291c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
 dependencies = [
+ "bitcoin-internals",
+ "hex-conservative 1.2.0",
  "serde",
 ]
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.4"
+name = "bitcoin-internals"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin-push-decoder"
@@ -777,19 +787,19 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.2"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+checksum = "9cb95693f371d089a4b5b6fc41c6f3ea6e01ee8c15388335dfac8ea685173b51"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-consensus-encoding",
  "serde",
 ]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.2.2",
@@ -798,31 +808,37 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "bitreq"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df90cd78f0510165fd370574676aeb57dbec0ee3bfff68645bb7b0e9a65dbd5"
+checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
 dependencies = [
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "rustls-webpki 0.103.13",
  "tokio",
  "tokio-rustls",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -867,7 +883,7 @@ checksum = "a6836000a836c3fc91ad5db2c95552c556b8347a6f6782a8f77a00d3fd989122"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -875,6 +891,15 @@ name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bumpalo"
@@ -890,15 +915,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -949,28 +974,22 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -980,9 +999,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -997,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1027,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1064,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1074,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1086,14 +1105,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1125,15 +1144,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1203,18 +1213,18 @@ dependencies = [
 
 [[package]]
 name = "crc-any"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73"
+checksum = "46db9f663dfb869b80fcf59e32d7a80fc6c464a4f6328f3f06a00f5e36d05f8c"
 dependencies = [
  "debug-helper",
 ]
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1227,27 +1237,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1302,7 +1312,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1345,7 +1355,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1358,7 +1368,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1369,7 +1379,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1380,14 +1390,45 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "debug-helper"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
+checksum = "80a4af69c60438a1a82af89d362f4729fd38db7b73f305a237636fad31ceb2bf"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "delegate"
@@ -1397,7 +1438,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1426,7 +1467,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1438,7 +1478,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1459,7 +1499,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1516,13 +1556,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1589,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -1606,7 +1646,7 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -1623,7 +1663,7 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -1662,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1672,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1735,11 +1775,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1752,9 +1791,9 @@ checksum = "a35a73237400bde66c82e38387343f90d7182a2f2f22729e096a2abd57d75db9"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -1870,9 +1909,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1885,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1895,15 +1934,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1923,38 +1962,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2007,16 +2046,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2027,9 +2066,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "goblin"
@@ -2055,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2115,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2171,6 +2210,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2215,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -2225,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2250,9 +2298,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2279,7 +2327,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2433,12 +2481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,9 +2499,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2472,20 +2514,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "inherent"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+checksum = "bee2c455ca60511a054699102d40ce7153621cb2429558f9eaa600e4499b5984"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2503,16 +2545,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -2541,6 +2573,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,10 +2589,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -2560,39 +2603,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff-static"
-version = "0.2.24"
+name = "jiff-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
 dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.19",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2611,24 +2669,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2646,16 +2704,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -2669,10 +2721,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2688,18 +2740,18 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ffe63f56b10d214be1ade8698ee80af82d981237cae3e581e7a631f5f4959f3"
+checksum = "c560d6c22b76ee0375c4fafcadd84dac7fcd9748af4d6626556c32b1a9753a0c"
 dependencies = [
  "bech32 0.11.1",
  "bitcoin",
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
- "lightning-invoice 0.33.2",
- "lightning-types 0.2.0",
- "possiblyrandom 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lightning-invoice 0.33.3",
+ "lightning-types 0.2.1",
+ "possiblyrandom 0.2.1",
 ]
 
 [[package]]
@@ -2759,13 +2811,13 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
-version = "0.33.2"
+version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
+checksum = "b39b494954ed8f1d774d86473224fadf9f0dfcca38c2d16a7dbdf2b5800c8943"
 dependencies = [
  "bech32 0.11.1",
  "bitcoin",
- "lightning-types 0.2.0",
+ "lightning-types 0.2.1",
 ]
 
 [[package]]
@@ -2799,7 +2851,7 @@ version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2810,7 +2862,7 @@ checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2857,9 +2909,9 @@ dependencies = [
 
 [[package]]
 name = "lightning-types"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
+checksum = "16acfbf632be138618a255b353b1c4577f06cf85972aff1cf59f46554528751f"
 dependencies = [
  "bitcoin",
 ]
@@ -2900,9 +2952,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -2964,9 +3016,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -3001,9 +3053,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniscript"
-version = "12.3.6"
+version = "12.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c14116d8342edd3626b0f8e84df16f4e6a76dc04799ba747493403236a1b8ac5"
+checksum = "b8343cc1ef1408bd9bdbf69f7aef47017dfab7e6349ec26fddf62e0e9fb5a4cf"
 dependencies = [
  "bech32 0.11.1",
  "bitcoin",
@@ -3035,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -3104,7 +3156,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3141,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3160,16 +3212,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3182,11 +3234,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3230,15 +3281,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3251,7 +3301,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3262,18 +3312,18 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.6.0+3.6.2"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -3318,7 +3368,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3429,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "pgvector"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
 dependencies = [
  "serde",
 ]
@@ -3520,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "possiblyrandom"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
+checksum = "9c564dbf654befd49035528299f1208a40508f6e07efb11c163444e304e4484f"
 dependencies = [
  "getrandom 0.2.17",
 ]
@@ -3562,16 +3612,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3599,14 +3639,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3619,7 +3659,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -3662,12 +3702,12 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
  "petgraph 0.6.5",
- "prettyplease 0.1.25",
+ "prettyplease",
  "prost 0.11.9",
  "prost-types 0.11.9",
  "regex",
@@ -3683,7 +3723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3696,7 +3736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3709,10 +3749,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3736,9 +3776,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3746,9 +3786,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3756,21 +3796,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3778,23 +3819,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3813,9 +3854,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3824,9 +3865,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3834,12 +3875,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3888,6 +3929,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "redb"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3911,16 +3961,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3936,29 +3986,29 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3968,9 +4018,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3979,9 +4029,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -4021,9 +4071,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4047,7 +4097,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -4125,7 +4175,7 @@ dependencies = [
  "getrandom 0.3.4",
  "hex-conservative 0.2.2",
  "mime",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rgb-aluvm",
  "rgb-strict-encoding",
  "rgb-strict-types",
@@ -4148,7 +4198,7 @@ dependencies = [
  "fluent-uri",
  "indexmap",
  "percent-encoding",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rgb-consensus",
  "rgb-strict-encoding",
  "rgb-strict-types",
@@ -4158,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#20d87dc4b5786137a8b296dcdd3d6a2d48948396"
+source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#684db9aeb862e4457bd3d246c055b0c57d67f071"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4170,8 +4220,8 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "rand 0.10.1",
- "reqwest 0.13.2",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
  "rgb-invoicing",
  "rgb-lib-migration",
  "rgb-ops",
@@ -4179,7 +4229,7 @@ dependencies = [
  "rgb-schemas",
  "rgb-strict-encoding",
  "rgb-strict-types",
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "scrypt",
  "sea-orm",
  "sea-query",
@@ -4190,20 +4240,20 @@ dependencies = [
  "slog-async",
  "slog-term",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "typenum",
  "url",
  "vss-client-ng",
  "walkdir",
- "zip 8.5.1",
+ "zip 8.6.0",
 ]
 
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#20d87dc4b5786137a8b296dcdd3d6a2d48948396"
+source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#684db9aeb862e4457bd3d246c055b0c57d67f071"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -4245,20 +4295,20 @@ dependencies = [
  "lightning-transaction-sync",
  "magic-crypt",
  "prost 0.13.5",
- "rand 0.8.6",
+ "rand 0.8.7",
  "regex",
  "reqwest 0.12.28",
  "rgb-lib",
  "rgb-psbt-utils",
  "rln-migration",
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "scrypt",
  "sea-orm",
  "serde",
  "serde_json",
  "signer-external",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tokio-util",
@@ -4295,7 +4345,7 @@ dependencies = [
  "getrandom 0.3.4",
  "indexmap",
  "nonasync",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rgb-aluvm",
  "rgb-ascii-armor",
  "rgb-consensus",
@@ -4349,9 +4399,9 @@ dependencies = [
 
 [[package]]
 name = "rgb-strict-encoding-derive"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8c0f56bb95ced46dbb953e982dd9b834c435b99563ee438855beb751e2132c"
+checksum = "33367536cfef03cb582cd9f8f25e193c2298d3ec3112eb59018a376b465f1ed9"
 dependencies = [
  "amplify_syn",
  "heck 0.5.0",
@@ -4413,7 +4463,7 @@ dependencies = [
  "rgb-lightning-node",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4446,9 +4496,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -4458,15 +4508,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4483,11 +4533,11 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4496,7 +4546,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -4517,9 +4567,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4533,9 +4583,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -4545,9 +4595,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4555,16 +4605,16 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
@@ -4604,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -4664,7 +4714,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4691,15 +4741,14 @@ dependencies = [
 
 [[package]]
 name = "sea-bae"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+checksum = "260bbc7148a8d6818ac5032a1b9970da1a68bdd723d45b12d59f7c1bf3565e24"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4726,7 +4775,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing",
  "url",
@@ -4762,7 +4811,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -4817,8 +4866,8 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "thiserror 2.0.18",
+ "syn 2.0.119",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4843,7 +4892,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4868,7 +4917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.6",
+ "rand 0.8.7",
  "secp256k1-sys",
  "serde",
 ]
@@ -4888,7 +4937,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4917,9 +4966,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -4939,29 +4988,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -5024,11 +5073,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "serde_core",
@@ -5039,14 +5089,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5074,9 +5124,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -5118,9 +5168,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5155,13 +5205,29 @@ dependencies = [
  "poly1305",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "vls-core",
  "vls-protocol",
  "vls-protocol-client",
  "vls-protocol-signer",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5215,24 +5281,24 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5240,9 +5306,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -5303,12 +5369,12 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5326,7 +5392,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5349,7 +5415,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn 2.0.119",
  "tokio",
  "url",
 ]
@@ -5362,7 +5428,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -5384,7 +5450,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "sha1",
@@ -5392,7 +5458,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "whoami",
 ]
@@ -5405,7 +5471,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.13.1",
  "byteorder",
  "chrono",
  "crc",
@@ -5423,14 +5489,14 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "whoami",
 ]
@@ -5455,7 +5521,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "url",
 ]
@@ -5530,9 +5596,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5556,7 +5633,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5565,7 +5642,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5593,7 +5670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5628,11 +5705,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -5643,25 +5720,25 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -5677,12 +5754,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5692,15 +5768,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5718,9 +5794,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5733,9 +5809,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5749,13 +5825,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5774,15 +5850,15 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.39",
+ "rustls 0.23.42",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5791,13 +5867,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -5876,7 +5953,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5909,22 +5986,22 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5959,7 +6036,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing-subscriber",
 ]
@@ -5972,7 +6049,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6041,9 +6118,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -6139,7 +6216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6169,7 +6246,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn 2.0.119",
  "toml 0.5.11",
  "uniffi_meta",
 ]
@@ -6260,11 +6337,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -6313,9 +6390,9 @@ dependencies = [
  "env_logger",
  "hashbrown 0.13.2",
  "hex",
- "itertools",
- "lightning 0.1.8",
- "lightning-invoice 0.33.2",
+ "itertools 0.10.5",
+ "lightning 0.1.11",
+ "lightning-invoice 0.33.3",
  "log",
  "scopeguard",
  "serde",
@@ -6414,7 +6491,7 @@ dependencies = [
  "log",
  "prost 0.11.9",
  "prost-build",
- "rand 0.8.6",
+ "rand 0.8.7",
  "tokio",
 ]
 
@@ -6449,16 +6526,7 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6469,9 +6537,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6483,9 +6551,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6493,9 +6561,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6503,65 +6571,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6598,14 +6632,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6693,7 +6727,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6704,7 +6738,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6744,15 +6778,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -6771,11 +6796,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6785,21 +6810,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6826,35 +6836,12 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6869,18 +6856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6891,18 +6866,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6917,28 +6880,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6953,18 +6898,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6975,18 +6908,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7001,18 +6922,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7025,12 +6934,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7041,103 +6944,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap",
- "prettyplease 0.2.37",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease 0.2.37",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -7153,9 +6968,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7170,35 +6985,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -7211,15 +7026,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -7251,7 +7066,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7266,16 +7081,16 @@ dependencies = [
  "displaydoc",
  "indexmap",
  "memchr",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "zstd",
 ]
 
 [[package]]
 name = "zip"
-version = "8.5.1"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "indexmap",
@@ -7286,9 +7101,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/bindings/c-ffi/Cargo.lock
+++ b/bindings/c-ffi/Cargo.lock
@@ -3888,6 +3888,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "redb"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a0b35b8077c954324cc3504bea8d35e27a2f5d07c0ba41052a35d92f020f84"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4140,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27#d8dba807d5028635143ffc8098e1b59086b646a0"
+source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#20d87dc4b5786137a8b296dcdd3d6a2d48948396"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4185,7 +4203,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.27#d8dba807d5028635143ffc8098e1b59086b646a0"
+source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#20d87dc4b5786137a8b296dcdd3d6a2d48948396"
 dependencies = [
  "sea-orm-migration",
  "tokio",
@@ -4214,6 +4232,7 @@ dependencies = [
  "esplora-client",
  "futures",
  "hex-conservative 0.3.2",
+ "libc",
  "lightning 0.2.2",
  "lightning-background-processor",
  "lightning-block-sync",
@@ -4243,6 +4262,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
+ "toml 0.8.23",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -4251,6 +4271,7 @@ dependencies = [
  "uniffi",
  "uuid",
  "vls-core",
+ "vls-persist",
  "vls-protocol",
  "vls-protocol-client",
  "vls-protocol-signer",
@@ -5124,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "signer-external"
 version = "0.1.0-alpha"
-source = "git+https://github.com/UTEXO-Protocol/rln-external-signer.git?branch=main#594d8c08e812aa9d237a177391ea6f56b7c58e8f"
+source = "git+https://github.com/UTEXO-Protocol/rln-external-signer.git?branch=main#0fb005ec4b927ddbe13e1646d247b5bb11e8ffed"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",
@@ -6244,7 +6265,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
+ "js-sys",
  "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -6303,6 +6326,24 @@ dependencies = [
  "txoo",
  "vls-common",
  "vls-policy-derive",
+]
+
+[[package]]
+name = "vls-persist"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84526aaf721d6086c433aa838b9cb668740e8784d29d8b6a273745ef80dae8f6"
+dependencies = [
+ "hex",
+ "log",
+ "redb 1.5.2",
+ "redb 2.6.3",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tracing",
+ "uuid",
+ "vls-core",
 ]
 
 [[package]]

--- a/bindings/c-ffi/Cargo.lock
+++ b/bindings/c-ffi/Cargo.lock
@@ -4208,7 +4208,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.6"
-source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#684db9aeb862e4457bd3d246c055b0c57d67f071"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?rev=4450094e6fe046a8ea68cded4f1813f6ec72d815#4450094e6fe046a8ea68cded4f1813f6ec72d815"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.4"
-source = "git+https://github.com/txalkan/rgb-lib.git?branch=feat%2Fasset-link#684db9aeb862e4457bd3d246c055b0c57d67f071"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?rev=4450094e6fe046a8ea68cded4f1813f6ec72d815#4450094e6fe046a8ea68cded4f1813f6ec72d815"
 dependencies = [
  "sea-orm-migration",
  "tokio",

--- a/bindings/c-ffi/Cargo.toml
+++ b/bindings/c-ffi/Cargo.toml
@@ -57,3 +57,7 @@ lightning-persister = { path = "../../rust-lightning/lightning-persister" }
 lightning-rapid-gossip-sync = { path = "../../rust-lightning/lightning-rapid-gossip-sync" }
 vls-core = { git = "https://github.com/UTEXO-Protocol/vls-core.git", branch = "feat/rgb-compatibility" }
 vls-protocol-signer = { git = "https://github.com/UTEXO-Protocol/vls-protocol-signer.git", branch = "feat/rgb-compatibility" }
+
+[patch."https://github.com/UTEXO-Protocol/rgb-lib.git"]
+rgb-lib = { git = "https://github.com/txalkan/rgb-lib.git", branch = "feat/asset-link" }
+rgb-lib-migration = { git = "https://github.com/txalkan/rgb-lib.git", branch = "feat/asset-link", package = "rgb-lib-migration" }

--- a/bindings/c-ffi/Cargo.toml
+++ b/bindings/c-ffi/Cargo.toml
@@ -57,7 +57,3 @@ lightning-persister = { path = "../../rust-lightning/lightning-persister" }
 lightning-rapid-gossip-sync = { path = "../../rust-lightning/lightning-rapid-gossip-sync" }
 vls-core = { git = "https://github.com/UTEXO-Protocol/vls-core.git", branch = "feat/rgb-compatibility" }
 vls-protocol-signer = { git = "https://github.com/UTEXO-Protocol/vls-protocol-signer.git", branch = "feat/rgb-compatibility" }
-
-[patch."https://github.com/UTEXO-Protocol/rgb-lib.git"]
-rgb-lib = { git = "https://github.com/txalkan/rgb-lib.git", branch = "feat/asset-link" }
-rgb-lib-migration = { git = "https://github.com/txalkan/rgb-lib.git", branch = "feat/asset-link", package = "rgb-lib-migration" }

--- a/bindings/c-ffi/rln.h
+++ b/bindings/c-ffi/rln.h
@@ -37,6 +37,9 @@ struct CResultString rln_address(const struct COpaqueStruct *node);
 
 struct CResultString rln_asset_balance(const struct COpaqueStruct *node, const char *asset_id);
 
+struct CResultString rln_asset_link_create(const struct COpaqueStruct *node,
+                                           const char *request_json);
+
 struct CResultString rln_asset_metadata(const struct COpaqueStruct *node, const char *asset_id);
 
 struct CResultString rln_btc_balance(const struct COpaqueStruct *node, bool skip_sync);

--- a/bindings/c-ffi/rln.hpp
+++ b/bindings/c-ffi/rln.hpp
@@ -39,6 +39,8 @@ CResultString rln_address(const COpaqueStruct *node);
 
 CResultString rln_asset_balance(const COpaqueStruct *node, const char *asset_id);
 
+CResultString rln_asset_link_create(const COpaqueStruct *node, const char *request_json);
+
 CResultString rln_asset_metadata(const COpaqueStruct *node, const char *asset_id);
 
 CResultString rln_btc_balance(const COpaqueStruct *node, bool skip_sync);

--- a/bindings/c-ffi/src/api.rs
+++ b/bindings/c-ffi/src/api.rs
@@ -21,8 +21,7 @@ use crate::COpaqueStruct;
 // ---------------------------------------------------------------------------
 
 fn parse_bolt11(s: &str) -> Result<rln::Bolt11Invoice, Error> {
-    rln::Bolt11Invoice::from_str(s)
-        .map_err(|e| Error::StringParse(format!("invalid bolt11: {e}")))
+    rln::Bolt11Invoice::from_str(s).map_err(|e| Error::StringParse(format!("invalid bolt11: {e}")))
 }
 
 fn parse_payment_hash(s: &str) -> Result<rln::PaymentHash, Error> {
@@ -185,7 +184,12 @@ pub(crate) fn close_channel(
 pub(crate) fn list_channels(node: &COpaqueStruct) -> Result<String, Error> {
     let node = require_handle(node)?;
     let channels = node.list_channels()?;
-    json(channels.into_iter().map(JsonChannel::from).collect::<Vec<_>>())
+    json(
+        channels
+            .into_iter()
+            .map(JsonChannel::from)
+            .collect::<Vec<_>>(),
+    )
 }
 
 pub(crate) fn list_peers(node: &COpaqueStruct) -> Result<String, Error> {
@@ -199,7 +203,8 @@ pub(crate) fn get_channel_id(
     temporary_channel_id_hex: *const c_char,
 ) -> Result<String, Error> {
     let node = require_handle(node)?;
-    let temp = lightning::ln::types::ChannelId(parse_32_hex(&ptr_to_string(temporary_channel_id_hex))?);
+    let temp =
+        lightning::ln::types::ChannelId(parse_32_hex(&ptr_to_string(temporary_channel_id_hex))?);
     let result = node.get_channel_id(temp)?;
     json(JsonChannelIdResponse {
         channel_id: result.0.as_hex().to_string(),
@@ -220,10 +225,7 @@ pub(crate) fn send_payment(
     json(JsonSendPaymentResponse::from(resp))
 }
 
-pub(crate) fn keysend(
-    node: &COpaqueStruct,
-    request_json: *const c_char,
-) -> Result<String, Error> {
+pub(crate) fn keysend(node: &COpaqueStruct, request_json: *const c_char) -> Result<String, Error> {
     let node = require_handle(node)?;
     let req: JsonKeysendRequest = parse_req(request_json)?;
     let resp = node.keysend(req.try_into()?)?;
@@ -307,7 +309,12 @@ pub(crate) fn get_payment(
 pub(crate) fn list_payments(node: &COpaqueStruct) -> Result<String, Error> {
     let node = require_handle(node)?;
     let payments = node.list_payments()?;
-    json(payments.into_iter().map(JsonPayment::from).collect::<Vec<_>>())
+    json(
+        payments
+            .into_iter()
+            .map(JsonPayment::from)
+            .collect::<Vec<_>>(),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -324,10 +331,7 @@ pub(crate) fn rgb_invoice(
     json(JsonRgbInvoiceResponse::from(resp))
 }
 
-pub(crate) fn send_rgb(
-    node: &COpaqueStruct,
-    request_json: *const c_char,
-) -> Result<String, Error> {
+pub(crate) fn send_rgb(node: &COpaqueStruct, request_json: *const c_char) -> Result<String, Error> {
     let node = require_handle(node)?;
     let req: JsonSendRgbRequest = parse_req(request_json)?;
     let resp = node.send_rgb(req.try_into()?)?;
@@ -354,10 +358,7 @@ pub(crate) fn fail_transfers(
     json(JsonFailTransfersResponse::from(resp))
 }
 
-pub(crate) fn inflate(
-    node: &COpaqueStruct,
-    request_json: *const c_char,
-) -> Result<String, Error> {
+pub(crate) fn inflate(node: &COpaqueStruct, request_json: *const c_char) -> Result<String, Error> {
     let node = require_handle(node)?;
     let req: JsonInflateRequest = parse_req(request_json)?;
     let resp = node.inflate(req.try_into()?)?;
@@ -371,7 +372,12 @@ pub(crate) fn list_transfers(
     let node = require_handle(node)?;
     let asset_id = parse_contract_id(&ptr_to_string(asset_id))?;
     let transfers = node.list_transfers(asset_id)?;
-    json(transfers.into_iter().map(JsonTransfer::from).collect::<Vec<_>>())
+    json(
+        transfers
+            .into_iter()
+            .map(JsonTransfer::from)
+            .collect::<Vec<_>>(),
+    )
 }
 
 pub(crate) fn list_transfers_by_txid(
@@ -389,7 +395,12 @@ pub(crate) fn list_unspents(
 ) -> Result<String, Error> {
     let node = require_handle(node)?;
     let unspents = node.list_unspents(skip_sync)?;
-    json(unspents.into_iter().map(JsonUnspent::from).collect::<Vec<_>>())
+    json(
+        unspents
+            .into_iter()
+            .map(JsonUnspent::from)
+            .collect::<Vec<_>>(),
+    )
 }
 
 pub(crate) fn post_asset_media(
@@ -441,7 +452,7 @@ pub(crate) fn issue_asset_ifa(
 ) -> Result<String, Error> {
     let node = require_handle(node)?;
     let req: JsonIssueAssetIfaRequest = parse_req(request_json)?;
-    let asset = node.issueassetifa(req.into())?;
+    let asset = node.issueassetifa(req.try_into()?)?;
     json(JsonAssetIfa::from(asset))
 }
 
@@ -513,19 +524,13 @@ pub(crate) fn rotate_address(node: &COpaqueStruct) -> Result<String, Error> {
     json(JsonAddressInfo::from(resp))
 }
 
-pub(crate) fn btc_balance(
-    node: &COpaqueStruct,
-    skip_sync: bool,
-) -> Result<String, Error> {
+pub(crate) fn btc_balance(node: &COpaqueStruct, skip_sync: bool) -> Result<String, Error> {
     let node = require_handle(node)?;
     let resp = node.btc_balance(skip_sync)?;
     json(JsonBtcBalanceInfo::from(resp))
 }
 
-pub(crate) fn sign_message(
-    node: &COpaqueStruct,
-    message: *const c_char,
-) -> Result<String, Error> {
+pub(crate) fn sign_message(node: &COpaqueStruct, message: *const c_char) -> Result<String, Error> {
     let node = require_handle(node)?;
     let resp = node.sign_message(ptr_to_string(message))?;
     json(JsonSignMessageResponse::from(resp))
@@ -565,10 +570,7 @@ pub(crate) fn check_proxy_endpoint(
     ok_void()
 }
 
-pub(crate) fn send_btc(
-    node: &COpaqueStruct,
-    request_json: *const c_char,
-) -> Result<String, Error> {
+pub(crate) fn send_btc(node: &COpaqueStruct, request_json: *const c_char) -> Result<String, Error> {
     let node = require_handle(node)?;
     let req: JsonSendBtcRequest = parse_req(request_json)?;
     let resp = node.sendbtc(req.into())?;
@@ -585,13 +587,14 @@ pub(crate) fn create_utxos(
     ok_void()
 }
 
-pub(crate) fn list_transactions(
-    node: &COpaqueStruct,
-    skip_sync: bool,
-) -> Result<String, Error> {
+pub(crate) fn list_transactions(node: &COpaqueStruct, skip_sync: bool) -> Result<String, Error> {
     let node = require_handle(node)?;
     let txs = node.list_transactions(skip_sync)?;
-    json(txs.into_iter().map(JsonTransaction::from).collect::<Vec<_>>())
+    json(
+        txs.into_iter()
+            .map(JsonTransaction::from)
+            .collect::<Vec<_>>(),
+    )
 }
 
 pub(crate) fn list_transactions_by_txid(
@@ -634,10 +637,7 @@ pub(crate) fn maker_execute(
     ok_void()
 }
 
-pub(crate) fn taker(
-    node: &COpaqueStruct,
-    request_json: *const c_char,
-) -> Result<String, Error> {
+pub(crate) fn taker(node: &COpaqueStruct, request_json: *const c_char) -> Result<String, Error> {
     let node = require_handle(node)?;
     let req: JsonTakerRequest = parse_req(request_json)?;
     node.taker(req.into())?;
@@ -718,9 +718,7 @@ pub(crate) fn native_external_signer_new(
     )?)
 }
 
-pub(crate) fn native_external_signer_bootstrap(
-    signer: &COpaqueStruct,
-) -> Result<String, Error> {
+pub(crate) fn native_external_signer_bootstrap(signer: &COpaqueStruct) -> Result<String, Error> {
     let signer = require_signer(signer)?;
     let bootstrap = signer.bootstrap()?;
     json(JsonSdkExternalSignerBootstrap::from(bootstrap))
@@ -778,9 +776,7 @@ pub(crate) fn sdk_node_init_with_external_signer(
     ok_void()
 }
 
-pub(crate) fn sdk_node_detach_external_signer(
-    node: &COpaqueStruct,
-) -> Result<String, Error> {
+pub(crate) fn sdk_node_detach_external_signer(node: &COpaqueStruct) -> Result<String, Error> {
     let node = require_handle(node)?;
     node.detach_external_signer();
     ok_void()

--- a/bindings/c-ffi/src/api.rs
+++ b/bindings/c-ffi/src/api.rs
@@ -386,13 +386,15 @@ pub(crate) fn list_transfers_by_txid(
 ) -> Result<String, Error> {
     let node = require_handle(node)?;
     let transfers = node.list_transfers_by_txid(ptr_to_string(txid))?;
-    json(transfers.into_iter().map(JsonTransfer::from).collect::<Vec<_>>())
+    json(
+        transfers
+            .into_iter()
+            .map(JsonTransfer::from)
+            .collect::<Vec<_>>(),
+    )
 }
 
-pub(crate) fn list_unspents(
-    node: &COpaqueStruct,
-    skip_sync: bool,
-) -> Result<String, Error> {
+pub(crate) fn list_unspents(node: &COpaqueStruct, skip_sync: bool) -> Result<String, Error> {
     let node = require_handle(node)?;
     let unspents = node.list_unspents(skip_sync)?;
     json(
@@ -484,6 +486,16 @@ pub(crate) fn asset_balance(
     let asset_id = parse_contract_id(&ptr_to_string(asset_id))?;
     let resp = node.asset_balance(asset_id)?;
     json(JsonAssetBalanceInfo::from(resp))
+}
+
+pub(crate) fn asset_link_create(
+    node: &COpaqueStruct,
+    request_json: *const c_char,
+) -> Result<String, Error> {
+    let node = require_handle(node)?;
+    let req: JsonAssetLinkRequest = parse_req(request_json)?;
+    let asset_link = node.asset_link(req.try_into()?)?;
+    json(JsonAssetLinkRecord::from(asset_link))
 }
 
 pub(crate) fn asset_metadata(
@@ -604,7 +616,11 @@ pub(crate) fn list_transactions_by_txid(
 ) -> Result<String, Error> {
     let node = require_handle(node)?;
     let txs = node.list_transactions_by_txid(ptr_to_string(txid), skip_sync)?;
-    json(txs.into_iter().map(JsonTransaction::from).collect::<Vec<_>>())
+    json(
+        txs.into_iter()
+            .map(JsonTransaction::from)
+            .collect::<Vec<_>>(),
+    )
 }
 
 pub(crate) fn sync(node: &COpaqueStruct) -> Result<String, Error> {

--- a/bindings/c-ffi/src/json_types.rs
+++ b/bindings/c-ffi/src/json_types.rs
@@ -789,6 +789,7 @@ impl From<DecodeLnInvoiceResponse> for JsonDecodeLnInvoiceResponse {
 #[derive(Debug, Serialize)]
 pub(crate) struct JsonDecodeRgbInvoiceResponse {
     pub recipient_id: String,
+    pub proxy_recipient_id: String,
     pub recipient_type: String,
     pub asset_schema: Option<String>,
     pub asset_id: Option<String>,
@@ -802,6 +803,7 @@ impl From<DecodeRgbInvoiceResponse> for JsonDecodeRgbInvoiceResponse {
     fn from(r: DecodeRgbInvoiceResponse) -> Self {
         JsonDecodeRgbInvoiceResponse {
             recipient_id: r.recipient_id,
+            proxy_recipient_id: r.proxy_recipient_id,
             recipient_type: r.recipient_type,
             asset_schema: r.asset_schema,
             asset_id: r.asset_id.as_ref().map(fmt_contract_id),
@@ -1063,7 +1065,6 @@ impl From<InflateResponse> for JsonInflateResponse {
 pub(crate) struct JsonAssetLinkRequest {
     pub parent_asset_id: String,
     pub child_asset_id: String,
-    pub fee_rate: u64,
     pub min_confirmations: u8,
 }
 
@@ -1074,7 +1075,6 @@ impl TryFrom<JsonAssetLinkRequest> for SdkAssetLinkRequest {
         Ok(Self {
             parent_asset_id: parse_contract_id(&j.parent_asset_id)?,
             child_asset_id: parse_contract_id(&j.child_asset_id)?,
-            fee_rate: j.fee_rate,
             min_confirmations: j.min_confirmations,
         })
     }
@@ -1435,7 +1435,7 @@ pub(crate) struct JsonAssetIfa {
     pub balance: JsonAssetBalanceInfo,
     pub media: Option<JsonMedia>,
     pub reject_list_url: Option<String>,
-    pub link_right_outpoint: Option<JsonRgbOutpoint>,
+    pub issuance_link_right_outpoint: Option<JsonRgbOutpoint>,
     pub linked_from_asset_id: Option<String>,
     pub linked_to_asset_id: Option<String>,
 }
@@ -1471,7 +1471,7 @@ impl From<AssetIfa> for JsonAssetIfa {
             balance: a.balance.into(),
             media: a.media.map(Into::into),
             reject_list_url: a.reject_list_url,
-            link_right_outpoint: a.link_right_outpoint.map(Into::into),
+            issuance_link_right_outpoint: a.issuance_link_right_outpoint.map(Into::into),
             linked_from_asset_id: a.linked_from_asset_id,
             linked_to_asset_id: a.linked_to_asset_id,
         }
@@ -1538,6 +1538,7 @@ pub(crate) struct JsonAssetMetadataInfo {
     pub ticker: Option<String>,
     pub details: Option<String>,
     pub token: Option<JsonToken>,
+    pub unspent_link_right_outpoint: Option<JsonRgbOutpoint>,
     pub linked_from_asset_id: Option<String>,
     pub linked_to_asset_id: Option<String>,
 }
@@ -1555,6 +1556,7 @@ impl From<AssetMetadataInfo> for JsonAssetMetadataInfo {
             ticker: a.ticker,
             details: a.details,
             token: a.token.map(Into::into),
+            unspent_link_right_outpoint: a.unspent_link_right_outpoint.map(Into::into),
             linked_from_asset_id: a.linked_from_asset_id,
             linked_to_asset_id: a.linked_to_asset_id,
         }
@@ -1885,6 +1887,7 @@ pub(crate) struct JsonTransfer {
     pub kind: String,
     pub txid: Option<String>,
     pub recipient_id: Option<String>,
+    pub proxy_recipient_id: Option<String>,
     pub receive_utxo: Option<String>,
     pub change_utxo: Option<String>,
     pub expiration: Option<i64>,
@@ -1903,6 +1906,7 @@ impl From<Transfer> for JsonTransfer {
             kind: t.kind,
             txid: t.txid.as_ref().map(fmt_txid),
             recipient_id: t.recipient_id,
+            proxy_recipient_id: t.proxy_recipient_id,
             receive_utxo: t.receive_utxo,
             change_utxo: t.change_utxo,
             expiration: t.expiration,

--- a/bindings/c-ffi/src/json_types.rs
+++ b/bindings/c-ffi/src/json_types.rs
@@ -14,26 +14,27 @@ use std::str::FromStr;
 use hex::DisplayHex;
 use hex::FromHex;
 use rgb_lightning_node::{
-    AddressInfo, AssetBalanceInfo, AssetCfa, AssetIfa, AssetMediaResponse, AssetMetadataInfo,
-    AssetNia, AssetRecipients, AssetUda, AssignmentKind, BlockTime, BtcBalance, BtcBalanceInfo,
-    CancelHodlInvoiceRequest, Channel, ChannelId, ChannelStatus, CheckIndexerUrlResponse,
-    ClaimHodlInvoiceRequest, ClaimHodlInvoiceResponse, ContractId, DecodeLnInvoiceResponse,
-    DecodeRgbInvoiceResponse, EmbeddedMedia, EstimateFeeResponse, HtlcStatus, IfaIssuanceType,
-    InflateRequest, InflateResponse, InvoiceStatus, ListAssetsResponse, LnInvoiceRequest,
-    LnInvoiceResponse, Media, MediaAttachment, NetworkInfo, NodeInfo, Payment, PaymentHash,
-    PaymentType, Peer, ProofOfReserves, PublicKey, RecipientId, RgbAllocation, RgbOutpoint,
-    RgbRecipient, SdkCloseChannelRequest, SdkCreateUtxosRequest, SdkDisconnectPeerRequest,
-    SdkExternalSignerBootstrap, SdkFailTransfersRequest, SdkFailTransfersResponse, SdkInitRequest,
-    SdkIssueAssetCfaRequest, SdkIssueAssetIfaRequest, SdkIssueAssetNiaRequest,
-    SdkIssueAssetUdaRequest, SdkKeysendRequest, SdkKeysendResponse, SdkMakerExecuteRequest,
-    SdkMakerInitRequest, SdkMakerInitResponse, SdkOpenChannelRequest, SdkOpenChannelResponse,
-    SdkPostAssetMediaRequest, SdkPostAssetMediaResponse, SdkRefreshTransfersRequest,
-    SdkRgbInvoiceRequest, SdkRgbInvoiceResponse, SdkSendBtcRequest, SdkSendBtcResponse,
-    SdkSendOnionMessageRequest, SdkSendPaymentRequest, SdkSendPaymentResponse, SdkTakerRequest,
-    SdkUnlockRequest, SdkVssClearFenceRequest, SendRgbRequest, SendRgbResponse,
-    SignMessageResponse, Swap, SwapList, SwapStatus, Token, TokenLight, Transaction,
-    TransactionType, Transfer, TransferTransportEndpoint, TransportEndpoint, Txid, Unspent, Utxo,
-    VerifyMessageResponse, WitnessData,
+    AddressInfo, AssetBalanceInfo, AssetCfa, AssetIfa, AssetLinkRecord, AssetMediaResponse,
+    AssetMetadataInfo, AssetNia, AssetRecipients, AssetUda, AssignmentKind, BlockTime, BtcBalance,
+    BtcBalanceInfo, CancelHodlInvoiceRequest, Channel, ChannelId, ChannelStatus,
+    CheckIndexerUrlResponse, ClaimHodlInvoiceRequest, ClaimHodlInvoiceResponse, ContractId,
+    DecodeLnInvoiceResponse, DecodeRgbInvoiceResponse, EmbeddedMedia, EstimateFeeResponse,
+    HtlcStatus, IfaIssuanceType, InflateRequest, InflateResponse, InvoiceStatus,
+    ListAssetsResponse, LnInvoiceRequest, LnInvoiceResponse, Media, MediaAttachment, NetworkInfo,
+    NodeInfo, Payment, PaymentHash, PaymentType, Peer, ProofOfReserves, PublicKey, RecipientId,
+    RgbAllocation, RgbOutpoint, RgbRecipient, SdkAssetLinkRequest, SdkCloseChannelRequest,
+    SdkCreateUtxosRequest, SdkDisconnectPeerRequest, SdkExternalSignerBootstrap,
+    SdkFailTransfersRequest, SdkFailTransfersResponse, SdkInitRequest, SdkIssueAssetCfaRequest,
+    SdkIssueAssetIfaRequest, SdkIssueAssetNiaRequest, SdkIssueAssetUdaRequest, SdkKeysendRequest,
+    SdkKeysendResponse, SdkMakerExecuteRequest, SdkMakerInitRequest, SdkMakerInitResponse,
+    SdkOpenChannelRequest, SdkOpenChannelResponse, SdkPostAssetMediaRequest,
+    SdkPostAssetMediaResponse, SdkRefreshTransfersRequest, SdkRgbInvoiceRequest,
+    SdkRgbInvoiceResponse, SdkSendBtcRequest, SdkSendBtcResponse, SdkSendOnionMessageRequest,
+    SdkSendPaymentRequest, SdkSendPaymentResponse, SdkTakerRequest, SdkUnlockRequest,
+    SdkVssClearFenceRequest, SendRgbRequest, SendRgbResponse, SignMessageResponse, Swap, SwapList,
+    SwapStatus, Token, TokenLight, Transaction, TransactionType, Transfer,
+    TransferTransportEndpoint, TransportEndpoint, Txid, Unspent, Utxo, VerifyMessageResponse,
+    WitnessData,
 };
 use serde::{Deserialize, Serialize};
 
@@ -1055,8 +1056,48 @@ impl From<InflateResponse> for JsonInflateResponse {
 }
 
 // ---------------------------------------------------------------------------
-// Asset issuance
+// Asset issuance and contract linking
 // ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct JsonAssetLinkRequest {
+    pub parent_asset_id: String,
+    pub child_asset_id: String,
+    pub fee_rate: u64,
+    pub min_confirmations: u8,
+}
+
+impl TryFrom<JsonAssetLinkRequest> for SdkAssetLinkRequest {
+    type Error = Error;
+
+    fn try_from(j: JsonAssetLinkRequest) -> Result<Self, Self::Error> {
+        Ok(Self {
+            parent_asset_id: parse_contract_id(&j.parent_asset_id)?,
+            child_asset_id: parse_contract_id(&j.child_asset_id)?,
+            fee_rate: j.fee_rate,
+            min_confirmations: j.min_confirmations,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct JsonAssetLinkRecord {
+    pub parent_asset_id: String,
+    pub child_asset_id: Option<String>,
+    pub created_at: Option<u64>,
+    pub txid: Option<String>,
+}
+
+impl From<AssetLinkRecord> for JsonAssetLinkRecord {
+    fn from(link: AssetLinkRecord) -> Self {
+        Self {
+            parent_asset_id: fmt_contract_id(&link.parent_asset_id),
+            child_asset_id: link.child_asset_id.map(|id| fmt_contract_id(&id)),
+            created_at: link.created_at,
+            txid: link.txid.map(|txid| fmt_txid(&txid)),
+        }
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct JsonIssueAssetNiaRequest {

--- a/bindings/c-ffi/src/json_types.rs
+++ b/bindings/c-ffi/src/json_types.rs
@@ -1395,6 +1395,8 @@ pub(crate) struct JsonAssetIfa {
     pub media: Option<JsonMedia>,
     pub reject_list_url: Option<String>,
     pub link_right_outpoint: Option<JsonRgbOutpoint>,
+    pub linked_from_asset_id: Option<String>,
+    pub linked_to_asset_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1429,6 +1431,8 @@ impl From<AssetIfa> for JsonAssetIfa {
             media: a.media.map(Into::into),
             reject_list_url: a.reject_list_url,
             link_right_outpoint: a.link_right_outpoint.map(Into::into),
+            linked_from_asset_id: a.linked_from_asset_id,
+            linked_to_asset_id: a.linked_to_asset_id,
         }
     }
 }
@@ -1493,6 +1497,8 @@ pub(crate) struct JsonAssetMetadataInfo {
     pub ticker: Option<String>,
     pub details: Option<String>,
     pub token: Option<JsonToken>,
+    pub linked_from_asset_id: Option<String>,
+    pub linked_to_asset_id: Option<String>,
 }
 
 impl From<AssetMetadataInfo> for JsonAssetMetadataInfo {
@@ -1508,6 +1514,8 @@ impl From<AssetMetadataInfo> for JsonAssetMetadataInfo {
             ticker: a.ticker,
             details: a.details,
             token: a.token.map(Into::into),
+            linked_from_asset_id: a.linked_from_asset_id,
+            linked_to_asset_id: a.linked_to_asset_id,
         }
     }
 }

--- a/bindings/c-ffi/src/json_types.rs
+++ b/bindings/c-ffi/src/json_types.rs
@@ -15,22 +15,22 @@ use hex::DisplayHex;
 use hex::FromHex;
 use rgb_lightning_node::{
     AddressInfo, AssetBalanceInfo, AssetCfa, AssetIfa, AssetMediaResponse, AssetMetadataInfo,
-    AssetNia, AssetUda, AssignmentKind, BlockTime, BtcBalance, BtcBalanceInfo,
+    AssetNia, AssetRecipients, AssetUda, AssignmentKind, BlockTime, BtcBalance, BtcBalanceInfo,
     CancelHodlInvoiceRequest, Channel, ChannelId, ChannelStatus, CheckIndexerUrlResponse,
     ClaimHodlInvoiceRequest, ClaimHodlInvoiceResponse, ContractId, DecodeLnInvoiceResponse,
-    DecodeRgbInvoiceResponse, EmbeddedMedia, EstimateFeeResponse, HtlcStatus, InflateRequest,
-    InflateResponse, InvoiceStatus, ListAssetsResponse, LnInvoiceRequest, LnInvoiceResponse, Media,
-    MediaAttachment, NetworkInfo, NodeInfo, Payment, PaymentHash, PaymentType, Peer, ProofOfReserves,
-    PublicKey, RecipientId, RgbAllocation, SdkCloseChannelRequest, SdkCreateUtxosRequest,
-    SdkDisconnectPeerRequest, SdkFailTransfersRequest, SdkFailTransfersResponse, SdkInitRequest,
+    DecodeRgbInvoiceResponse, EmbeddedMedia, EstimateFeeResponse, HtlcStatus, IfaIssuanceType,
+    InflateRequest, InflateResponse, InvoiceStatus, ListAssetsResponse, LnInvoiceRequest,
+    LnInvoiceResponse, Media, MediaAttachment, NetworkInfo, NodeInfo, Payment, PaymentHash,
+    PaymentType, Peer, ProofOfReserves, PublicKey, RecipientId, RgbAllocation, RgbOutpoint,
+    RgbRecipient, SdkCloseChannelRequest, SdkCreateUtxosRequest, SdkDisconnectPeerRequest,
+    SdkExternalSignerBootstrap, SdkFailTransfersRequest, SdkFailTransfersResponse, SdkInitRequest,
     SdkIssueAssetCfaRequest, SdkIssueAssetIfaRequest, SdkIssueAssetNiaRequest,
     SdkIssueAssetUdaRequest, SdkKeysendRequest, SdkKeysendResponse, SdkMakerExecuteRequest,
     SdkMakerInitRequest, SdkMakerInitResponse, SdkOpenChannelRequest, SdkOpenChannelResponse,
     SdkPostAssetMediaRequest, SdkPostAssetMediaResponse, SdkRefreshTransfersRequest,
     SdkRgbInvoiceRequest, SdkRgbInvoiceResponse, SdkSendBtcRequest, SdkSendBtcResponse,
-    SdkExternalSignerBootstrap, SdkSendOnionMessageRequest, SdkSendPaymentRequest,
-    SdkSendPaymentResponse, SdkTakerRequest, SdkUnlockRequest, SdkVssClearFenceRequest, SendRgbRequest, SendRgbResponse,
-    AssetRecipients, RgbRecipient,
+    SdkSendOnionMessageRequest, SdkSendPaymentRequest, SdkSendPaymentResponse, SdkTakerRequest,
+    SdkUnlockRequest, SdkVssClearFenceRequest, SendRgbRequest, SendRgbResponse,
     SignMessageResponse, Swap, SwapList, SwapStatus, Token, TokenLight, Transaction,
     TransactionType, Transfer, TransferTransportEndpoint, TransportEndpoint, Txid, Unspent, Utxo,
     VerifyMessageResponse, WitnessData,
@@ -142,7 +142,11 @@ impl TryFrom<JsonSdkInitRequest> for SdkInitRequest {
     fn try_from(j: JsonSdkInitRequest) -> Result<Self, Self::Error> {
         let virtual_peer_pubkeys = j
             .virtual_peer_pubkeys
-            .map(|v| v.iter().map(|s| parse_pubkey(s)).collect::<Result<Vec<_>, _>>())
+            .map(|v| {
+                v.iter()
+                    .map(|s| parse_pubkey(s))
+                    .collect::<Result<Vec<_>, _>>()
+            })
             .transpose()?;
         Ok(SdkInitRequest {
             storage_dir_path: j.storage_dir_path,
@@ -1105,18 +1109,50 @@ pub(crate) struct JsonIssueAssetIfaRequest {
     pub precision: u8,
     #[serde(default)]
     pub reject_list_url: Option<String>,
+    #[serde(default)]
+    pub issuance_type: Option<JsonIfaIssuanceType>,
 }
 
-impl From<JsonIssueAssetIfaRequest> for SdkIssueAssetIfaRequest {
-    fn from(j: JsonIssueAssetIfaRequest) -> Self {
-        SdkIssueAssetIfaRequest {
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum JsonIfaIssuanceType {
+    Legacy,
+    LinkRightOnly,
+    LinkedFromParent {
+        contract_id: String,
+        #[serde(default)]
+        request_link_right: bool,
+    },
+}
+
+impl TryFrom<JsonIssueAssetIfaRequest> for SdkIssueAssetIfaRequest {
+    type Error = Error;
+
+    fn try_from(j: JsonIssueAssetIfaRequest) -> Result<Self, Self::Error> {
+        Ok(SdkIssueAssetIfaRequest {
             amounts: j.amounts,
             inflation_amounts: j.inflation_amounts,
             ticker: j.ticker,
             name: j.name,
             precision: j.precision,
             reject_list_url: j.reject_list_url,
-        }
+            issuance_type: j
+                .issuance_type
+                .map(|issuance_type| -> Result<IfaIssuanceType, Error> {
+                    match issuance_type {
+                        JsonIfaIssuanceType::Legacy => Ok(IfaIssuanceType::Legacy),
+                        JsonIfaIssuanceType::LinkRightOnly => Ok(IfaIssuanceType::LinkRightOnly),
+                        JsonIfaIssuanceType::LinkedFromParent {
+                            contract_id,
+                            request_link_right,
+                        } => Ok(IfaIssuanceType::LinkedFromParent {
+                            contract_id: parse_contract_id(&contract_id)?,
+                            request_link_right,
+                        }),
+                    }
+                })
+                .transpose()?,
+        })
     }
 }
 
@@ -1358,6 +1394,22 @@ pub(crate) struct JsonAssetIfa {
     pub balance: JsonAssetBalanceInfo,
     pub media: Option<JsonMedia>,
     pub reject_list_url: Option<String>,
+    pub link_right_outpoint: Option<JsonRgbOutpoint>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct JsonRgbOutpoint {
+    pub txid: String,
+    pub vout: u32,
+}
+
+impl From<RgbOutpoint> for JsonRgbOutpoint {
+    fn from(outpoint: RgbOutpoint) -> Self {
+        Self {
+            txid: outpoint.txid,
+            vout: outpoint.vout,
+        }
+    }
 }
 
 impl From<AssetIfa> for JsonAssetIfa {
@@ -1376,6 +1428,7 @@ impl From<AssetIfa> for JsonAssetIfa {
             balance: a.balance.into(),
             media: a.media.map(Into::into),
             reject_list_url: a.reject_list_url,
+            link_right_outpoint: a.link_right_outpoint.map(Into::into),
         }
     }
 }

--- a/bindings/c-ffi/src/lib.rs
+++ b/bindings/c-ffi/src/lib.rs
@@ -100,7 +100,10 @@ pub extern "C" fn rln_sdk_node_init(
     password: *const c_char,
     mnemonic_opt: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_sdk_node_init", api::sdk_node_init(node, password, mnemonic_opt))
+    ffi_call!(
+        "rln_sdk_node_init",
+        api::sdk_node_init(node, password, mnemonic_opt)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -108,7 +111,10 @@ pub extern "C" fn rln_sdk_node_unlock(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_sdk_node_unlock", api::sdk_node_unlock(node, request_json))
+    ffi_call!(
+        "rln_sdk_node_unlock",
+        api::sdk_node_unlock(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -126,7 +132,10 @@ pub extern "C" fn rln_sdk_node_vss_clear_fence(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_sdk_node_vss_clear_fence", api::sdk_node_vss_clear_fence(node, request_json))
+    ffi_call!(
+        "rln_sdk_node_vss_clear_fence",
+        api::sdk_node_vss_clear_fence(node, request_json)
+    )
 }
 
 /// Force an immediate VSS backup flush. Returns `{"version": i64}` JSON
@@ -153,7 +162,10 @@ pub extern "C" fn rln_sdk_node_apay_new(
     node: &COpaqueStruct,
     host_node_id: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_sdk_node_apay_new", api::sdk_node_apay_new(node, host_node_id))
+    ffi_call!(
+        "rln_sdk_node_apay_new",
+        api::sdk_node_apay_new(node, host_node_id)
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -165,7 +177,10 @@ pub extern "C" fn rln_connect_peer(
     node: &COpaqueStruct,
     peer_pubkey_and_addr: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_connect_peer", api::connect_peer(node, peer_pubkey_and_addr))
+    ffi_call!(
+        "rln_connect_peer",
+        api::connect_peer(node, peer_pubkey_and_addr)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -173,7 +188,10 @@ pub extern "C" fn rln_disconnect_peer(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_disconnect_peer", api::disconnect_peer(node, request_json))
+    ffi_call!(
+        "rln_disconnect_peer",
+        api::disconnect_peer(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -207,7 +225,10 @@ pub extern "C" fn rln_get_channel_id(
     node: &COpaqueStruct,
     temporary_channel_id_hex: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_get_channel_id", api::get_channel_id(node, temporary_channel_id_hex))
+    ffi_call!(
+        "rln_get_channel_id",
+        api::get_channel_id(node, temporary_channel_id_hex)
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -223,10 +244,7 @@ pub extern "C" fn rln_send_payment(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rln_keysend(
-    node: &COpaqueStruct,
-    request_json: *const c_char,
-) -> CResultString {
+pub extern "C" fn rln_keysend(node: &COpaqueStruct, request_json: *const c_char) -> CResultString {
     ffi_call!("rln_keysend", api::keysend(node, request_json))
 }
 
@@ -243,7 +261,10 @@ pub extern "C" fn rln_cancel_hodl_invoice(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_cancel_hodl_invoice", api::cancel_hodl_invoice(node, request_json))
+    ffi_call!(
+        "rln_cancel_hodl_invoice",
+        api::cancel_hodl_invoice(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -251,7 +272,10 @@ pub extern "C" fn rln_claim_hodl_invoice(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_claim_hodl_invoice", api::claim_hodl_invoice(node, request_json))
+    ffi_call!(
+        "rln_claim_hodl_invoice",
+        api::claim_hodl_invoice(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -267,7 +291,10 @@ pub extern "C" fn rln_decode_ln_invoice(
     node: &COpaqueStruct,
     invoice: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_decode_ln_invoice", api::decode_ln_invoice(node, invoice))
+    ffi_call!(
+        "rln_decode_ln_invoice",
+        api::decode_ln_invoice(node, invoice)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -275,7 +302,10 @@ pub extern "C" fn rln_decode_rgb_invoice(
     node: &COpaqueStruct,
     invoice: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_decode_rgb_invoice", api::decode_rgb_invoice(node, invoice))
+    ffi_call!(
+        "rln_decode_rgb_invoice",
+        api::decode_rgb_invoice(node, invoice)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -284,7 +314,10 @@ pub extern "C" fn rln_get_payment(
     payment_hash_hex: *const c_char,
     payment_type: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_get_payment", api::get_payment(node, payment_hash_hex, payment_type))
+    ffi_call!(
+        "rln_get_payment",
+        api::get_payment(node, payment_hash_hex, payment_type)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -305,10 +338,7 @@ pub extern "C" fn rln_rgb_invoice(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rln_send_rgb(
-    node: &COpaqueStruct,
-    request_json: *const c_char,
-) -> CResultString {
+pub extern "C" fn rln_send_rgb(node: &COpaqueStruct, request_json: *const c_char) -> CResultString {
     ffi_call!("rln_send_rgb", api::send_rgb(node, request_json))
 }
 
@@ -317,7 +347,10 @@ pub extern "C" fn rln_refresh_transfers(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_refresh_transfers", api::refresh_transfers(node, request_json))
+    ffi_call!(
+        "rln_refresh_transfers",
+        api::refresh_transfers(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -325,14 +358,14 @@ pub extern "C" fn rln_fail_transfers(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_fail_transfers", api::fail_transfers(node, request_json))
+    ffi_call!(
+        "rln_fail_transfers",
+        api::fail_transfers(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rln_inflate(
-    node: &COpaqueStruct,
-    request_json: *const c_char,
-) -> CResultString {
+pub extern "C" fn rln_inflate(node: &COpaqueStruct, request_json: *const c_char) -> CResultString {
     ffi_call!("rln_inflate", api::inflate(node, request_json))
 }
 
@@ -365,7 +398,10 @@ pub extern "C" fn rln_post_asset_media(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_post_asset_media", api::post_asset_media(node, request_json))
+    ffi_call!(
+        "rln_post_asset_media",
+        api::post_asset_media(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -385,7 +421,10 @@ pub extern "C" fn rln_issue_asset_nia(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_issue_asset_nia", api::issue_asset_nia(node, request_json))
+    ffi_call!(
+        "rln_issue_asset_nia",
+        api::issue_asset_nia(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -393,7 +432,10 @@ pub extern "C" fn rln_issue_asset_cfa(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_issue_asset_cfa", api::issue_asset_cfa(node, request_json))
+    ffi_call!(
+        "rln_issue_asset_cfa",
+        api::issue_asset_cfa(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -401,7 +443,10 @@ pub extern "C" fn rln_issue_asset_ifa(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_issue_asset_ifa", api::issue_asset_ifa(node, request_json))
+    ffi_call!(
+        "rln_issue_asset_ifa",
+        api::issue_asset_ifa(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -409,7 +454,10 @@ pub extern "C" fn rln_issue_asset_uda(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_issue_asset_uda", api::issue_asset_uda(node, request_json))
+    ffi_call!(
+        "rln_issue_asset_uda",
+        api::issue_asset_uda(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -417,7 +465,10 @@ pub extern "C" fn rln_list_assets(
     node: &COpaqueStruct,
     filter_asset_schemas_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_list_assets", api::list_assets(node, filter_asset_schemas_json))
+    ffi_call!(
+        "rln_list_assets",
+        api::list_assets(node, filter_asset_schemas_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -426,6 +477,17 @@ pub extern "C" fn rln_asset_balance(
     asset_id: *const c_char,
 ) -> CResultString {
     ffi_call!("rln_asset_balance", api::asset_balance(node, asset_id))
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn rln_asset_link_create(
+    node: &COpaqueStruct,
+    request_json: *const c_char,
+) -> CResultString {
+    ffi_call!(
+        "rln_asset_link_create",
+        api::asset_link_create(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -466,10 +528,7 @@ pub extern "C" fn rln_btc_balance(node: &COpaqueStruct, skip_sync: bool) -> CRes
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rln_sign_message(
-    node: &COpaqueStruct,
-    message: *const c_char,
-) -> CResultString {
+pub extern "C" fn rln_sign_message(node: &COpaqueStruct, message: *const c_char) -> CResultString {
     ffi_call!("rln_sign_message", api::sign_message(node, message))
 }
 
@@ -495,7 +554,10 @@ pub extern "C" fn rln_check_indexer_url(
     node: &COpaqueStruct,
     indexer_url: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_check_indexer_url", api::check_indexer_url(node, indexer_url))
+    ffi_call!(
+        "rln_check_indexer_url",
+        api::check_indexer_url(node, indexer_url)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -503,14 +565,14 @@ pub extern "C" fn rln_check_proxy_endpoint(
     node: &COpaqueStruct,
     proxy_endpoint: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_check_proxy_endpoint", api::check_proxy_endpoint(node, proxy_endpoint))
+    ffi_call!(
+        "rln_check_proxy_endpoint",
+        api::check_proxy_endpoint(node, proxy_endpoint)
+    )
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rln_send_btc(
-    node: &COpaqueStruct,
-    request_json: *const c_char,
-) -> CResultString {
+pub extern "C" fn rln_send_btc(node: &COpaqueStruct, request_json: *const c_char) -> CResultString {
     ffi_call!("rln_send_btc", api::send_btc(node, request_json))
 }
 
@@ -523,11 +585,11 @@ pub extern "C" fn rln_create_utxos(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rln_list_transactions(
-    node: &COpaqueStruct,
-    skip_sync: bool,
-) -> CResultString {
-    ffi_call!("rln_list_transactions", api::list_transactions(node, skip_sync))
+pub extern "C" fn rln_list_transactions(node: &COpaqueStruct, skip_sync: bool) -> CResultString {
+    ffi_call!(
+        "rln_list_transactions",
+        api::list_transactions(node, skip_sync)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -568,10 +630,7 @@ pub extern "C" fn rln_maker_execute(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rln_taker(
-    node: &COpaqueStruct,
-    request_json: *const c_char,
-) -> CResultString {
+pub extern "C" fn rln_taker(node: &COpaqueStruct, request_json: *const c_char) -> CResultString {
     ffi_call!("rln_taker", api::taker(node, request_json))
 }
 
@@ -580,7 +639,10 @@ pub extern "C" fn rln_send_onion_message(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_send_onion_message", api::send_onion_message(node, request_json))
+    ffi_call!(
+        "rln_send_onion_message",
+        api::send_onion_message(node, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -589,7 +651,10 @@ pub extern "C" fn rln_get_swap(
     payment_hash: *const c_char,
     taker_flag: bool,
 ) -> CResultString {
-    ffi_call!("rln_get_swap", api::get_swap(node, payment_hash, taker_flag))
+    ffi_call!(
+        "rln_get_swap",
+        api::get_swap(node, payment_hash, taker_flag)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -613,7 +678,10 @@ pub extern "C" fn rln_uniffi_is_initialized() -> CResultString {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn rln_sdk_initialize(request_json: *const c_char) -> CResultString {
-    ffi_call!("rln_sdk_initialize", api::sdk_global_initialize(request_json))
+    ffi_call!(
+        "rln_sdk_initialize",
+        api::sdk_global_initialize(request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -654,14 +722,18 @@ pub extern "C" fn rln_native_external_signer_new(
     network: *const c_char,
     permissive_policy: bool,
 ) -> CResult {
-    ffi_call!("rln_native_external_signer_new", api::native_external_signer_new(seed_hex, network, permissive_policy))
+    ffi_call!(
+        "rln_native_external_signer_new",
+        api::native_external_signer_new(seed_hex, network, permissive_policy)
+    )
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rln_native_external_signer_bootstrap(
-    signer: &COpaqueStruct,
-) -> CResultString {
-    ffi_call!("rln_native_external_signer_bootstrap", api::native_external_signer_bootstrap(signer))
+pub extern "C" fn rln_native_external_signer_bootstrap(signer: &COpaqueStruct) -> CResultString {
+    ffi_call!(
+        "rln_native_external_signer_bootstrap",
+        api::native_external_signer_bootstrap(signer)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -669,7 +741,10 @@ pub extern "C" fn rln_sdk_node_init_with_native_external_signer(
     node: &COpaqueStruct,
     signer: &COpaqueStruct,
 ) -> CResultString {
-    ffi_call!("rln_sdk_node_init_with_native_external_signer", api::sdk_node_init_with_native_external_signer(node, signer))
+    ffi_call!(
+        "rln_sdk_node_init_with_native_external_signer",
+        api::sdk_node_init_with_native_external_signer(node, signer)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -677,7 +752,10 @@ pub extern "C" fn rln_sdk_node_attach_native_external_signer(
     node: &COpaqueStruct,
     signer: &COpaqueStruct,
 ) -> CResultString {
-    ffi_call!("rln_sdk_node_attach_native_external_signer", api::sdk_node_attach_native_external_signer(node, signer))
+    ffi_call!(
+        "rln_sdk_node_attach_native_external_signer",
+        api::sdk_node_attach_native_external_signer(node, signer)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -686,7 +764,10 @@ pub extern "C" fn rln_sdk_node_unlock_with_native_external_signer(
     signer: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_sdk_node_unlock_with_native_external_signer", api::sdk_node_unlock_with_native_external_signer(node, signer, request_json))
+    ffi_call!(
+        "rln_sdk_node_unlock_with_native_external_signer",
+        api::sdk_node_unlock_with_native_external_signer(node, signer, request_json)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -694,14 +775,18 @@ pub extern "C" fn rln_sdk_node_init_with_external_signer(
     node: &COpaqueStruct,
     bootstrap_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_sdk_node_init_with_external_signer", api::sdk_node_init_with_external_signer(node, bootstrap_json))
+    ffi_call!(
+        "rln_sdk_node_init_with_external_signer",
+        api::sdk_node_init_with_external_signer(node, bootstrap_json)
+    )
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn rln_sdk_node_detach_external_signer(
-    node: &COpaqueStruct,
-) -> CResultString {
-    ffi_call!("rln_sdk_node_detach_external_signer", api::sdk_node_detach_external_signer(node))
+pub extern "C" fn rln_sdk_node_detach_external_signer(node: &COpaqueStruct) -> CResultString {
+    ffi_call!(
+        "rln_sdk_node_detach_external_signer",
+        api::sdk_node_detach_external_signer(node)
+    )
 }
 
 #[unsafe(no_mangle)]
@@ -709,5 +794,8 @@ pub extern "C" fn rln_sdk_node_unlock_with_attached_external_signer(
     node: &COpaqueStruct,
     request_json: *const c_char,
 ) -> CResultString {
-    ffi_call!("rln_sdk_node_unlock_with_attached_external_signer", api::sdk_node_unlock_with_attached_external_signer(node, request_json))
+    ffi_call!(
+        "rln_sdk_node_unlock_with_attached_external_signer",
+        api::sdk_node_unlock_with_attached_external_signer(node, request_json)
+    )
 }

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -57,6 +57,8 @@ interface SdkNode {
     [Throws=RlnError]
     void createutxos(SdkCreateUtxosRequest request);
     [Throws=RlnError]
+    AssetLinkRecord asset_link(SdkAssetLinkRequest request);
+    [Throws=RlnError]
     AssetNia issueassetnia(SdkIssueAssetNiaRequest request);
     [Throws=RlnError]
     AssetCfa issueassetcfa(SdkIssueAssetCfaRequest request);
@@ -328,6 +330,13 @@ dictionary AssetBalanceInfo {
     u64 spendable;
     u64 offchain_outbound;
     u64 offchain_inbound;
+};
+
+dictionary AssetLinkRecord {
+    ContractId parent_asset_id;
+    ContractId? child_asset_id;
+    u64? created_at;
+    Txid? txid;
 };
 
 dictionary AssetMetadataInfo {
@@ -695,6 +704,14 @@ interface IfaIssuanceType {
     Legacy();
     LinkRightOnly();
     LinkedFromParent(ContractId contract_id, boolean request_link_right);
+};
+
+
+dictionary SdkAssetLinkRequest {
+    ContractId parent_asset_id;
+    ContractId child_asset_id;
+    u64 fee_rate;
+    u8 min_confirmations;
 };
 
 dictionary SdkIssueAssetUdaRequest {

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -350,6 +350,7 @@ dictionary AssetMetadataInfo {
     string? ticker;
     string? details;
     Token? token;
+    RgbOutpoint? unspent_link_right_outpoint;
     string? linked_from_asset_id;
     string? linked_to_asset_id;
 };
@@ -452,7 +453,7 @@ dictionary AssetIfa {
     AssetBalanceInfo balance;
     Media? media;
     string? reject_list_url;
-    RgbOutpoint? link_right_outpoint;
+    RgbOutpoint? issuance_link_right_outpoint;
     string? linked_from_asset_id;
     string? linked_to_asset_id;
 };
@@ -484,6 +485,7 @@ dictionary DecodeLnInvoiceResponse {
 
 dictionary DecodeRgbInvoiceResponse {
     string recipient_id;
+    string proxy_recipient_id;
     string recipient_type;
     string? asset_schema;
     ContractId? asset_id;
@@ -519,6 +521,7 @@ dictionary Transfer {
     string kind;
     Txid? txid;
     string? recipient_id;
+    string? proxy_recipient_id;
     string? receive_utxo;
     string? change_utxo;
     i64? expiration;
@@ -710,7 +713,6 @@ interface IfaIssuanceType {
 dictionary SdkAssetLinkRequest {
     ContractId parent_asset_id;
     ContractId child_asset_id;
-    u64 fee_rate;
     u8 min_confirmations;
 };
 

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -441,6 +441,12 @@ dictionary AssetIfa {
     AssetBalanceInfo balance;
     Media? media;
     string? reject_list_url;
+    RgbOutpoint? link_right_outpoint;
+};
+
+dictionary RgbOutpoint {
+    string txid;
+    u32 vout;
 };
 
 dictionary ListAssetsResponse {
@@ -677,6 +683,14 @@ dictionary SdkIssueAssetIfaRequest {
     string name;
     u8 precision;
     string? reject_list_url;
+    IfaIssuanceType? issuance_type = null;
+};
+
+[Enum]
+interface IfaIssuanceType {
+    Legacy();
+    LinkRightOnly();
+    LinkedFromParent(ContractId contract_id, boolean request_link_right);
 };
 
 dictionary SdkIssueAssetUdaRequest {

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -341,6 +341,8 @@ dictionary AssetMetadataInfo {
     string? ticker;
     string? details;
     Token? token;
+    string? linked_from_asset_id;
+    string? linked_to_asset_id;
 };
 
 dictionary AssetMediaResponse {
@@ -442,6 +444,8 @@ dictionary AssetIfa {
     Media? media;
     string? reject_list_url;
     RgbOutpoint? link_right_outpoint;
+    string? linked_from_asset_id;
+    string? linked_to_asset_id;
 };
 
 dictionary RgbOutpoint {

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,6 @@
 services:
   bitcoind:
+    platform: linux/amd64
     image: registry.gitlab.com/hashbeam/docker/bitcoind:30.2
     command: ["-fallbackfee=0.0002", "-rest"]
     environment:
@@ -11,6 +12,7 @@ services:
     volumes:
       - ./datacore:/srv/app/.bitcoin
   electrs:
+    platform: linux/amd64
     image: registry.gitlab.com/hashbeam/docker/electrs:0.11.0
     environment:
       MYUID: 1000
@@ -39,6 +41,7 @@ services:
     ports:
       - 3002:3002
   proxy:
+    platform: linux/amd64
     image: ghcr.io/rgb-tools/rgb-proxy-server:0.3.0
     ports:
       - 3000:3000

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -99,6 +99,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AssetBalanceResponse'
+  /assetlink:
+    post:
+      tags:
+        - RGB
+      summary: Create a contract link
+      description: Link a parent IFA contract to a child IFA contract using a link-right UTXO
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetLinkRequest'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetLinkResponse'
   /assetmetadata:
     post:
       tags:
@@ -1593,6 +1611,52 @@ components:
             - string
             - 'null'
           example: https://some.domain/someasset/rejectlist
+    AssetLinkRequest:
+      type: object
+      required:
+        - parent_asset_id
+        - child_asset_id
+        - fee_rate
+        - min_confirmations
+      properties:
+        parent_asset_id:
+          type: string
+          example: rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ8
+        child_asset_id:
+          type: string
+          example: rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ9
+        fee_rate:
+          type: integer
+          example: 5
+        min_confirmations:
+          type: integer
+          example: 1
+    AssetLinkResponse:
+      type: object
+      required:
+        - parent_asset_id
+        - child_asset_id
+        - created_at
+        - txid
+      properties:
+        parent_asset_id:
+          type: string
+          example: rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ8
+        child_asset_id:
+          type:
+            - string
+            - 'null'
+          example: rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ9
+        created_at:
+          type:
+            - integer
+            - 'null'
+          example: 1691160565
+        txid:
+          type:
+            - string
+            - 'null'
+          example: 4b0d1f2c0d8a4e8d7e5e3f8f5a6b7c8d9e0f102132435465768798a9b0c1d2e3
     AssetMetadataRequest:
       type: object
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1275,6 +1275,11 @@ paths:
                     description: >
                       True if the local wallet has changes since the last
                       successful upload (i.e. a manual backup is needed).
+                  last_auto_backup_error:
+                    type:
+                      - string
+                      - 'null'
+                    description: Most recent automatic VSS backup error, if any.
                   pending_kv_writes:
                     type: integer
                     description: >
@@ -1611,12 +1616,23 @@ components:
             - string
             - 'null'
           example: https://some.domain/someasset/rejectlist
+        issuance_link_right_outpoint:
+          oneOf:
+            - $ref: '#/components/schemas/Outpoint'
+            - type: 'null'
+        linked_from_asset_id:
+          type:
+            - string
+            - 'null'
+        linked_to_asset_id:
+          type:
+            - string
+            - 'null'
     AssetLinkRequest:
       type: object
       required:
         - parent_asset_id
         - child_asset_id
-        - fee_rate
         - min_confirmations
       properties:
         parent_asset_id:
@@ -1625,9 +1641,6 @@ components:
         child_asset_id:
           type: string
           example: rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ9
-        fee_rate:
-          type: integer
-          example: 5
         min_confirmations:
           type: integer
           example: 1
@@ -1709,6 +1722,18 @@ components:
         token:
           oneOf:
             - $ref: '#/components/schemas/Token'
+            - type: 'null'
+        linked_from_asset_id:
+          type:
+            - string
+            - 'null'
+        linked_to_asset_id:
+          type:
+            - string
+            - 'null'
+        unspent_link_right_outpoint:
+          oneOf:
+            - $ref: '#/components/schemas/Outpoint'
             - type: 'null'
     AssetNIA:
       type: object
@@ -1879,6 +1904,19 @@ components:
         - Signet
         - SignetCustom
         - Regtest
+    Outpoint:
+      type: object
+      required:
+        - txid
+        - vout
+      properties:
+        txid:
+          type: string
+          example: 4b0d1f2c0d8a4e8d7e5e3f8f5a6b7c8d9e0f102132435465768798a9b0c1d2e3
+        vout:
+          type: integer
+          format: int32
+          example: 0
     BlockTime:
       type: object
       required:
@@ -2198,6 +2236,7 @@ components:
       type: object
       required:
         - recipient_id
+        - proxy_recipient_id
         - recipient_type
         - assignment
         - network
@@ -2206,6 +2245,9 @@ components:
         recipient_id:
           type: string
           example: bcrt:utxob:cbgHUJ4e-7QyKY4U-Jsj5AZw-oI0gxZh-7fxQY2_-tFFUAZN-4CgpX
+        proxy_recipient_id:
+          type: string
+          example: bcrt:utxob:cbgHUJ4e-7QyKY4U-Jsj5AZw-oI0gxZh-7fxQY2_-tFFUAZN-4CgpY
         recipient_type:
           $ref: '#/components/schemas/RecipientType'
         asset_schema:
@@ -3897,6 +3939,11 @@ components:
             - string
             - 'null'
           example: 61qsVbWtkNmU54F2i6qtB9uSmEGsPoaeypCi5uC5uctZ
+        proxy_recipient_id:
+          type:
+            - string
+            - 'null'
+          example: 61qsVbWtkNmU54F2i6qtB9uSmEGsPoaeypCi5uC5ucX
         receive_utxo:
           type:
             - string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2605,6 +2605,10 @@ components:
             - string
             - 'null'
           example: https://some.domain/someasset/rejectlist
+        issuance_type:
+          oneOf:
+            - $ref: '#/components/schemas/IfaIssuanceType'
+            - type: 'null'
     IssueAssetIFAResponse:
       type: object
       required:
@@ -2612,6 +2616,33 @@ components:
       properties:
         asset:
           $ref: '#/components/schemas/AssetIFA'
+    IfaIssuanceType:
+      oneOf:
+        - $ref: '#/components/schemas/IfaIssuanceTypeLegacy'
+        - $ref: '#/components/schemas/IfaIssuanceTypeLinkRightOnly'
+        - $ref: '#/components/schemas/IfaIssuanceTypeLinkedFromParent'
+    IfaIssuanceTypeLegacy:
+      type: string
+      enum: [legacy]
+    IfaIssuanceTypeLinkRightOnly:
+      type: string
+      enum: [linkRightOnly]
+    IfaIssuanceTypeLinkedFromParent:
+      type: object
+      required:
+        - linkedFromParent
+      properties:
+        linkedFromParent:
+          type: object
+          required:
+            - contractId
+          properties:
+            contractId:
+              type: string
+              example: rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ8
+            requestLinkRight:
+              type: boolean
+              example: true
     IssueAssetNIARequest:
       type: object
       required:

--- a/regtest.sh
+++ b/regtest.sh
@@ -65,6 +65,20 @@ _wait_for_electrs() {
     done
 }
 
+_wait_for_proxy() {
+    # wait for proxy to be responding to requests
+    start_time=$(date +%s)
+    until curl -s http://127.0.0.1:3000 >/dev/null 2>&1; do
+        current_time=$(date +%s)
+        if [ $((current_time - start_time)) -gt $TIMEOUT ]; then
+            echo "Timeout waiting for proxy to start"
+            $COMPOSE logs proxy
+            exit 1
+        fi
+        sleep 1
+    done
+}
+
 _start_services() {
     _stop_services
 
@@ -85,6 +99,8 @@ _start_services() {
     $COMPOSE up -d
     echo "waiting for electrs to have completed startup"
     _wait_for_electrs
+    echo "waiting for proxy to be ready"
+    _wait_for_proxy
 
     # optionally start VSS server
     if [ "${VSS:-}" = "1" ]; then

--- a/src/asset_link.rs
+++ b/src/asset_link.rs
@@ -1,24 +1,49 @@
-use bitcoin::secp256k1::PublicKey;
+use amplify::s;
+use bitcoin::{hashes::Hash, secp256k1::PublicKey};
 use lightning::{
     io,
     ln::{
+        channelmanager::{PaymentId, RecipientOnionFields},
         msgs::{DecodeError, Init, LightningError},
         peer_handler::CustomMessageHandler,
         wire::{CustomMessageReader, Type},
     },
-    types::features::{InitFeatures, NodeFeatures},
-    util::ser::{LengthLimitedRead, LengthReadable, WithoutLength, Writeable, Writer},
+    routing::router::{Path as LnPath, PaymentParameters, Route, RouteParameters},
+    types::{
+        features::{InitFeatures, NodeFeatures},
+        payment::PaymentHash,
+    },
+    util::{
+        ser::{LengthLimitedRead, LengthReadable, WithoutLength, Writeable, Writer},
+        IS_SWAP_SCID,
+    },
 };
+use lightning_invoice::{Bolt11Invoice, PaymentSecret};
+use rgb_lib::{AssetSchema as RgbLibAssetSchema, ContractId};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::time::timeout;
 use tracing::warn;
 
 use crate::custom_msg_rpc::{
     jsonrpc_error_value, jsonrpc_result_value, resolve_pending_response,
     CustomMsgPeerAccessControl, CustomMsgRpcEnvelope, CustomMsgRpcResponseReceiver,
     JsonRpcErrorWire, PendingResponses, JSONRPC_INVALID_PARAMS, JSONRPC_METHOD_NOT_FOUND,
-    JSONRPC_VERSION,
+    JSONRPC_MSG_RESPONSE_TIMEOUT_SECS, JSONRPC_VERSION,
+};
+use crate::{
+    core_types::{HTLCStatus, MAX_SWAP_FEE_MSAT},
+    error::APIError,
+    ldk::{clear_rgb_payment_pending, write_rgb_payment_info_file, PaymentInfo},
+    rgb::get_rgb_channel_info_optional,
+    utils::{
+        description_hash_from_invoice, get_current_timestamp, get_route, hex_str,
+        new_jsonrpc_request_id, UnlockedAppState,
+    },
 };
 
 const ASSET_LINK_AUTHORIZE_SWAP_METHOD: &str = "asset_link.authorize_swap";
@@ -73,13 +98,6 @@ pub(crate) struct AssetLinkAuthorizeResultWire {
     pub(crate) authorized: bool,
 }
 
-#[derive(Deserialize, Serialize)]
-pub(crate) struct AssetLinkSendPaymentRequest {
-    pub(crate) invoice: String,
-    pub(crate) asset_id: String,
-    pub(crate) host_pubkey: String,
-}
-
 pub(crate) trait AssetLinkAuthorizer: Send + Sync {
     fn authorize_swap(
         &self,
@@ -98,6 +116,13 @@ pub(crate) struct AssetLinkMessageHandler {
 struct AssetLinkHandlerState {
     pending: Vec<(PublicKey, AssetLinkMessage)>,
     pending_responses: PendingResponses,
+}
+
+pub(crate) struct LinkedAssetPaymentResult {
+    pub(crate) payment_id: PaymentId,
+    pub(crate) payment_hash: PaymentHash,
+    pub(crate) payment_secret: PaymentSecret,
+    pub(crate) status: HTLCStatus,
 }
 
 impl AssetLinkMessageHandler {
@@ -384,4 +409,302 @@ impl CustomMessageHandler for AssetLinkMessageHandler {
     fn provided_init_features(&self, _their_node_id: PublicKey) -> InitFeatures {
         InitFeatures::empty()
     }
+}
+
+pub(crate) fn find_linked_asset_channel(
+    unlocked_state: &UnlockedAppState,
+    contract_id: ContractId,
+    asset_amount: u64,
+    amt_msat: u64,
+    recipient_pubkey: PublicKey,
+) -> Option<(ContractId, PublicKey)> {
+    let asset_id = contract_id.to_string();
+    unlocked_state
+        .channel_manager
+        .list_usable_channels()
+        .into_iter()
+        .filter_map(|channel| {
+            if channel.counterparty.node_id == recipient_pubkey
+                || channel.next_outbound_htlc_minimum_msat > amt_msat
+                || channel.next_outbound_htlc_limit_msat < amt_msat
+            {
+                return None;
+            }
+
+            let rgb_info = get_rgb_channel_info_optional(
+                &channel.channel_id,
+                false,
+                unlocked_state.kv_store.as_ref(),
+            )?;
+            if rgb_info.contract_id == contract_id || rgb_info.local_rgb_amount < asset_amount {
+                return None;
+            }
+
+            let metadata = unlocked_state
+                .rgb_get_asset_metadata(rgb_info.contract_id)
+                .ok()?;
+            if metadata.asset_schema != RgbLibAssetSchema::Ifa {
+                return None;
+            }
+
+            let is_linked = metadata.linked_from_asset_id.as_deref() == Some(asset_id.as_str())
+                || metadata.linked_to_asset_id.as_deref() == Some(asset_id.as_str());
+            is_linked.then_some((
+                rgb_info.contract_id,
+                channel.counterparty.node_id,
+                rgb_info.local_rgb_amount,
+            ))
+        })
+        .max_by_key(|(_, _, local_rgb_amount)| *local_rgb_amount)
+        .map(|(linked_contract_id, host_pubkey, _)| (linked_contract_id, host_pubkey))
+}
+
+pub(crate) fn has_sufficient_asset_channel(
+    unlocked_state: &UnlockedAppState,
+    contract_id: ContractId,
+    asset_amount: u64,
+    amt_msat: u64,
+) -> bool {
+    unlocked_state
+        .channel_manager
+        .list_usable_channels()
+        .iter()
+        .any(|channel| {
+            channel.next_outbound_htlc_minimum_msat <= amt_msat
+                && channel.next_outbound_htlc_limit_msat >= amt_msat
+                && get_rgb_channel_info_optional(
+                    &channel.channel_id,
+                    false,
+                    unlocked_state.kv_store.as_ref(),
+                )
+                .is_some_and(|rgb_info| {
+                    rgb_info.contract_id == contract_id && rgb_info.local_rgb_amount >= asset_amount
+                })
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn send_linked_asset_payment(
+    unlocked_state: &UnlockedAppState,
+    invoice: &Bolt11Invoice,
+    contract_id: ContractId,
+    linked_contract_id: ContractId,
+    asset_amount: u64,
+    amt_msat: u64,
+    host_pubkey: PublicKey,
+) -> Result<LinkedAssetPaymentResult, APIError> {
+    let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());
+    let payment_secret = *invoice.payment_secret();
+    let recipient_pubkey = invoice.recover_payee_pub_key();
+
+    if contract_id == linked_contract_id
+        || host_pubkey == unlocked_state.runtime_node_id()
+        || host_pubkey == recipient_pubkey
+    {
+        return Err(APIError::InvalidRequest(
+            "linked payment requires distinct payer, host, recipient, and asset IDs".to_string(),
+        ));
+    }
+
+    let first_leg = get_route(
+        unlocked_state.config.as_ref(),
+        &unlocked_state.channel_manager,
+        &unlocked_state.router,
+        unlocked_state.kv_store.as_ref(),
+        unlocked_state.runtime_node_id(),
+        host_pubkey,
+        Some(amt_msat),
+        Some((linked_contract_id, asset_amount)),
+        vec![],
+    );
+    let second_leg = get_route(
+        unlocked_state.config.as_ref(),
+        &unlocked_state.channel_manager,
+        &unlocked_state.router,
+        unlocked_state.kv_store.as_ref(),
+        host_pubkey,
+        recipient_pubkey,
+        Some(amt_msat),
+        Some((contract_id, asset_amount)),
+        invoice.route_hints(),
+    );
+    let (mut first_leg, mut second_leg) = match (first_leg, second_leg) {
+        (Some(first_leg), Some(second_leg)) => (first_leg, second_leg),
+        _ => return Err(APIError::NoRoute),
+    };
+
+    second_leg.paths[0].hops[0].short_channel_id |= IS_SWAP_SCID;
+    first_leg.paths[0]
+        .hops
+        .last_mut()
+        .expect("Path not to be empty")
+        .fee_msat = 0;
+
+    let mut fullpaths = first_leg.paths[0]
+        .hops
+        .clone()
+        .into_iter()
+        .map(|mut hop| {
+            hop.rgb_payment = Some((linked_contract_id, asset_amount));
+            hop
+        })
+        .chain(second_leg.paths[0].hops.clone().into_iter().map(|mut hop| {
+            hop.rgb_payment = Some((contract_id, asset_amount));
+            hop
+        }))
+        .collect::<Vec<_>>();
+
+    if let Some(last_hop) = fullpaths.last_mut() {
+        last_hop.cltv_expiry_delta = last_hop
+            .cltv_expiry_delta
+            .max(invoice.min_final_cltv_expiry_delta() as u32);
+    }
+
+    let total_fee = fullpaths
+        .iter()
+        .rev()
+        .skip(1)
+        .map(|hop| hop.fee_msat)
+        .sum::<u64>();
+    if total_fee >= MAX_SWAP_FEE_MSAT {
+        return Err(APIError::FailedPayment(format!(
+            "Fee too high: {total_fee}"
+        )));
+    }
+
+    let mut recipient_onion = RecipientOnionFields::secret_only(payment_secret);
+    recipient_onion.payment_metadata = invoice.payment_metadata().cloned();
+
+    let mut route_params = RouteParameters::from_payment_params_and_value(
+        PaymentParameters::from_bolt11_invoice(invoice),
+        amt_msat,
+        Some((contract_id, asset_amount)),
+    );
+    route_params
+        .set_max_path_length(
+            &recipient_onion,
+            false,
+            unlocked_state.channel_manager.current_best_block().height,
+        )
+        .map_err(|()| APIError::FailedPayment(s!("onion packet size exceeded")))?;
+    let route = Route {
+        paths: vec![LnPath {
+            hops: fullpaths,
+            blinded_tail: None,
+        }],
+        route_params: Some(route_params),
+    };
+
+    let params = AssetLinkAuthorizeParamsWire {
+        protocol_version: ASSET_LINK_PROTOCOL_VERSION,
+        payment_hash: hex_str(&payment_hash.0),
+        asset_id: contract_id.to_string(),
+        linked_asset_id: linked_contract_id.to_string(),
+        amount: asset_amount,
+        expiry_sec: invoice.duration_until_expiry().as_secs(),
+    };
+    let request_id = new_jsonrpc_request_id();
+    let response_rx = unlocked_state
+        .asset_link_handler
+        .queue_asset_link_authorize(host_pubkey, Value::String(request_id.clone()), params)
+        .map_err(|err| APIError::InvalidRequest(err.message))?;
+    unlocked_state.peer_manager.process_events();
+    match timeout(
+        Duration::from_secs(JSONRPC_MSG_RESPONSE_TIMEOUT_SECS),
+        response_rx,
+    )
+    .await
+    {
+        Ok(Ok(Ok(result))) => {
+            let authorized = serde_json::from_value::<AssetLinkAuthorizeResultWire>(result)
+                .map(|result| result.authorized)
+                .unwrap_or(false);
+            if !authorized {
+                return Err(APIError::InvalidRequest(s!(
+                    "host did not authorize the linked payment"
+                )));
+            }
+        }
+        Ok(Ok(Err(err))) => {
+            return Err(APIError::InvalidRequest(format!(
+                "authorize_swap error {}: {}",
+                err.code, err.message
+            )));
+        }
+        Ok(Err(_)) => {
+            return Err(APIError::Network(s!(
+                "linked payment response channel closed before the host replied"
+            )));
+        }
+        Err(_) => {
+            unlocked_state
+                .asset_link_handler
+                .forget_asset_link_response(host_pubkey, &request_id);
+            return Err(APIError::Network(s!(
+                "linked payment timed out waiting for host authorization"
+            )));
+        }
+    }
+
+    let created_at = get_current_timestamp();
+    let payment_id = PaymentId(payment_hash.0);
+    let mut status = HTLCStatus::Pending;
+    unlocked_state.add_outbound_payment(
+        payment_id,
+        PaymentInfo {
+            preimage: None,
+            secret: Some(payment_secret),
+            status,
+            amt_msat: Some(amt_msat),
+            created_at,
+            updated_at: created_at,
+            payee_pubkey: invoice.get_payee_pub_key(),
+            expires_at: None,
+            claim_deadline_height: None,
+            invoice_type: None,
+            description_hash: description_hash_from_invoice(invoice),
+            payment_idx: None,
+            async_hash_index: None,
+            async_host_node_id: None,
+        },
+    )?;
+    write_rgb_payment_info_file(
+        &payment_hash,
+        linked_contract_id,
+        asset_amount,
+        true,
+        false,
+        unlocked_state.kv_store.as_ref(),
+    );
+
+    match unlocked_state.channel_manager.send_payment_with_route(
+        route,
+        payment_hash,
+        recipient_onion,
+        payment_id,
+    ) {
+        Ok(()) => {
+            tracing::info!(
+                asset_id = %contract_id,
+                linked_asset_id = %linked_contract_id,
+                amount = asset_amount,
+                recipient = %recipient_pubkey,
+                host = %host_pubkey,
+                "sent linked-asset payment"
+            );
+        }
+        Err(err) => {
+            tracing::error!("ERROR: failed to send linked-asset payment: {err:?}");
+            clear_rgb_payment_pending(&payment_hash, false, unlocked_state.kv_store.as_ref());
+            status = HTLCStatus::Failed;
+            unlocked_state.update_outbound_payment_status(payment_id, status);
+        }
+    }
+
+    Ok(LinkedAssetPaymentResult {
+        payment_id,
+        payment_hash,
+        payment_secret,
+        status,
+    })
 }

--- a/src/asset_link.rs
+++ b/src/asset_link.rs
@@ -24,6 +24,7 @@ use crate::custom_msg_rpc::{
 const ASSET_LINK_AUTHORIZE_SWAP_METHOD: &str = "asset_link.authorize_swap";
 pub(crate) const ASSET_LINK_ERROR_DUPLICATE_PAYMENT_HASH: i64 = 1203;
 pub(crate) const ASSET_LINK_ERROR_INSUFFICIENT_LIQUIDITY: i64 = 1202;
+pub(crate) const ASSET_LINK_ERROR_UNKNOWN_ASSET: i64 = 1204;
 pub(crate) const ASSET_LINK_ERROR_UNKNOWN_LINK: i64 = 1201;
 pub(crate) const ASSET_LINK_ERROR_UNSUPPORTED_PROTOCOL_VERSION: i64 = 1200;
 pub(crate) const ASSET_LINK_MESSAGE_TYPE_ID: u16 = 37917;

--- a/src/asset_link.rs
+++ b/src/asset_link.rs
@@ -1,0 +1,386 @@
+use bitcoin::secp256k1::PublicKey;
+use lightning::{
+    io,
+    ln::{
+        msgs::{DecodeError, Init, LightningError},
+        peer_handler::CustomMessageHandler,
+        wire::{CustomMessageReader, Type},
+    },
+    types::features::{InitFeatures, NodeFeatures},
+    util::ser::{LengthLimitedRead, LengthReadable, WithoutLength, Writeable, Writer},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::sync::{Arc, Mutex};
+use tracing::warn;
+
+use crate::custom_msg_rpc::{
+    jsonrpc_error_value, jsonrpc_result_value, resolve_pending_response,
+    CustomMsgPeerAccessControl, CustomMsgRpcEnvelope, CustomMsgRpcResponseReceiver,
+    JsonRpcErrorWire, PendingResponses, JSONRPC_INVALID_PARAMS, JSONRPC_METHOD_NOT_FOUND,
+    JSONRPC_VERSION,
+};
+
+const ASSET_LINK_AUTHORIZE_SWAP_METHOD: &str = "asset_link.authorize_swap";
+pub(crate) const ASSET_LINK_ERROR_DUPLICATE_PAYMENT_HASH: i64 = 1203;
+pub(crate) const ASSET_LINK_ERROR_INSUFFICIENT_LIQUIDITY: i64 = 1202;
+pub(crate) const ASSET_LINK_ERROR_UNKNOWN_LINK: i64 = 1201;
+pub(crate) const ASSET_LINK_ERROR_UNSUPPORTED_PROTOCOL_VERSION: i64 = 1200;
+pub(crate) const ASSET_LINK_MESSAGE_TYPE_ID: u16 = 37917;
+pub(crate) const ASSET_LINK_PROTOCOL_VERSION: u64 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AssetLinkMessage {
+    pub(crate) payload: String,
+}
+
+impl Type for AssetLinkMessage {
+    fn type_id(&self) -> u16 {
+        ASSET_LINK_MESSAGE_TYPE_ID
+    }
+}
+
+impl Writeable for AssetLinkMessage {
+    fn write<W: Writer>(&self, w: &mut W) -> Result<(), io::Error> {
+        WithoutLength(&self.payload).write(w)
+    }
+}
+
+impl LengthReadable for AssetLinkMessage {
+    fn read_from_fixed_length_buffer<R: LengthLimitedRead>(r: &mut R) -> Result<Self, DecodeError> {
+        let payload_without_length: WithoutLength<String> =
+            LengthReadable::read_from_fixed_length_buffer(r)?;
+        Ok(Self {
+            payload: payload_without_length.0,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AssetLinkAuthorizeParamsWire {
+    pub(crate) protocol_version: u64,
+    pub(crate) payment_hash: String,
+    pub(crate) asset_id: String,
+    pub(crate) linked_asset_id: String,
+    pub(crate) amount: u64,
+    pub(crate) expiry_sec: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct AssetLinkAuthorizeResultWire {
+    pub(crate) authorized: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct AssetLinkSendPaymentRequest {
+    pub(crate) invoice: String,
+    pub(crate) asset_id: String,
+    pub(crate) host_pubkey: String,
+}
+
+pub(crate) trait AssetLinkAuthorizer: Send + Sync {
+    fn authorize_swap(
+        &self,
+        sender_node_id: PublicKey,
+        params: &AssetLinkAuthorizeParamsWire,
+    ) -> Result<(), JsonRpcErrorWire>;
+}
+
+pub(crate) struct AssetLinkMessageHandler {
+    access_control: Arc<dyn CustomMsgPeerAccessControl>,
+    authorizer: Mutex<Option<Arc<dyn AssetLinkAuthorizer>>>,
+    state: Mutex<AssetLinkHandlerState>,
+}
+
+#[derive(Default)]
+struct AssetLinkHandlerState {
+    pending: Vec<(PublicKey, AssetLinkMessage)>,
+    pending_responses: PendingResponses,
+}
+
+impl AssetLinkMessageHandler {
+    pub(crate) fn new(access_control: Arc<dyn CustomMsgPeerAccessControl>) -> Self {
+        Self {
+            access_control,
+            authorizer: Mutex::new(None),
+            state: Mutex::new(AssetLinkHandlerState::default()),
+        }
+    }
+
+    pub(crate) fn set_authorizer(&self, authorizer: Arc<dyn AssetLinkAuthorizer>) {
+        *self.authorizer.lock().unwrap() = Some(authorizer);
+    }
+
+    pub(crate) fn queue_asset_link_authorize(
+        &self,
+        host_node_id: PublicKey,
+        id: Value,
+        params: AssetLinkAuthorizeParamsWire,
+    ) -> Result<CustomMsgRpcResponseReceiver, JsonRpcErrorWire> {
+        let Some(request_id) = id.as_str().map(str::to_owned) else {
+            return Err(JsonRpcErrorWire::invalid_request());
+        };
+
+        let (response_sender, response_receiver) = tokio::sync::oneshot::channel();
+        let mut state = self.state.lock().unwrap();
+        let response_key = (host_node_id, request_id);
+        if state.pending_responses.contains_key(&response_key) {
+            return Err(JsonRpcErrorWire::internal_error(
+                "asset_link_request_id_already_pending".to_owned(),
+            ));
+        }
+        state
+            .pending_responses
+            .insert(response_key, response_sender);
+        state.pending.push((
+            host_node_id,
+            AssetLinkMessage {
+                payload: json!({
+                    "jsonrpc": JSONRPC_VERSION,
+                    "id": id,
+                    "method": ASSET_LINK_AUTHORIZE_SWAP_METHOD,
+                    "params": params,
+                })
+                .to_string(),
+            },
+        ));
+
+        Ok(response_receiver)
+    }
+
+    pub(crate) fn forget_asset_link_response(&self, host_node_id: PublicKey, request_id: &str) {
+        let mut state = self.state.lock().unwrap();
+        state
+            .pending_responses
+            .remove(&(host_node_id, request_id.to_owned()));
+    }
+
+    fn queue_jsonrpc_value(&self, peer: PublicKey, value: Value) {
+        let mut state = self.state.lock().unwrap();
+        state.pending.push((
+            peer,
+            AssetLinkMessage {
+                payload: value.to_string(),
+            },
+        ));
+    }
+
+    fn queue_jsonrpc_parse_error(&self, peer: PublicKey) {
+        self.queue_jsonrpc_value(
+            peer,
+            jsonrpc_error_value(Value::Null, JsonRpcErrorWire::parse_error()),
+        );
+    }
+
+    fn queue_jsonrpc_invalid_request(&self, peer: PublicKey) {
+        self.queue_jsonrpc_value(
+            peer,
+            jsonrpc_error_value(Value::Null, JsonRpcErrorWire::invalid_request()),
+        );
+    }
+
+    fn queue_jsonrpc_result(&self, peer: PublicKey, id: Value, result: impl Serialize) {
+        self.queue_jsonrpc_value(peer, jsonrpc_result_value(id, result));
+    }
+
+    fn queue_jsonrpc_error(&self, peer: PublicKey, id: Value, code: i64, message: &str) {
+        self.queue_jsonrpc_value(
+            peer,
+            jsonrpc_error_value(
+                id,
+                JsonRpcErrorWire {
+                    code,
+                    message: message.to_owned(),
+                },
+            ),
+        );
+    }
+
+    fn complete_asset_link_response(
+        &self,
+        sender_node_id: PublicKey,
+        id: Option<Value>,
+        result: Option<Value>,
+        error: Option<Value>,
+    ) {
+        let mut state = self.state.lock().unwrap();
+        resolve_pending_response(
+            &mut state.pending_responses,
+            "asset_link",
+            sender_node_id,
+            id,
+            result,
+            error,
+        );
+    }
+
+    fn receive_authorize(
+        &self,
+        sender_node_id: PublicKey,
+        params: AssetLinkAuthorizeParamsWire,
+    ) -> Result<AssetLinkAuthorizeResultWire, JsonRpcErrorWire> {
+        if params.protocol_version != ASSET_LINK_PROTOCOL_VERSION {
+            return Err(JsonRpcErrorWire::application_error(
+                ASSET_LINK_ERROR_UNSUPPORTED_PROTOCOL_VERSION,
+                "unsupported_protocol_version",
+            ));
+        }
+        let Some(authorizer) = self.authorizer.lock().unwrap().clone() else {
+            return Err(JsonRpcErrorWire::internal_error(
+                "asset_link_authorizer_not_available".to_owned(),
+            ));
+        };
+        authorizer.authorize_swap(sender_node_id, &params)?;
+        Ok(AssetLinkAuthorizeResultWire { authorized: true })
+    }
+}
+
+impl CustomMessageReader for AssetLinkMessageHandler {
+    type CustomMessage = AssetLinkMessage;
+
+    fn read<RD: LengthLimitedRead>(
+        &self,
+        message_type: u16,
+        buffer: &mut RD,
+    ) -> Result<Option<Self::CustomMessage>, DecodeError> {
+        if message_type != ASSET_LINK_MESSAGE_TYPE_ID {
+            return Ok(None);
+        }
+
+        Ok(Some(AssetLinkMessage::read_from_fixed_length_buffer(
+            buffer,
+        )?))
+    }
+}
+
+impl CustomMessageHandler for AssetLinkMessageHandler {
+    fn handle_custom_message(
+        &self,
+        msg: Self::CustomMessage,
+        sender_node_id: PublicKey,
+    ) -> Result<(), LightningError> {
+        if !self.access_control.allows_peer(&sender_node_id) {
+            warn!(peer = %sender_node_id, "rejected asset_link message from untrusted peer");
+            return Ok(());
+        }
+
+        if msg.payload.as_bytes().contains(&0) {
+            warn!(
+                peer = %sender_node_id,
+                payload_len = msg.payload.len(),
+                "asset_link message contained a NUL byte"
+            );
+            self.queue_jsonrpc_parse_error(sender_node_id);
+            return Ok(());
+        }
+
+        let envelope: CustomMsgRpcEnvelope = match serde_json::from_str(&msg.payload) {
+            Ok(envelope) => envelope,
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    peer = %sender_node_id,
+                    payload_len = msg.payload.len(),
+                    "failed to decode asset_link message"
+                );
+                self.queue_jsonrpc_parse_error(sender_node_id);
+                return Ok(());
+            }
+        };
+
+        if envelope.jsonrpc != JSONRPC_VERSION {
+            self.queue_jsonrpc_invalid_request(sender_node_id);
+            return Ok(());
+        }
+
+        if envelope.is_response_like() {
+            if envelope.method.is_some() {
+                warn!(
+                    peer = %sender_node_id,
+                    "ignoring malformed asset_link response envelope with method field"
+                );
+                return Ok(());
+            }
+            self.complete_asset_link_response(
+                sender_node_id,
+                envelope.id,
+                envelope.result,
+                envelope.error,
+            );
+            return Ok(());
+        }
+
+        let (Some(method), Some(id)) = (envelope.method, envelope.id) else {
+            self.queue_jsonrpc_invalid_request(sender_node_id);
+            return Ok(());
+        };
+
+        if method == ASSET_LINK_AUTHORIZE_SWAP_METHOD {
+            let params_value = match envelope.params {
+                Some(params) => params,
+                None => {
+                    self.queue_jsonrpc_error(
+                        sender_node_id,
+                        id,
+                        JSONRPC_INVALID_PARAMS,
+                        "missing params",
+                    );
+                    return Ok(());
+                }
+            };
+
+            let params: AssetLinkAuthorizeParamsWire = match serde_json::from_value(params_value) {
+                Ok(params) => params,
+                Err(err) => {
+                    warn!(error = %err, "invalid asset_link.authorize_swap params from {sender_node_id}");
+                    self.queue_jsonrpc_error(
+                        sender_node_id,
+                        id,
+                        JSONRPC_INVALID_PARAMS,
+                        "invalid_authorize_swap_params",
+                    );
+                    return Ok(());
+                }
+            };
+
+            match self.receive_authorize(sender_node_id, params) {
+                Ok(result) => self.queue_jsonrpc_result(sender_node_id, id, result),
+                Err(err) => self.queue_jsonrpc_error(sender_node_id, id, err.code, &err.message),
+            }
+            return Ok(());
+        }
+
+        self.queue_jsonrpc_error(
+            sender_node_id,
+            id,
+            JSONRPC_METHOD_NOT_FOUND,
+            "method not found",
+        );
+        Ok(())
+    }
+
+    fn get_and_clear_pending_msg(&self) -> Vec<(PublicKey, Self::CustomMessage)> {
+        let mut state = self.state.lock().unwrap();
+        std::mem::take(&mut state.pending)
+    }
+
+    fn peer_disconnected(&self, _their_node_id: PublicKey) {}
+
+    fn peer_connected(
+        &self,
+        _their_node_id: PublicKey,
+        _msg: &Init,
+        _inbound: bool,
+    ) -> Result<(), ()> {
+        Ok(())
+    }
+
+    fn provided_node_features(&self) -> NodeFeatures {
+        NodeFeatures::empty()
+    }
+
+    fn provided_init_features(&self, _their_node_id: PublicKey) -> InitFeatures {
+        InitFeatures::empty()
+    }
+}

--- a/src/asset_link.rs
+++ b/src/asset_link.rs
@@ -23,6 +23,7 @@ use rgb_lib::{AssetSchema as RgbLibAssetSchema, ContractId};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{
+    str::FromStr,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -36,6 +37,7 @@ use crate::custom_msg_rpc::{
     JSONRPC_MSG_RESPONSE_TIMEOUT_SECS, JSONRPC_VERSION,
 };
 use crate::{
+    core_types::asset_link::{AssetLinkRequest, AssetLinkResponse},
     core_types::{HTLCStatus, MAX_SWAP_FEE_MSAT},
     error::APIError,
     ldk::{clear_rgb_payment_pending, write_rgb_payment_info_file, PaymentInfo},
@@ -411,6 +413,103 @@ impl CustomMessageHandler for AssetLinkMessageHandler {
     }
 }
 
+pub(crate) fn create_asset_link(
+    unlocked_state: &UnlockedAppState,
+    params: AssetLinkRequest,
+) -> Result<AssetLinkResponse, APIError> {
+    if unlocked_state.external_signer_mode {
+        return Err(APIError::UnsupportedInExternalSignerMode(s!(
+            "asset linking is not supported in external signer mode"
+        )));
+    }
+
+    let parent_id = params.parent_asset_id.trim().to_string();
+    let child_id = params.child_asset_id.trim().to_string();
+    let parent_contract_id = ContractId::from_str(&parent_id)
+        .map_err(|_| APIError::InvalidAssetID(parent_id.clone()))?;
+    let child_contract_id =
+        ContractId::from_str(&child_id).map_err(|_| APIError::InvalidAssetID(child_id.clone()))?;
+
+    if parent_contract_id == child_contract_id {
+        return Err(APIError::InvalidRequest(s!(
+            "parent and child contracts must be different"
+        )));
+    }
+
+    let parent_metadata = unlocked_state.rgb_get_asset_metadata(parent_contract_id)?;
+    let child_metadata = unlocked_state.rgb_get_asset_metadata(child_contract_id)?;
+    if parent_metadata.asset_schema != RgbLibAssetSchema::Ifa
+        || child_metadata.asset_schema != RgbLibAssetSchema::Ifa
+    {
+        return Err(APIError::InvalidContractLink(s!(
+            "asset linking is only supported for IFA assets"
+        )));
+    }
+
+    match child_metadata.linked_from_asset_id.as_deref() {
+        Some(existing_parent_id) if existing_parent_id == parent_id => {}
+        Some(existing_parent_id) => {
+            return Err(APIError::InvalidContractLink(format!(
+                "child_asset_id {child_id} is already linked from {existing_parent_id}"
+            )));
+        }
+        None => {
+            return Err(APIError::InvalidContractLink(format!(
+                "child_asset_id {child_id} does not declare parent_asset_id {parent_id} as its parent"
+            )));
+        }
+    }
+
+    match parent_metadata.linked_to_asset_id.as_deref() {
+        Some(existing_child_id) if existing_child_id == child_id => {
+            let link_transfer = unlocked_state.rgb_find_link_transfer(parent_contract_id)?;
+            let created_at = link_transfer
+                .as_ref()
+                .map(|transfer| transfer.created_at.max(0) as u64)
+                .unwrap_or_else(get_current_timestamp);
+            return Ok(AssetLinkResponse {
+                parent_asset_id: parent_id,
+                child_asset_id: Some(child_id),
+                created_at: Some(created_at),
+                txid: link_transfer.and_then(|transfer| transfer.txid),
+            });
+        }
+        Some(existing_child_id) => {
+            return Err(APIError::InvalidContractLink(format!(
+                "parent_asset_id {parent_id} is already linked to {existing_child_id}"
+            )));
+        }
+        None => {}
+    }
+
+    let link_right_outpoint = unlocked_state
+        .rgb_find_link_right_outpoint(parent_contract_id)?
+        .ok_or_else(|| {
+            APIError::InvalidRequest(format!(
+                "missing link_right_outpoint for parent_asset_id {parent_id}"
+            ))
+        })?;
+    let link_ifa = unlocked_state.rgb_link_ifa(
+        parent_id.clone(),
+        child_id.clone(),
+        link_right_outpoint,
+        params.fee_rate,
+        params.min_confirmations,
+    )?;
+    let link_transfer = unlocked_state.rgb_find_link_transfer(parent_contract_id)?;
+    let created_at = link_transfer
+        .as_ref()
+        .map(|transfer| transfer.created_at.max(0) as u64)
+        .unwrap_or_else(get_current_timestamp);
+
+    Ok(AssetLinkResponse {
+        parent_asset_id: parent_id,
+        child_asset_id: Some(child_id),
+        created_at: Some(created_at),
+        txid: Some(link_ifa.txid),
+    })
+}
+
 pub(crate) fn find_linked_asset_channel(
     unlocked_state: &UnlockedAppState,
     contract_id: ContractId,
@@ -501,9 +600,9 @@ pub(crate) async fn send_linked_asset_payment(
         || host_pubkey == unlocked_state.runtime_node_id()
         || host_pubkey == recipient_pubkey
     {
-        return Err(APIError::InvalidRequest(
-            "linked payment requires distinct payer, host, recipient, and asset IDs".to_string(),
-        ));
+        return Err(APIError::InvalidRequest(s!(
+            "linked payment requires distinct payer, host, recipient, and asset IDs"
+        )));
     }
 
     let first_leg = get_route(

--- a/src/asset_link.rs
+++ b/src/asset_link.rs
@@ -486,14 +486,14 @@ pub(crate) fn create_asset_link(
         .rgb_find_link_right_outpoint(parent_contract_id)?
         .ok_or_else(|| {
             APIError::InvalidRequest(format!(
-                "missing link_right_outpoint for parent_asset_id {parent_id}"
+                "missing unspent_link_right_outpoint for parent_asset_id {parent_id}"
             ))
         })?;
     let link_ifa = unlocked_state.rgb_link_ifa(
         parent_id.clone(),
         child_id.clone(),
         link_right_outpoint,
-        params.fee_rate,
+        unlocked_state.config.rgb.fee_rate_sat_vb,
         params.min_confirmations,
     )?;
     let link_transfer = unlocked_state.rgb_find_link_transfer(parent_contract_id)?;
@@ -518,6 +518,49 @@ pub(crate) fn find_linked_asset_channel(
     recipient_pubkey: PublicKey,
 ) -> Option<(ContractId, PublicKey)> {
     let asset_id = contract_id.to_string();
+    let validate_locally_discoverable_asset_link = |linked_contract_id: ContractId| -> Option<()> {
+        let linked_metadata = unlocked_state
+            .rgb_get_asset_metadata(linked_contract_id)
+            .ok()?;
+        if linked_metadata.asset_schema != RgbLibAssetSchema::Ifa {
+            return None;
+        }
+
+        let linked_asset_id = linked_contract_id.to_string();
+        if linked_metadata.linked_from_asset_id.as_deref() == Some(asset_id.as_str()) {
+            if let Ok(parent_metadata) = unlocked_state.rgb_get_asset_metadata(contract_id) {
+                if parent_metadata.linked_to_asset_id.as_deref() != Some(linked_asset_id.as_str()) {
+                    return None;
+                }
+                let is_link_settled = unlocked_state
+                    .rgb_find_link_transfer(contract_id)
+                    .ok()?
+                    .is_some_and(|transfer| transfer.status == rgb_lib::TransferStatus::Settled);
+                if !is_link_settled {
+                    return None;
+                }
+            }
+        } else if linked_metadata.linked_to_asset_id.as_deref() == Some(asset_id.as_str()) {
+            if let Ok(child_metadata) = unlocked_state.rgb_get_asset_metadata(contract_id) {
+                if child_metadata.linked_from_asset_id.as_deref() != Some(linked_asset_id.as_str())
+                {
+                    return None;
+                }
+            }
+            let is_link_settled = unlocked_state
+                .rgb_find_link_transfer(linked_contract_id)
+                .ok()?
+                .is_some_and(|transfer| transfer.status == rgb_lib::TransferStatus::Settled);
+            if !is_link_settled {
+                return None;
+            }
+        } else {
+            return None;
+        }
+
+        Some(())
+    };
+
     unlocked_state
         .channel_manager
         .list_usable_channels()
@@ -539,16 +582,9 @@ pub(crate) fn find_linked_asset_channel(
                 return None;
             }
 
-            let metadata = unlocked_state
-                .rgb_get_asset_metadata(rgb_info.contract_id)
-                .ok()?;
-            if metadata.asset_schema != RgbLibAssetSchema::Ifa {
-                return None;
-            }
+            validate_locally_discoverable_asset_link(rgb_info.contract_id)?;
 
-            let is_linked = metadata.linked_from_asset_id.as_deref() == Some(asset_id.as_str())
-                || metadata.linked_to_asset_id.as_deref() == Some(asset_id.as_str());
-            is_linked.then_some((
+            Some((
                 rgb_info.contract_id,
                 channel.counterparty.node_id,
                 rgb_info.local_rgb_amount,

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -25,6 +25,12 @@ use tokio::runtime::Handle;
 use tokio::sync::oneshot;
 use tracing::warn;
 
+use crate::custom_msg_rpc::{
+    jsonrpc_error_value, jsonrpc_result_value, resolve_pending_response,
+    CustomMsgPeerAccessControl, CustomMsgRpcEnvelope, CustomMsgRpcResponseReceiver,
+    JsonRpcErrorWire, PendingResponses, JSONRPC_INVALID_PARAMS, JSONRPC_METHOD_NOT_FOUND,
+    JSONRPC_VERSION,
+};
 use crate::utils::{hex_str, validate_and_parse_description_hash, validate_and_parse_payment_hash};
 
 pub(crate) const ASYNC_ORDER_MESSAGE_TYPE_ID: u16 = 37915;
@@ -38,12 +44,6 @@ const ASYNC_ORDER_NEW_METHOD: &str = "async_order.new";
 const ASYNC_ORDER_REQUEST_INVOICE_METHOD: &str = "async_order.request_invoice";
 const ASYNC_ORDER_PAYMENT_SENT_PATH: &str = "/internal/async_order/payment_sent";
 const ASYNC_ERROR_UNSUPPORTED_PROTOCOL_VERSION: i64 = 1000;
-const JSONRPC_INVALID_REQUEST: i64 = -32600;
-const JSONRPC_INVALID_PARAMS: i64 = -32602;
-const JSONRPC_INTERNAL_ERROR: i64 = -32603;
-const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
-const JSONRPC_PARSE_ERROR: i64 = -32700;
-const JSONRPC_VERSION: &str = "2.0";
 const PROTOCOL_VERSION: u64 = 1;
 const ASYNC_ORDER_FIRST_HASH_INDEX: u64 = 1;
 const ASYNC_PAYMENTS_ACCOUNT_INDEX: u32 = 0;
@@ -78,21 +78,6 @@ impl LengthReadable for AsyncOrderMessage {
             payload: payload_without_length.0,
         })
     }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-struct AsyncOrderEnvelope {
-    jsonrpc: String,
-    #[serde(default)]
-    id: Option<Value>,
-    #[serde(default)]
-    method: Option<String>,
-    #[serde(default)]
-    params: Option<Value>,
-    #[serde(default)]
-    result: Option<Value>,
-    #[serde(default)]
-    error: Option<Value>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -327,12 +312,6 @@ struct AsyncOrderHttpResponseWire {
     error: Option<JsonRpcErrorWire>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub(crate) struct JsonRpcErrorWire {
-    pub(crate) code: i64,
-    pub(crate) message: String,
-}
-
 #[derive(Clone)]
 pub(crate) struct AsyncPaymentsPreimageRoot {
     account_xprv: Xpriv,
@@ -395,10 +374,6 @@ pub(crate) fn write_async_payments_next_hash_index(
         })
 }
 
-pub(crate) trait AsyncOrderAccessControl: Send + Sync {
-    fn allows_peer(&self, peer: &PublicKey) -> bool;
-}
-
 pub(crate) trait AsyncOrderInvoiceProvider: Send + Sync {
     fn request_outbound_invoice(
         &self,
@@ -410,14 +385,14 @@ pub(crate) trait AsyncOrderInvoiceProvider: Send + Sync {
 #[derive(Debug)]
 struct AllowFreeAccess;
 
-impl AsyncOrderAccessControl for AllowFreeAccess {
+impl CustomMsgPeerAccessControl for AllowFreeAccess {
     fn allows_peer(&self, _peer: &PublicKey) -> bool {
         true
     }
 }
 
 pub(crate) struct AsyncOrderMessageHandler {
-    access_control: Arc<dyn AsyncOrderAccessControl>,
+    access_control: Arc<dyn CustomMsgPeerAccessControl>,
     invoice_provider: Arc<Mutex<Option<Arc<dyn AsyncOrderInvoiceProvider>>>>,
     lsp_client: Option<AsyncOrderLspClient>,
     runtime_handle: Option<Handle>,
@@ -428,13 +403,9 @@ struct AsyncOrderState {
     next_order_id: u64,
     peers: HashMap<PublicKey, PeerOrderState>,
     pending: Vec<(PublicKey, AsyncOrderMessage)>,
-    pending_responses: HashMap<(PublicKey, String), AsyncOrderResponseSender>,
+    pending_responses: PendingResponses,
     request_invoice_cache: HashMap<(PublicKey, String), AsyncOrderRequestInvoiceCacheEntry>,
 }
-
-type AsyncOrderResponse = Result<Value, JsonRpcErrorWire>;
-type AsyncOrderResponseSender = oneshot::Sender<AsyncOrderResponse>;
-pub(crate) type AsyncOrderResponseReceiver = oneshot::Receiver<AsyncOrderResponse>;
 
 #[derive(Debug, Default)]
 struct PeerOrderState {
@@ -855,7 +826,7 @@ impl AsyncPaymentsPreimageRoot {
 }
 
 impl AsyncOrderMessageHandler {
-    pub(crate) fn new(access_control: Arc<dyn AsyncOrderAccessControl>) -> Self {
+    pub(crate) fn new(access_control: Arc<dyn CustomMsgPeerAccessControl>) -> Self {
         Self {
             access_control,
             invoice_provider: Arc::new(Mutex::new(None)),
@@ -866,7 +837,7 @@ impl AsyncOrderMessageHandler {
     }
 
     pub(crate) fn new_with_lsp_client(
-        access_control: Arc<dyn AsyncOrderAccessControl>,
+        access_control: Arc<dyn CustomMsgPeerAccessControl>,
         lsp_base_url: String,
         lsp_bearer_token: Option<String>,
         runtime_handle: Handle,
@@ -900,7 +871,7 @@ impl AsyncOrderMessageHandler {
         id: Value,
         method: &'static str,
         params: impl Serialize,
-    ) -> Result<AsyncOrderResponseReceiver, JsonRpcErrorWire> {
+    ) -> Result<CustomMsgRpcResponseReceiver, JsonRpcErrorWire> {
         let Some(request_id) = id.as_str().map(str::to_owned) else {
             return Err(JsonRpcErrorWire::invalid_request());
         };
@@ -951,14 +922,7 @@ impl AsyncOrderMessageHandler {
     }
 
     fn queue_jsonrpc_result<T: Serialize>(&self, peer: PublicKey, id: Value, result: T) {
-        self.queue_jsonrpc_value(
-            peer,
-            json!({
-                "jsonrpc": JSONRPC_VERSION,
-                "id": id,
-                "result": result,
-            }),
-        );
+        self.queue_jsonrpc_value(peer, jsonrpc_result_value(id, result));
     }
 
     pub(crate) fn queue_async_order_new(
@@ -966,7 +930,7 @@ impl AsyncOrderMessageHandler {
         host_node_id: PublicKey,
         id: Value,
         params: AsyncOrderNewParamsWire,
-    ) -> Result<AsyncOrderResponseReceiver, JsonRpcErrorWire> {
+    ) -> Result<CustomMsgRpcResponseReceiver, JsonRpcErrorWire> {
         Self::validate_async_order_new_params(&params)?;
         self.queue_async_order_request(host_node_id, id, ASYNC_ORDER_NEW_METHOD, params)
     }
@@ -976,7 +940,7 @@ impl AsyncOrderMessageHandler {
         peer_node_id: PublicKey,
         id: Value,
         params: AsyncOrderRequestInvoiceParamsWire,
-    ) -> Result<AsyncOrderResponseReceiver, JsonRpcErrorWire> {
+    ) -> Result<CustomMsgRpcResponseReceiver, JsonRpcErrorWire> {
         self.queue_async_order_request(peer_node_id, id, ASYNC_ORDER_REQUEST_INVOICE_METHOD, params)
     }
 
@@ -1001,14 +965,13 @@ impl AsyncOrderMessageHandler {
         Self::queue_jsonrpc_value_to_state(
             state,
             peer,
-            json!({
-                "jsonrpc": JSONRPC_VERSION,
-                "id": id,
-                "error": JsonRpcErrorWire {
+            jsonrpc_error_value(
+                id,
+                JsonRpcErrorWire {
                     code,
                     message: message.to_owned(),
                 },
-            }),
+            ),
         );
     }
 
@@ -1018,36 +981,20 @@ impl AsyncOrderMessageHandler {
         id: Value,
         result: impl Serialize,
     ) {
-        Self::queue_jsonrpc_value_to_state(
-            state,
-            peer,
-            json!({
-                "jsonrpc": JSONRPC_VERSION,
-                "id": id,
-                "result": result,
-            }),
-        );
+        Self::queue_jsonrpc_value_to_state(state, peer, jsonrpc_result_value(id, result));
     }
 
     fn queue_jsonrpc_parse_error(&self, peer: PublicKey) {
         self.queue_jsonrpc_value(
             peer,
-            json!({
-                "jsonrpc": JSONRPC_VERSION,
-                "id": Value::Null,
-                "error": JsonRpcErrorWire::parse_error(),
-            }),
+            jsonrpc_error_value(Value::Null, JsonRpcErrorWire::parse_error()),
         );
     }
 
     fn queue_jsonrpc_invalid_request(&self, peer: PublicKey) {
         self.queue_jsonrpc_value(
             peer,
-            json!({
-                "jsonrpc": JSONRPC_VERSION,
-                "id": Value::Null,
-                "error": JsonRpcErrorWire::invalid_request(),
-            }),
+            jsonrpc_error_value(Value::Null, JsonRpcErrorWire::invalid_request()),
         );
     }
 
@@ -1058,36 +1005,15 @@ impl AsyncOrderMessageHandler {
         result: Option<Value>,
         error: Option<Value>,
     ) {
-        let Some(Value::String(request_id)) = id else {
-            warn!(peer = %sender_node_id, "ignoring async_order response with missing or non-string id");
-            return;
-        };
-
-        let response = match (result, error) {
-            (Some(result), None) => Ok(result),
-            (None, Some(error)) => match serde_json::from_value::<JsonRpcErrorWire>(error) {
-                Ok(err) => Err(err),
-                Err(err) => Err(JsonRpcErrorWire::internal_error(format!(
-                    "invalid_async_order_response_error: {err}"
-                ))),
-            },
-            (Some(_), Some(_)) => Err(JsonRpcErrorWire::internal_error(
-                "invalid_async_order_response: contained both result and error".to_owned(),
-            )),
-            (None, None) => Err(JsonRpcErrorWire::internal_error(
-                "invalid_async_order_response: missing result and error".to_owned(),
-            )),
-        };
-
-        let response_sender = {
-            let mut state = self.state.lock().unwrap();
-            state
-                .pending_responses
-                .remove(&(sender_node_id, request_id))
-        };
-        if let Some(response_sender) = response_sender {
-            let _ = response_sender.send(response);
-        }
+        let mut state = self.state.lock().unwrap();
+        resolve_pending_response(
+            &mut state.pending_responses,
+            "async_order",
+            sender_node_id,
+            id,
+            result,
+            error,
+        );
     }
 
     fn receive_async_order_request_invoice(
@@ -1313,7 +1239,7 @@ impl CustomMessageHandler for AsyncOrderMessageHandler {
             return Ok(());
         }
 
-        let envelope: AsyncOrderEnvelope = match serde_json::from_str(&msg.payload) {
+        let envelope: CustomMsgRpcEnvelope = match serde_json::from_str(&msg.payload) {
             Ok(envelope) => envelope,
             Err(err) => {
                 warn!(
@@ -1332,10 +1258,7 @@ impl CustomMessageHandler for AsyncOrderMessageHandler {
             return Ok(());
         }
 
-        let response_like = envelope.result.is_some()
-            || envelope.error.is_some()
-            || (envelope.method.is_none() && envelope.id.is_some() && envelope.params.is_none());
-        if response_like {
+        if envelope.is_response_like() {
             if envelope.method.is_some() {
                 warn!(
                     peer = %sender_node_id,
@@ -1581,13 +1504,6 @@ impl AsyncOrderRecord {
 }
 
 impl JsonRpcErrorWire {
-    fn parse_error() -> Self {
-        Self {
-            code: JSONRPC_PARSE_ERROR,
-            message: "parse error".to_owned(),
-        }
-    }
-
     fn duplicate_index_conflict() -> Self {
         Self {
             code: ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT,
@@ -1602,38 +1518,10 @@ impl JsonRpcErrorWire {
         }
     }
 
-    pub(crate) fn application_error(code: i64, message: impl Into<String>) -> Self {
-        Self {
-            code,
-            message: message.into(),
-        }
-    }
-
-    pub(crate) fn internal_error(message: String) -> Self {
-        Self {
-            code: JSONRPC_INTERNAL_ERROR,
-            message,
-        }
-    }
-
     fn invalid_hash_batch() -> Self {
         Self {
             code: ASYNC_ERROR_INVALID_HASH_BATCH,
             message: "invalid_hash_batch".to_owned(),
-        }
-    }
-
-    pub(crate) fn invalid_params(message: impl Into<String>) -> Self {
-        Self {
-            code: JSONRPC_INVALID_PARAMS,
-            message: message.into(),
-        }
-    }
-
-    fn invalid_request() -> Self {
-        Self {
-            code: JSONRPC_INVALID_REQUEST,
-            message: "invalid request".to_owned(),
         }
     }
 
@@ -1703,6 +1591,9 @@ fn validate_async_payments_next_hash_index(next_index: u64) -> Result<(), JsonRp
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::custom_msg_rpc::{
+        JSONRPC_INTERNAL_ERROR, JSONRPC_INVALID_REQUEST, JSONRPC_PARSE_ERROR,
+    };
     use crate::kv_store::test_support::MemoryKvStore;
     use crate::utils::new_jsonrpc_request_id;
     use axum::{extract::Json, http::StatusCode, routing::post, Router};
@@ -1741,7 +1632,7 @@ mod tests {
         }
     }
 
-    impl AsyncOrderAccessControl for DenyAllAccess {
+    impl CustomMsgPeerAccessControl for DenyAllAccess {
         fn allows_peer(&self, _peer: &PublicKey) -> bool {
             false
         }

--- a/src/core_types.rs
+++ b/src/core_types.rs
@@ -23,7 +23,6 @@ pub mod asset_link {
     pub(crate) struct AssetLinkRequest {
         pub(crate) parent_asset_id: String,
         pub(crate) child_asset_id: String,
-        pub(crate) fee_rate: u64,
         pub(crate) min_confirmations: u8,
     }
 

--- a/src/core_types.rs
+++ b/src/core_types.rs
@@ -13,6 +13,7 @@ pub(crate) const DUST_LIMIT_MSAT: u64 = 546000;
 pub(crate) const HTLC_MIN_MSAT: u64 = 3_000_000;
 pub(crate) const VIRTUAL_HTLC_MIN_MSAT: u64 = 1_000;
 pub(crate) const MAX_SWAP_FEE_MSAT: u64 = 3_000_000;
+pub(crate) const PENDING_SWAP_TIMEOUT_SECS: u64 = 24 * 60 * 60;
 pub(crate) const DEFAULT_FINAL_CLTV_EXPIRY_DELTA: u32 = 14;
 
 pub mod async_order {

--- a/src/core_types.rs
+++ b/src/core_types.rs
@@ -16,6 +16,26 @@ pub(crate) const MAX_SWAP_FEE_MSAT: u64 = 3_000_000;
 pub(crate) const PENDING_SWAP_TIMEOUT_SECS: u64 = 24 * 60 * 60;
 pub(crate) const DEFAULT_FINAL_CLTV_EXPIRY_DELTA: u32 = 14;
 
+pub mod asset_link {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    pub(crate) struct AssetLinkRequest {
+        pub(crate) parent_asset_id: String,
+        pub(crate) child_asset_id: String,
+        pub(crate) fee_rate: u64,
+        pub(crate) min_confirmations: u8,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+    pub(crate) struct AssetLinkResponse {
+        pub(crate) parent_asset_id: String,
+        pub(crate) child_asset_id: Option<String>,
+        pub(crate) created_at: Option<u64>,
+        pub(crate) txid: Option<String>,
+    }
+}
+
 pub mod async_order {
     use crate::async_order::{AsyncOrderNewHashWire, AsyncOrderRequestInvoiceParamsWire};
     use serde::{Deserialize, Serialize};

--- a/src/custom_msg_rpc.rs
+++ b/src/custom_msg_rpc.rs
@@ -1,0 +1,245 @@
+use bitcoin::secp256k1::PublicKey;
+use lightning::{
+    ln::{
+        msgs::{DecodeError, Init, LightningError},
+        peer_handler::CustomMessageHandler,
+        wire::{CustomMessageReader, Type},
+    },
+    types::features::{InitFeatures, NodeFeatures},
+    util::ser::{LengthLimitedRead, Writeable, Writer},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+use tracing::warn;
+
+use crate::asset_link::{AssetLinkMessage, AssetLinkMessageHandler};
+use crate::async_order::{AsyncOrderMessage, AsyncOrderMessageHandler};
+
+pub(crate) const JSONRPC_INTERNAL_ERROR: i64 = -32603;
+pub(crate) const JSONRPC_INVALID_PARAMS: i64 = -32602;
+pub(crate) const JSONRPC_INVALID_REQUEST: i64 = -32600;
+pub(crate) const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
+pub(crate) const JSONRPC_MSG_RESPONSE_TIMEOUT_SECS: u64 = 30;
+pub(crate) const JSONRPC_PARSE_ERROR: i64 = -32700;
+pub(crate) const JSONRPC_VERSION: &str = "2.0";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct JsonRpcErrorWire {
+    pub(crate) code: i64,
+    pub(crate) message: String,
+}
+
+impl JsonRpcErrorWire {
+    pub(crate) fn application_error(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn internal_error(message: String) -> Self {
+        Self {
+            code: JSONRPC_INTERNAL_ERROR,
+            message,
+        }
+    }
+
+    pub(crate) fn invalid_params(message: impl Into<String>) -> Self {
+        Self {
+            code: JSONRPC_INVALID_PARAMS,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn invalid_request() -> Self {
+        Self {
+            code: JSONRPC_INVALID_REQUEST,
+            message: "invalid request".to_owned(),
+        }
+    }
+
+    pub(crate) fn parse_error() -> Self {
+        Self {
+            code: JSONRPC_PARSE_ERROR,
+            message: "parse error".to_owned(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct CustomMsgRpcEnvelope {
+    pub(crate) jsonrpc: String,
+    #[serde(default)]
+    pub(crate) id: Option<Value>,
+    #[serde(default)]
+    pub(crate) method: Option<String>,
+    #[serde(default)]
+    pub(crate) params: Option<Value>,
+    #[serde(default)]
+    pub(crate) result: Option<Value>,
+    #[serde(default)]
+    pub(crate) error: Option<Value>,
+}
+
+impl CustomMsgRpcEnvelope {
+    pub(crate) fn is_response_like(&self) -> bool {
+        self.result.is_some()
+            || self.error.is_some()
+            || (self.method.is_none() && self.id.is_some() && self.params.is_none())
+    }
+}
+
+pub(crate) type CustomMsgRpcResponse = Result<Value, JsonRpcErrorWire>;
+pub(crate) type CustomMsgRpcResponseReceiver = oneshot::Receiver<CustomMsgRpcResponse>;
+pub(crate) type CustomMsgRpcResponseSender = oneshot::Sender<CustomMsgRpcResponse>;
+
+pub(crate) type PendingResponses = HashMap<(PublicKey, String), CustomMsgRpcResponseSender>;
+
+pub(crate) fn jsonrpc_error_value(id: Value, error: JsonRpcErrorWire) -> Value {
+    json!({ "jsonrpc": JSONRPC_VERSION, "id": id, "error": error })
+}
+
+pub(crate) fn jsonrpc_result_value(id: Value, result: impl Serialize) -> Value {
+    json!({ "jsonrpc": JSONRPC_VERSION, "id": id, "result": result })
+}
+
+pub(crate) fn resolve_pending_response(
+    pending: &mut PendingResponses,
+    protocol: &str,
+    sender_node_id: PublicKey,
+    id: Option<Value>,
+    result: Option<Value>,
+    error: Option<Value>,
+) {
+    let Some(Value::String(request_id)) = id else {
+        warn!(peer = %sender_node_id, "ignoring {protocol} response with missing or non-string id");
+        return;
+    };
+
+    let response = match (result, error) {
+        (Some(result), None) => Ok(result),
+        (None, Some(error)) => match serde_json::from_value::<JsonRpcErrorWire>(error) {
+            Ok(err) => Err(err),
+            Err(err) => Err(JsonRpcErrorWire::internal_error(format!(
+                "invalid_{protocol}_response_error: {err}"
+            ))),
+        },
+        (Some(_), Some(_)) => Err(JsonRpcErrorWire::internal_error(format!(
+            "invalid_{protocol}_response: contained both result and error"
+        ))),
+        (None, None) => Err(JsonRpcErrorWire::internal_error(format!(
+            "invalid_{protocol}_response: missing result and error"
+        ))),
+    };
+
+    if let Some(response_sender) = pending.remove(&(sender_node_id, request_id)) {
+        let _ = response_sender.send(response);
+    }
+}
+
+pub(crate) trait CustomMsgPeerAccessControl: Send + Sync {
+    fn allows_peer(&self, peer: &PublicKey) -> bool;
+}
+
+#[derive(Debug)]
+pub(crate) enum NodeCustomMessage {
+    AsyncOrder(AsyncOrderMessage),
+    AssetLink(AssetLinkMessage),
+}
+
+impl Type for NodeCustomMessage {
+    fn type_id(&self) -> u16 {
+        match self {
+            NodeCustomMessage::AsyncOrder(msg) => msg.type_id(),
+            NodeCustomMessage::AssetLink(msg) => msg.type_id(),
+        }
+    }
+}
+
+impl Writeable for NodeCustomMessage {
+    fn write<W: Writer>(&self, w: &mut W) -> Result<(), lightning::io::Error> {
+        match self {
+            NodeCustomMessage::AsyncOrder(msg) => msg.write(w),
+            NodeCustomMessage::AssetLink(msg) => msg.write(w),
+        }
+    }
+}
+
+pub(crate) struct CustomMessenger {
+    pub(crate) async_order: Arc<AsyncOrderMessageHandler>,
+    pub(crate) asset_link: Arc<AssetLinkMessageHandler>,
+}
+
+impl CustomMessageReader for CustomMessenger {
+    type CustomMessage = NodeCustomMessage;
+
+    fn read<RD: LengthLimitedRead>(
+        &self,
+        message_type: u16,
+        buffer: &mut RD,
+    ) -> Result<Option<Self::CustomMessage>, DecodeError> {
+        if let Some(msg) = self.async_order.read(message_type, buffer)? {
+            return Ok(Some(NodeCustomMessage::AsyncOrder(msg)));
+        }
+        if let Some(msg) = self.asset_link.read(message_type, buffer)? {
+            return Ok(Some(NodeCustomMessage::AssetLink(msg)));
+        }
+        Ok(None)
+    }
+}
+
+impl CustomMessageHandler for CustomMessenger {
+    fn handle_custom_message(
+        &self,
+        msg: Self::CustomMessage,
+        sender_node_id: PublicKey,
+    ) -> Result<(), LightningError> {
+        match msg {
+            NodeCustomMessage::AsyncOrder(msg) => {
+                self.async_order.handle_custom_message(msg, sender_node_id)
+            }
+            NodeCustomMessage::AssetLink(msg) => {
+                self.asset_link.handle_custom_message(msg, sender_node_id)
+            }
+        }
+    }
+
+    fn get_and_clear_pending_msg(&self) -> Vec<(PublicKey, Self::CustomMessage)> {
+        let mut pending = Vec::new();
+        for (peer, msg) in self.async_order.get_and_clear_pending_msg() {
+            pending.push((peer, NodeCustomMessage::AsyncOrder(msg)));
+        }
+        for (peer, msg) in self.asset_link.get_and_clear_pending_msg() {
+            pending.push((peer, NodeCustomMessage::AssetLink(msg)));
+        }
+        pending
+    }
+
+    fn peer_disconnected(&self, their_node_id: PublicKey) {
+        self.async_order.peer_disconnected(their_node_id);
+        self.asset_link.peer_disconnected(their_node_id);
+    }
+
+    fn peer_connected(
+        &self,
+        their_node_id: PublicKey,
+        msg: &Init,
+        inbound: bool,
+    ) -> Result<(), ()> {
+        self.async_order
+            .peer_connected(their_node_id, msg, inbound)?;
+        self.asset_link.peer_connected(their_node_id, msg, inbound)
+    }
+
+    fn provided_node_features(&self) -> NodeFeatures {
+        self.async_order.provided_node_features() | self.asset_link.provided_node_features()
+    }
+
+    fn provided_init_features(&self, their_node_id: PublicKey) -> InitFeatures {
+        self.async_order.provided_init_features(their_node_id)
+            | self.asset_link.provided_init_features(their_node_id)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -167,6 +167,9 @@ pub enum APIError {
     #[error("Invalid channel ID")]
     InvalidChannelID,
 
+    #[error("Invalid contract link: {0}")]
+    InvalidContractLink(String),
+
     #[error("Invalid description hash: {0}")]
     InvalidDescriptionHash(String),
 
@@ -440,6 +443,7 @@ impl From<RgbLibError> for APIError {
             RgbLibError::InvalidAmountZero => APIError::InvalidAmount(s!("0")),
             RgbLibError::InvalidAssignment => APIError::InvalidAssignment,
             RgbLibError::InvalidAttachments { details } => APIError::InvalidAttachments(details),
+            RgbLibError::InvalidContractLink { details } => APIError::InvalidContractLink(details),
             RgbLibError::InvalidDetails { details } => APIError::InvalidDetails(details),
             RgbLibError::InvalidElectrum { details } => APIError::InvalidIndexer(details),
             RgbLibError::InvalidEstimationBlocks => APIError::InvalidEstimationBlocks,
@@ -531,6 +535,7 @@ impl IntoResponse for APIError {
             | APIError::InvalidBackupPath
             | APIError::InvalidBiscuitToken
             | APIError::InvalidChannelID
+            | APIError::InvalidContractLink(_)
             | APIError::InvalidDescriptionHash(_)
             | APIError::InvalidDetails(_)
             | APIError::InvalidEstimationBlocks

--- a/src/error.rs
+++ b/src/error.rs
@@ -170,6 +170,9 @@ pub enum APIError {
     #[error("Invalid contract link: {0}")]
     InvalidContractLink(String),
 
+    #[error("Invalid right outpoint: {0}")]
+    InvalidRightOutpoint(String),
+
     #[error("Invalid description hash: {0}")]
     InvalidDescriptionHash(String),
 
@@ -347,6 +350,9 @@ pub enum APIError {
     #[error("Unexpected error: {0}")]
     Unexpected(String),
 
+    #[error("Restored VSS backup is inconsistent: {0}")]
+    RestoredBackupInconsistent(String),
+
     #[error("Unknown channel ID")]
     UnknownChannelId,
 
@@ -444,6 +450,9 @@ impl From<RgbLibError> for APIError {
             RgbLibError::InvalidAssignment => APIError::InvalidAssignment,
             RgbLibError::InvalidAttachments { details } => APIError::InvalidAttachments(details),
             RgbLibError::InvalidContractLink { details } => APIError::InvalidContractLink(details),
+            RgbLibError::InvalidRightOutpoint { details } => {
+                APIError::InvalidRightOutpoint(details)
+            }
             RgbLibError::InvalidDetails { details } => APIError::InvalidDetails(details),
             RgbLibError::InvalidElectrum { details } => APIError::InvalidIndexer(details),
             RgbLibError::InvalidEstimationBlocks => APIError::InvalidEstimationBlocks,
@@ -483,6 +492,9 @@ impl From<RgbLibError> for APIError {
             RgbLibError::OutputBelowDustLimit => APIError::OutputBelowDustLimit,
             RgbLibError::Proxy { details } => APIError::Network(format!("proxy err: {details}")),
             RgbLibError::RecipientIDAlreadyUsed => APIError::RecipientIDAlreadyUsed,
+            RgbLibError::RestoredBackupInconsistent { details } => {
+                APIError::RestoredBackupInconsistent(details)
+            }
             RgbLibError::TooHighInflationAmounts => {
                 APIError::InvalidAmount(s!("inflation amount exceeds the max possible supply"))
             }
@@ -516,6 +528,7 @@ impl IntoResponse for APIError {
             | APIError::FailedPeerDisconnection(_)
             | APIError::FailedSendingOnionMessage(_)
             | APIError::IO(_)
+            | APIError::RestoredBackupInconsistent(_)
             | APIError::Unexpected(_) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 self.to_string(),
@@ -536,6 +549,7 @@ impl IntoResponse for APIError {
             | APIError::InvalidBiscuitToken
             | APIError::InvalidChannelID
             | APIError::InvalidContractLink(_)
+            | APIError::InvalidRightOutpoint(_)
             | APIError::InvalidDescriptionHash(_)
             | APIError::InvalidDetails(_)
             | APIError::InvalidEstimationBlocks

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1,7 +1,7 @@
 use crate::asset_link::{
     AssetLinkAuthorizeParamsWire, AssetLinkAuthorizer, AssetLinkMessageHandler,
     ASSET_LINK_ERROR_DUPLICATE_PAYMENT_HASH, ASSET_LINK_ERROR_INSUFFICIENT_LIQUIDITY,
-    ASSET_LINK_ERROR_UNKNOWN_LINK,
+    ASSET_LINK_ERROR_UNKNOWN_ASSET, ASSET_LINK_ERROR_UNKNOWN_LINK,
 };
 use crate::async_order::{
     AsyncOrderInvoiceProvider, AsyncOrderMessageHandler, AsyncOrderOutboundInvoiceResultWire,
@@ -114,7 +114,7 @@ use std::net::{SocketAddr, TcpListener};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, MutexGuard, RwLock};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock, Weak};
 use std::time::{Duration, SystemTime};
 use time::OffsetDateTime;
 use tokio::runtime::Handle;
@@ -153,7 +153,6 @@ use crate::rgb::{
     check_rgb_proxy_endpoint, get_rgb_channel_info_optional, RgbBumpWalletSource,
     RgbLibWalletWrapper,
 };
-use crate::routes::asset_link_read_record;
 use crate::signer::vls_adapter::{ExternalSignerBackend, VlsSignerAdapter};
 use crate::signer::{
     read_key_source_file, validate_bootstrap_payload, validate_key_source_matches_bootstrap,
@@ -1216,6 +1215,7 @@ impl CustomMsgPeerAccessControl for LiveChannelAccess {
 }
 
 struct NodeAssetLinkAuthorizer {
+    unlocked_state_weak: Weak<UnlockedAppState>,
     channel_manager: Arc<ChannelManager>,
     kv_store: Arc<SyncedKvStore>,
     taker_swaps: Arc<Mutex<SwapMap>>,
@@ -1240,11 +1240,25 @@ impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
             return Err(JsonRpcErrorWire::invalid_params("invalid_expiry_sec"));
         }
 
-        let record =
-            asset_link_read_record(self.kv_store.as_ref(), &params.asset_id).map_err(|_| {
-                JsonRpcErrorWire::application_error(ASSET_LINK_ERROR_UNKNOWN_LINK, "unknown_link")
+        let unlocked_state = self.unlocked_state_weak.upgrade().ok_or_else(|| {
+            JsonRpcErrorWire::internal_error("asset_link_state_unavailable".to_owned())
+        })?;
+        let child_metadata = unlocked_state
+            .rgb_get_asset_metadata(asset_contract_id)
+            .map_err(|_| {
+                JsonRpcErrorWire::application_error(ASSET_LINK_ERROR_UNKNOWN_ASSET, "unknown_link")
             })?;
-        if record.linked_asset_id.as_deref() != Some(params.linked_asset_id.as_str()) {
+        let parent_metadata = unlocked_state
+            .rgb_get_asset_metadata(linked_contract_id)
+            .map_err(|_| {
+                JsonRpcErrorWire::application_error(ASSET_LINK_ERROR_UNKNOWN_ASSET, "unknown_link")
+            })?;
+        if child_metadata.asset_schema != AssetSchema::Ifa
+            || parent_metadata.asset_schema != AssetSchema::Ifa
+            || child_metadata.linked_from_asset_id.as_deref() != Some(params.asset_id.as_str())
+            || parent_metadata.linked_to_asset_id.as_deref()
+                != Some(params.linked_asset_id.as_str())
+        {
             return Err(JsonRpcErrorWire::application_error(
                 ASSET_LINK_ERROR_UNKNOWN_LINK,
                 "unknown_link",
@@ -1252,7 +1266,7 @@ impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
         }
 
         let max_balance = get_max_local_rgb_amount(
-            linked_contract_id,
+            asset_contract_id,
             self.channel_manager.list_channels().iter(),
             self.kv_store.as_ref(),
         );
@@ -1277,8 +1291,8 @@ impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
         let swap_info = SwapInfo {
             qty_from: params.amount,
             qty_to: params.amount,
-            from_asset: Some(linked_contract_id),
-            to_asset: Some(asset_contract_id),
+            from_asset: Some(asset_contract_id),
+            to_asset: Some(linked_contract_id),
             expiry: get_current_timestamp().saturating_add(expiry_sec),
         };
         let mut swap_data = SwapData::create_from_swap_info(&swap_info);
@@ -5433,12 +5447,6 @@ pub(crate) async fn start_ldk(
         external_signer: external_signer.clone(),
     }));
 
-    asset_link_handler.set_authorizer(Arc::new(NodeAssetLinkAuthorizer {
-        channel_manager: Arc::clone(&channel_manager),
-        kv_store: Arc::clone(&kv_store),
-        taker_swaps: Arc::clone(&taker_swaps),
-    }));
-
     let unlocked_state = Arc::new(UnlockedAppState {
         config: static_state.config.clone(),
         channel_manager: Arc::clone(&channel_manager),
@@ -5452,7 +5460,7 @@ pub(crate) async fn start_ldk(
         outbound_payments,
         peer_manager: Arc::clone(&peer_manager),
         async_order_handler,
-        asset_link_handler,
+        asset_link_handler: Arc::clone(&asset_link_handler),
         async_payments_preimage_root,
         kv_store: Arc::clone(&kv_store),
         #[cfg(feature = "vss")]
@@ -5460,7 +5468,7 @@ pub(crate) async fn start_ldk(
         bump_tx_event_handler,
         rgb_wallet_wrapper,
         maker_swaps,
-        taker_swaps,
+        taker_swaps: Arc::clone(&taker_swaps),
         router: Arc::clone(&router),
         output_sweeper: Arc::clone(&output_sweeper),
         channel_ids_map,
@@ -5472,6 +5480,13 @@ pub(crate) async fn start_ldk(
         virtual_channel_session_store,
         next_payment_idx,
     });
+
+    asset_link_handler.set_authorizer(Arc::new(NodeAssetLinkAuthorizer {
+        unlocked_state_weak: Arc::downgrade(&unlocked_state),
+        channel_manager: Arc::clone(&channel_manager),
+        kv_store: Arc::clone(&kv_store),
+        taker_swaps: Arc::clone(&taker_swaps),
+    }));
 
     // Refresh the RGS snapshot on a fixed interval (RGS mode only). The first
     // tick fires immediately, so a freshly unlocked node syncs right away.

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -164,11 +164,11 @@ use crate::signer::{
 };
 use crate::swap::{SwapData, SwapInfo};
 use crate::utils::{
-    check_port_is_available, connect_peer_if_necessary, do_connect_peer, get_current_timestamp,
-    get_max_local_rgb_amount, hex_str, validate_and_parse_payment_hash,
-    validate_and_parse_payment_preimage, AppState, StaticState, UnlockedAppState,
-    ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST, ELECTRUM_URL_SIGNET, ELECTRUM_URL_TESTNET,
-    ELECTRUM_URL_TESTNET4, PROXY_ENDPOINT_LOCAL, PROXY_ENDPOINT_PUBLIC,
+    check_port_is_available, connect_peer_if_necessary, description_hash_from_invoice,
+    do_connect_peer, get_current_timestamp, get_max_local_rgb_amount, hex_str,
+    validate_and_parse_payment_hash, validate_and_parse_payment_preimage, AppState, StaticState,
+    UnlockedAppState, ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST, ELECTRUM_URL_SIGNET,
+    ELECTRUM_URL_TESTNET, ELECTRUM_URL_TESTNET4, PROXY_ENDPOINT_LOCAL, PROXY_ENDPOINT_PUBLIC,
 };
 
 const VIRTUAL_CHANNEL_DOMAIN_SEPARATOR: &[u8] = b"rln_virtual_channels_v0";
@@ -1494,7 +1494,7 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
                 invoice_type: Some(InvoiceType::Hodl {
                     async_payment_recipient: true,
                 }),
-                description_hash: crate::routes::description_hash_from_invoice(&invoice),
+                description_hash: description_hash_from_invoice(&invoice),
                 payment_idx: None,
                 async_hash_index: self.external_signer_mode.then_some(hash_index),
                 async_host_node_id: self.external_signer_mode.then_some(sender_node_id),

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1855,7 +1855,7 @@ async fn handle_ldk_events(
                         &temporary_channel_id,
                         unlocked_state.kv_store.as_ref(),
                     );
-                    let channel_rgb_amount = rgb_info.local_rgb_amount;
+                    let channel_rgb_amount = rgb_info.local_rgb_amount + rgb_info.remote_rgb_amount;
                     let asset_id = rgb_info.contract_id.to_string();
                     let assignment = match rgb_info.schema {
                         AssetSchema::Nia | AssetSchema::Cfa | AssetSchema::Ifa => {

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -101,7 +101,7 @@ use rgb_lib::{
         Wallet as RgbLibWallet, WalletData, WitnessData,
     },
     AssetSchema, Assignment, BitcoinNetwork, ConsignmentExt, ContractId, Error as RgbLibError,
-    Fascia, FileContent, RgbTransfer, RgbTxid, WitnessOrd,
+    Fascia, FileContent, RgbTransfer, RgbTxid, TransferStatus, WitnessOrd,
 };
 use std::collections::HashMap;
 #[cfg(feature = "vss")]
@@ -1292,13 +1292,37 @@ impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
             && asset_metadata.linked_from_asset_id.as_deref()
                 == Some(params.linked_asset_id.as_str());
 
-        let contracts_are_linked =
-            asset_is_parent_of_linked_asset || linked_asset_is_parent_of_asset;
+        let parent_contract_id = if asset_is_parent_of_linked_asset {
+            Some(asset_contract_id)
+        } else if linked_asset_is_parent_of_asset {
+            Some(linked_contract_id)
+        } else {
+            None
+        };
+
+        let Some(parent_contract_id) = parent_contract_id else {
+            return Err(JsonRpcErrorWire::application_error(
+                ASSET_LINK_ERROR_UNKNOWN_LINK,
+                "unknown_link",
+            ));
+        };
 
         if asset_metadata.asset_schema != AssetSchema::Ifa
             || linked_asset_metadata.asset_schema != AssetSchema::Ifa
-            || !contracts_are_linked
         {
+            return Err(JsonRpcErrorWire::application_error(
+                ASSET_LINK_ERROR_UNKNOWN_LINK,
+                "unknown_link",
+            ));
+        }
+
+        let link_is_settled = unlocked_state
+            .rgb_find_link_transfer(parent_contract_id)
+            .map_err(|_| {
+                JsonRpcErrorWire::application_error(ASSET_LINK_ERROR_UNKNOWN_LINK, "unknown_link")
+            })?
+            .is_some_and(|transfer| transfer.status == TransferStatus::Settled);
+        if !link_is_settled {
             return Err(JsonRpcErrorWire::application_error(
                 ASSET_LINK_ERROR_UNKNOWN_LINK,
                 "unknown_link",
@@ -1332,13 +1356,18 @@ impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
         let expiry_sec = params
             .expiry_sec
             .min(ASSET_LINK_SWAP_AUTHORIZATION_MAX_EXPIRY_SECS);
+        let one_to_one_redemption_amount = params.amount;
         let swap_info = SwapInfo {
-            qty_from: params.amount,
-            qty_to: params.amount,
+            qty_from: one_to_one_redemption_amount,
+            qty_to: one_to_one_redemption_amount,
             from_asset: Some(asset_contract_id),
             to_asset: Some(linked_contract_id),
             expiry: authorization_time.saturating_add(expiry_sec),
         };
+        assert_eq!(
+            swap_info.qty_from, swap_info.qty_to,
+            "linked-asset redemption must remain 1:1"
+        );
         let mut swap_data = SwapData::create_from_swap_info(&swap_info);
         swap_data.authorized_peer = Some(sender_node_id);
         taker_swaps.swaps.insert(payment_hash, swap_data);

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -136,6 +136,7 @@ const OUTBOUND_PAYMENTS_KEY: &str = "outbound_payments";
 const CHANNEL_IDS_KEY: &str = "channel_ids";
 const MAKER_SWAPS_KEY: &str = "maker_swaps";
 const TAKER_SWAPS_KEY: &str = "taker_swaps";
+const ASSET_LINK_SWAP_AUTHORIZATION_MAX_EXPIRY_SECS: u64 = 24 * 60 * 60;
 const OUTPUT_SPENDER_TXES_KEY: &str = "output_spender_txes";
 const PSBT_NAMESPACE: &str = "psbt";
 const PENDING_FUNDING_NAMESPACE: &str = "pending_funding";
@@ -457,12 +458,26 @@ impl UnlockedAppState {
         self.save_taker_swaps(taker_swaps);
     }
 
+    pub(crate) fn update_taker_swap_pending_intercept(
+        &self,
+        payment_hash: &PaymentHash,
+        intercept_id: channelmanager::InterceptId,
+    ) {
+        let mut taker_swaps = self.get_taker_swaps();
+        let taker_swap = taker_swaps.swaps.get_mut(payment_hash).unwrap();
+        taker_swap.status = SwapStatus::Pending;
+        taker_swap.initiated_at = Some(get_current_timestamp());
+        taker_swap.pending_intercept_id = Some(intercept_id);
+        self.save_taker_swaps(taker_swaps);
+    }
+
     pub(crate) fn update_taker_swap_status(&self, payment_hash: &PaymentHash, status: SwapStatus) {
         let mut taker_swaps = self.get_taker_swaps();
         let taker_swap = taker_swaps.swaps.get_mut(payment_hash).unwrap();
         match &status {
             SwapStatus::Succeeded | SwapStatus::Failed | SwapStatus::Expired => {
-                taker_swap.completed_at = Some(get_current_timestamp())
+                taker_swap.completed_at = Some(get_current_timestamp());
+                taker_swap.pending_intercept_id = None;
             }
             SwapStatus::Pending => taker_swap.initiated_at = Some(get_current_timestamp()),
             SwapStatus::Waiting => panic!("this doesn't make sense: swap starts in Waiting status"),
@@ -1258,16 +1273,19 @@ impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
             ));
         }
 
+        let expiry_sec = params
+            .expiry_sec
+            .min(ASSET_LINK_SWAP_AUTHORIZATION_MAX_EXPIRY_SECS);
         let swap_info = SwapInfo {
             qty_from: params.amount,
             qty_to: params.amount,
             from_asset: Some(linked_contract_id),
             to_asset: Some(asset_contract_id),
-            expiry: get_current_timestamp() + params.expiry_sec,
+            expiry: get_current_timestamp().saturating_add(expiry_sec),
         };
-        taker_swaps
-            .swaps
-            .insert(payment_hash, SwapData::create_from_swap_info(&swap_info));
+        let mut swap_data = SwapData::create_from_swap_info(&swap_info);
+        swap_data.authorized_peer = Some(sender_node_id);
+        taker_swaps.swaps.insert(payment_hash, swap_data);
         self.kv_store
             .write("", "", TAKER_SWAPS_KEY, taker_swaps.encode())
             .map_err(|e| {
@@ -3139,12 +3157,18 @@ async fn handle_ldk_events(
             requested_next_hop_scid,
             prev_outbound_scid_alias,
         } => {
-            if !is_swap {
-                tracing::warn!("Intercepted an HTLC that's not related to a swap");
-                unlocked_state
+            let reject_intercept = |reason: &str| {
+                if let Err(e) = unlocked_state
                     .channel_manager
                     .fail_intercepted_htlc(intercept_id)
-                    .unwrap();
+                {
+                    tracing::debug!("could not fail intercepted HTLC ({reason}): {e:?}");
+                }
+            };
+
+            if !is_swap {
+                tracing::warn!("Intercepted an HTLC that's not related to a swap");
+                reject_intercept("not a swap");
                 return Ok(());
             }
 
@@ -3159,59 +3183,109 @@ async fn handle_ldk_events(
                     })
             };
 
-            let inbound_channel = unlocked_state
+            let Some(inbound_channel) = unlocked_state
                 .channel_manager
                 .list_channels()
                 .into_iter()
                 .find(|details| details.outbound_scid_alias == Some(prev_outbound_scid_alias))
-                .expect("Should always be a valid channel");
-            let outbound_channel = unlocked_state
+            else {
+                tracing::error!(
+                    "ERROR: no inbound channel matches the intercepted HTLC prev scid alias {prev_outbound_scid_alias}, rejecting it"
+                );
+                reject_intercept("no inbound channel");
+                return Ok(());
+            };
+            let Some(outbound_channel) = unlocked_state
                 .channel_manager
                 .list_channels()
                 .into_iter()
                 .find(|details| {
                     details.short_channel_id == Some(requested_next_hop_scid)
                         || details.outbound_scid_alias == Some(requested_next_hop_scid)
-                        || details.inbound_scid_alias == Some(requested_next_hop_scid)
                 })
-                .expect("Should always be a valid channel");
+            else {
+                tracing::error!(
+                    "ERROR: no outbound channel matches the intercepted HTLC next hop scid {requested_next_hop_scid}, rejecting it"
+                );
+                reject_intercept("no outbound channel");
+                return Ok(());
+            };
 
             let inbound_rgb_info = get_rgb_info(&inbound_channel.channel_id);
             let outbound_rgb_info = get_rgb_info(&outbound_channel.channel_id);
 
             tracing::debug!("EVENT: Requested swap with params inbound_msat={} outbound_msat={} inbound_rgb={:?} outbound_rgb={:?} inbound_contract_id={:?}, outbound_contract_id={:?}", inbound_amount_msat, expected_outbound_amount_msat, inbound_rgb_amount, expected_outbound_rgb_payment.map(|(_, a)| a), inbound_rgb_info.map(|i| i.0), expected_outbound_rgb_payment.map(|(c, _)| c));
 
-            let swaps_lock = unlocked_state.taker_swaps.lock().unwrap();
-            let whitelist_swap = match swaps_lock.swaps.get(&payment_hash) {
-                None => {
-                    tracing::error!("ERROR: rejecting non-whitelisted swap");
-                    unlocked_state
-                        .channel_manager
-                        .fail_intercepted_htlc(intercept_id)
-                        .unwrap();
-                    return Ok(());
+            let (whitelist_swap_info, whitelist_swap_status, pending_intercept_id, authorized_peer) = {
+                let swaps_lock = unlocked_state.taker_swaps.lock().unwrap();
+                match swaps_lock.swaps.get(&payment_hash) {
+                    None => {
+                        tracing::error!("ERROR: rejecting non-whitelisted swap");
+                        reject_intercept("non-whitelisted swap");
+                        return Ok(());
+                    }
+                    Some(x) => (
+                        x.swap_info.clone(),
+                        x.status,
+                        x.pending_intercept_id,
+                        x.authorized_peer,
+                    ),
                 }
-                Some(x) => x,
             };
 
+            match whitelist_swap_status {
+                SwapStatus::Waiting => {}
+                SwapStatus::Pending if pending_intercept_id == Some(intercept_id) => {}
+                _ => {
+                    tracing::error!(
+                        "ERROR: swap whitelist entry is not in a forwardable state (status {whitelist_swap_status:?}), rejecting it"
+                    );
+                    reject_intercept(&format!(
+                        "whitelist entry not forwardable (status {whitelist_swap_status:?})"
+                    ));
+                    return Ok(());
+                }
+            }
+
+            if let Some(authorized_peer) = authorized_peer {
+                if inbound_channel.counterparty.node_id != authorized_peer {
+                    tracing::error!(
+                        "ERROR: swap whitelist entry was authorized for peer {}, but intercepted HTLC came from {}, rejecting it",
+                        authorized_peer,
+                        inbound_channel.counterparty.node_id
+                    );
+                    reject_intercept("unauthorized peer");
+                    return Ok(());
+                }
+            }
+
+            if get_current_timestamp() > whitelist_swap_info.expiry {
+                tracing::error!("ERROR: swap whitelist entry expired, rejecting it");
+                unlocked_state.update_taker_swap_status(&payment_hash, SwapStatus::Expired);
+                reject_intercept("whitelist entry expired");
+                return Ok(());
+            }
+
             let mut fail = false;
-            if whitelist_swap.swap_info.is_from_btc() {
+            if whitelist_swap_info.is_from_btc() {
                 let net_msat_diff = expected_outbound_amount_msat.checked_sub(inbound_amount_msat);
 
-                if inbound_rgb_amount != Some(whitelist_swap.swap_info.qty_to)
-                    || inbound_rgb_info.map(|x| x.0) != whitelist_swap.swap_info.to_asset
-                    || net_msat_diff != Some(whitelist_swap.swap_info.qty_from)
+                if inbound_rgb_amount != Some(whitelist_swap_info.qty_to)
+                    || inbound_rgb_info.map(|x| x.0) != whitelist_swap_info.to_asset
+                    || net_msat_diff != Some(whitelist_swap_info.qty_from)
                 {
                     fail = true;
                 }
-            } else if whitelist_swap.swap_info.is_to_btc() {
+            } else if whitelist_swap_info.is_to_btc() {
                 let net_msat_diff =
                     inbound_amount_msat.saturating_sub(expected_outbound_amount_msat);
 
-                if expected_outbound_rgb_payment.map(|(_, a)| a)
-                    != Some(whitelist_swap.swap_info.qty_from)
-                    || outbound_rgb_info.map(|x| x.0) != whitelist_swap.swap_info.from_asset
-                    || net_msat_diff != whitelist_swap.swap_info.qty_to
+                if expected_outbound_rgb_payment
+                    != whitelist_swap_info
+                        .from_asset
+                        .map(|asset| (asset, whitelist_swap_info.qty_from))
+                    || outbound_rgb_info.map(|x| x.0) != whitelist_swap_info.from_asset
+                    || net_msat_diff != whitelist_swap_info.qty_to
                 {
                     fail = true;
                 }
@@ -3219,41 +3293,39 @@ async fn handle_ldk_events(
                 let net_msat_diff = inbound_amount_msat.checked_sub(expected_outbound_amount_msat);
 
                 if net_msat_diff != Some(0)
-                    || expected_outbound_rgb_payment.map(|(_, a)| a)
-                        != Some(whitelist_swap.swap_info.qty_from)
-                    || outbound_rgb_info.map(|x| x.0) != whitelist_swap.swap_info.from_asset
-                    || inbound_rgb_amount != Some(whitelist_swap.swap_info.qty_to)
-                    || inbound_rgb_info.map(|x| x.0) != whitelist_swap.swap_info.to_asset
+                    || expected_outbound_rgb_payment
+                        != whitelist_swap_info
+                            .from_asset
+                            .map(|asset| (asset, whitelist_swap_info.qty_from))
+                    || outbound_rgb_info.map(|x| x.0) != whitelist_swap_info.from_asset
+                    || inbound_rgb_amount != Some(whitelist_swap_info.qty_to)
+                    || inbound_rgb_info.map(|x| x.0) != whitelist_swap_info.to_asset
                 {
                     fail = true;
                 }
             }
 
-            drop(swaps_lock);
-
             if fail {
                 tracing::error!("ERROR: swap doesn't match the whitelisted info, rejecting it");
                 unlocked_state.update_taker_swap_status(&payment_hash, SwapStatus::Failed);
-                unlocked_state
-                    .channel_manager
-                    .fail_intercepted_htlc(intercept_id)
-                    .unwrap();
+                reject_intercept("whitelist mismatch");
                 return Ok(());
             }
 
             tracing::debug!("Swap is whitelisted, forwarding the htlc...");
-            unlocked_state.update_taker_swap_status(&payment_hash, SwapStatus::Pending);
+            unlocked_state.update_taker_swap_pending_intercept(&payment_hash, intercept_id);
 
-            unlocked_state
-                .channel_manager
-                .forward_intercepted_htlc(
-                    intercept_id,
-                    channelmanager::NextHopForward::ShortChannelId(requested_next_hop_scid),
-                    outbound_channel.counterparty.node_id,
-                    expected_outbound_amount_msat,
-                    expected_outbound_rgb_payment,
-                )
-                .expect("Forward should be valid");
+            if let Err(e) = unlocked_state.channel_manager.forward_intercepted_htlc(
+                intercept_id,
+                channelmanager::NextHopForward::ShortChannelId(requested_next_hop_scid),
+                outbound_channel.counterparty.node_id,
+                expected_outbound_amount_msat,
+                expected_outbound_rgb_payment,
+            ) {
+                tracing::error!("ERROR: failed to forward whitelisted swap HTLC: {e:?}");
+                unlocked_state.update_taker_swap_status(&payment_hash, SwapStatus::Failed);
+                reject_intercept("forward failed");
+            }
         }
         Event::OnionMessageIntercepted { .. } => {
             // We don't use the onion message interception feature, so this event should never be

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1244,9 +1244,7 @@ impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
             asset_link_read_record(self.kv_store.as_ref(), &params.asset_id).map_err(|_| {
                 JsonRpcErrorWire::application_error(ASSET_LINK_ERROR_UNKNOWN_LINK, "unknown_link")
             })?;
-        if record.linked_asset_id.as_deref() != Some(params.linked_asset_id.as_str())
-            || record.signature.is_none()
-        {
+        if record.linked_asset_id.as_deref() != Some(params.linked_asset_id.as_str()) {
             return Err(JsonRpcErrorWire::application_error(
                 ASSET_LINK_ERROR_UNKNOWN_LINK,
                 "unknown_link",

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1,9 +1,14 @@
-use crate::async_order::{
-    AsyncOrderAccessControl, AsyncOrderInvoiceProvider, AsyncOrderMessageHandler,
-    AsyncOrderOutboundInvoiceResultWire, AsyncOrderRequestInvoiceParamsWire,
-    AsyncPaymentsPreimageRoot, JsonRpcErrorWire, ASYNC_ERROR_INVOICE_HASH_MISMATCH,
-    ASYNC_ERROR_STALE_FLOW,
+use crate::asset_link::{
+    AssetLinkAuthorizeParamsWire, AssetLinkAuthorizer, AssetLinkMessageHandler,
+    ASSET_LINK_ERROR_DUPLICATE_PAYMENT_HASH, ASSET_LINK_ERROR_INSUFFICIENT_LIQUIDITY,
+    ASSET_LINK_ERROR_UNKNOWN_LINK,
 };
+use crate::async_order::{
+    AsyncOrderInvoiceProvider, AsyncOrderMessageHandler, AsyncOrderOutboundInvoiceResultWire,
+    AsyncOrderRequestInvoiceParamsWire, AsyncPaymentsPreimageRoot,
+    ASYNC_ERROR_INVOICE_HASH_MISMATCH, ASYNC_ERROR_STALE_FLOW,
+};
+use crate::custom_msg_rpc::{CustomMessenger, CustomMsgPeerAccessControl, JsonRpcErrorWire};
 use crate::synced_kv_store::SyncedKvStore;
 use amplify::{map, s};
 use bitcoin::blockdata::locktime::absolute::LockTime;
@@ -147,6 +152,7 @@ use crate::rgb::{
     check_rgb_proxy_endpoint, get_rgb_channel_info_optional, RgbBumpWalletSource,
     RgbLibWalletWrapper,
 };
+use crate::routes::asset_link_read_record;
 use crate::signer::vls_adapter::{ExternalSignerBackend, VlsSignerAdapter};
 use crate::signer::{
     read_key_source_file, validate_bootstrap_payload, validate_key_source_matches_bootstrap,
@@ -156,12 +162,13 @@ use crate::signer::{
     ActiveSignerRef, DynRlnChannelSigner, DynRlnSigner, LightningEntropySource, RlnKeysInterface,
     SystemEntropySource,
 };
-use crate::swap::SwapData;
+use crate::swap::{SwapData, SwapInfo};
 use crate::utils::{
     check_port_is_available, connect_peer_if_necessary, do_connect_peer, get_current_timestamp,
-    hex_str, validate_and_parse_payment_hash, validate_and_parse_payment_preimage, AppState,
-    StaticState, UnlockedAppState, ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST, ELECTRUM_URL_SIGNET,
-    ELECTRUM_URL_TESTNET, ELECTRUM_URL_TESTNET4, PROXY_ENDPOINT_LOCAL, PROXY_ENDPOINT_PUBLIC,
+    get_max_local_rgb_amount, hex_str, validate_and_parse_payment_hash,
+    validate_and_parse_payment_preimage, AppState, StaticState, UnlockedAppState,
+    ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST, ELECTRUM_URL_SIGNET, ELECTRUM_URL_TESTNET,
+    ELECTRUM_URL_TESTNET4, PROXY_ENDPOINT_LOCAL, PROXY_ENDPOINT_PUBLIC,
 };
 
 const VIRTUAL_CHANNEL_DOMAIN_SEPARATOR: &[u8] = b"rln_virtual_channels_v0";
@@ -1051,7 +1058,7 @@ pub(crate) type PeerManager = LdkPeerManager<
     Arc<RoutingMessageHandler>,
     Arc<OnionMessenger>,
     Arc<FilesystemLogger>,
-    Arc<AsyncOrderMessageHandler>,
+    Arc<CustomMessenger>,
     ActiveSignerRef,
     Arc<ChainMonitor>,
 >;
@@ -1187,9 +1194,95 @@ impl LiveChannelAccess {
     }
 }
 
-impl AsyncOrderAccessControl for LiveChannelAccess {
+impl CustomMsgPeerAccessControl for LiveChannelAccess {
     fn allows_peer(&self, peer: &PublicKey) -> bool {
         self.lookup.peer_has_live_channel(peer)
+    }
+}
+
+struct NodeAssetLinkAuthorizer {
+    channel_manager: Arc<ChannelManager>,
+    kv_store: Arc<SyncedKvStore>,
+    taker_swaps: Arc<Mutex<SwapMap>>,
+}
+
+impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
+    fn authorize_swap(
+        &self,
+        sender_node_id: PublicKey,
+        params: &AssetLinkAuthorizeParamsWire,
+    ) -> Result<(), JsonRpcErrorWire> {
+        let payment_hash = validate_and_parse_payment_hash(&params.payment_hash)
+            .map_err(|_| JsonRpcErrorWire::invalid_params("invalid_payment_hash"))?;
+        let asset_contract_id = ContractId::from_str(&params.asset_id)
+            .map_err(|_| JsonRpcErrorWire::invalid_params("invalid_asset_id"))?;
+        let linked_contract_id = ContractId::from_str(&params.linked_asset_id)
+            .map_err(|_| JsonRpcErrorWire::invalid_params("invalid_linked_asset_id"))?;
+        if params.amount == 0 {
+            return Err(JsonRpcErrorWire::invalid_params("invalid_amount"));
+        }
+        if params.expiry_sec == 0 {
+            return Err(JsonRpcErrorWire::invalid_params("invalid_expiry_sec"));
+        }
+
+        let record =
+            asset_link_read_record(self.kv_store.as_ref(), &params.asset_id).map_err(|_| {
+                JsonRpcErrorWire::application_error(ASSET_LINK_ERROR_UNKNOWN_LINK, "unknown_link")
+            })?;
+        if record.linked_asset_id.as_deref() != Some(params.linked_asset_id.as_str())
+            || record.signature.is_none()
+        {
+            return Err(JsonRpcErrorWire::application_error(
+                ASSET_LINK_ERROR_UNKNOWN_LINK,
+                "unknown_link",
+            ));
+        }
+
+        let max_balance = get_max_local_rgb_amount(
+            linked_contract_id,
+            self.channel_manager.list_channels().iter(),
+            self.kv_store.as_ref(),
+        );
+        if params.amount > max_balance {
+            return Err(JsonRpcErrorWire::application_error(
+                ASSET_LINK_ERROR_INSUFFICIENT_LIQUIDITY,
+                "insufficient_liquidity",
+            ));
+        }
+
+        let mut taker_swaps = self.taker_swaps.lock().unwrap();
+        if taker_swaps.swaps.contains_key(&payment_hash) {
+            return Err(JsonRpcErrorWire::application_error(
+                ASSET_LINK_ERROR_DUPLICATE_PAYMENT_HASH,
+                "duplicate_payment_hash",
+            ));
+        }
+
+        let swap_info = SwapInfo {
+            qty_from: params.amount,
+            qty_to: params.amount,
+            from_asset: Some(linked_contract_id),
+            to_asset: Some(asset_contract_id),
+            expiry: get_current_timestamp() + params.expiry_sec,
+        };
+        taker_swaps
+            .swaps
+            .insert(payment_hash, SwapData::create_from_swap_info(&swap_info));
+        self.kv_store
+            .write("", "", TAKER_SWAPS_KEY, taker_swaps.encode())
+            .map_err(|e| {
+                JsonRpcErrorWire::internal_error(format!("taker_swaps_write_failed: {e}"))
+            })?;
+
+        tracing::info!(
+            peer = %sender_node_id,
+            payment_hash = %hex_str(&payment_hash.0),
+            asset_id = %params.asset_id,
+            linked_asset_id = %params.linked_asset_id,
+            amount = params.amount,
+            "authorized linked-asset payment"
+        );
+        Ok(())
     }
 }
 
@@ -3076,7 +3169,11 @@ async fn handle_ldk_events(
                 .channel_manager
                 .list_channels()
                 .into_iter()
-                .find(|details| details.short_channel_id == Some(requested_next_hop_scid))
+                .find(|details| {
+                    details.short_channel_id == Some(requested_next_hop_scid)
+                        || details.outbound_scid_alias == Some(requested_next_hop_scid)
+                        || details.inbound_scid_alias == Some(requested_next_hop_scid)
+                })
                 .expect("Should always be a valid channel");
 
             let inbound_rgb_info = get_rgb_info(&inbound_channel.channel_id);
@@ -4909,14 +5006,19 @@ pub(crate) async fn start_ldk(
     let live_channel_access = Arc::new(LiveChannelAccess::new(channel_manager.clone()));
     let async_order_handler = match static_state.lsp_base_url.as_ref() {
         Some(lsp_base_url) => Arc::new(AsyncOrderMessageHandler::new_with_lsp_client(
-            live_channel_access,
+            live_channel_access.clone(),
             lsp_base_url.clone(),
             static_state.lsp_bearer_token.clone(),
             Handle::current(),
             static_state.config.lsp.request_timeout_secs,
         )),
-        None => Arc::new(AsyncOrderMessageHandler::new(live_channel_access)),
+        None => Arc::new(AsyncOrderMessageHandler::new(live_channel_access.clone())),
     };
+    let asset_link_handler = Arc::new(AssetLinkMessageHandler::new(live_channel_access));
+    let custom_messenger = Arc::new(CustomMessenger {
+        async_order: Arc::clone(&async_order_handler),
+        asset_link: Arc::clone(&asset_link_handler),
+    });
     let async_payments_preimage_root = Arc::new(
         match internal_mnemonic.as_ref() {
             Some(mnemonic) => AsyncPaymentsPreimageRoot::build_from_mnemonic(
@@ -4943,7 +5045,7 @@ pub(crate) async fn start_ldk(
         chan_handler: channel_manager.clone(),
         route_handler: Arc::clone(&route_handler),
         onion_message_handler: onion_messenger.clone(),
-        custom_message_handler: Arc::clone(&async_order_handler),
+        custom_message_handler: Arc::clone(&custom_messenger),
         send_only_message_handler: Arc::clone(&chain_monitor),
     };
     let peer_manager: Arc<PeerManager> = Arc::new(PeerManager::new(
@@ -5261,6 +5363,12 @@ pub(crate) async fn start_ldk(
         external_signer: external_signer.clone(),
     }));
 
+    asset_link_handler.set_authorizer(Arc::new(NodeAssetLinkAuthorizer {
+        channel_manager: Arc::clone(&channel_manager),
+        kv_store: Arc::clone(&kv_store),
+        taker_swaps: Arc::clone(&taker_swaps),
+    }));
+
     let unlocked_state = Arc::new(UnlockedAppState {
         config: static_state.config.clone(),
         channel_manager: Arc::clone(&channel_manager),
@@ -5274,6 +5382,7 @@ pub(crate) async fn start_ldk(
         outbound_payments,
         peer_manager: Arc::clone(&peer_manager),
         async_order_handler,
+        asset_link_handler,
         async_payments_preimage_root,
         kv_store: Arc::clone(&kv_store),
         #[cfg(feature = "vss")]

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -1243,21 +1243,33 @@ impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
         let unlocked_state = self.unlocked_state_weak.upgrade().ok_or_else(|| {
             JsonRpcErrorWire::internal_error("asset_link_state_unavailable".to_owned())
         })?;
-        let child_metadata = unlocked_state
+        let asset_metadata = unlocked_state
             .rgb_get_asset_metadata(asset_contract_id)
             .map_err(|_| {
                 JsonRpcErrorWire::application_error(ASSET_LINK_ERROR_UNKNOWN_ASSET, "unknown_link")
             })?;
-        let parent_metadata = unlocked_state
+        let linked_asset_metadata = unlocked_state
             .rgb_get_asset_metadata(linked_contract_id)
             .map_err(|_| {
                 JsonRpcErrorWire::application_error(ASSET_LINK_ERROR_UNKNOWN_ASSET, "unknown_link")
             })?;
-        if child_metadata.asset_schema != AssetSchema::Ifa
-            || parent_metadata.asset_schema != AssetSchema::Ifa
-            || child_metadata.linked_from_asset_id.as_deref() != Some(params.asset_id.as_str())
-            || parent_metadata.linked_to_asset_id.as_deref()
-                != Some(params.linked_asset_id.as_str())
+
+        let asset_is_parent_of_linked_asset = asset_metadata.linked_to_asset_id.as_deref()
+            == Some(params.linked_asset_id.as_str())
+            && linked_asset_metadata.linked_from_asset_id.as_deref()
+                == Some(params.asset_id.as_str());
+
+        let linked_asset_is_parent_of_asset = linked_asset_metadata.linked_to_asset_id.as_deref()
+            == Some(params.asset_id.as_str())
+            && asset_metadata.linked_from_asset_id.as_deref()
+                == Some(params.linked_asset_id.as_str());
+
+        let contracts_are_linked =
+            asset_is_parent_of_linked_asset || linked_asset_is_parent_of_asset;
+
+        if asset_metadata.asset_schema != AssetSchema::Ifa
+            || linked_asset_metadata.asset_schema != AssetSchema::Ifa
+            || !contracts_are_linked
         {
             return Err(JsonRpcErrorWire::application_error(
                 ASSET_LINK_ERROR_UNKNOWN_LINK,

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -125,7 +125,9 @@ use tokio::task::JoinHandle;
 use crate::async_kv_store::RemoteFirstKvStore;
 use crate::bitcoind::BitcoindClient;
 use crate::chain_backend::ChainBackend;
-use crate::core_types::{HTLCStatus, NodeKeySource, SwapStatus, UnlockRequest};
+use crate::core_types::{
+    HTLCStatus, NodeKeySource, SwapStatus, UnlockRequest, PENDING_SWAP_TIMEOUT_SECS,
+};
 use crate::database::RlnDatabase;
 use crate::disk::{self, FilesystemLogger};
 use crate::gossip::{GossipSource, GossipSourceConfig};
@@ -1221,6 +1223,32 @@ struct NodeAssetLinkAuthorizer {
     taker_swaps: Arc<Mutex<SwapMap>>,
 }
 
+fn reserved_outbound_rgb_amount(
+    taker_swaps: &SwapMap,
+    outbound_contract_id: ContractId,
+    current_time: u64,
+) -> u64 {
+    taker_swaps
+        .swaps
+        .values()
+        .filter(|swap| {
+            if swap.swap_info.from_asset != Some(outbound_contract_id) {
+                return false;
+            }
+
+            match swap.status {
+                SwapStatus::Waiting => current_time <= swap.swap_info.expiry,
+                SwapStatus::Pending => swap.initiated_at.is_none_or(|initiated_at| {
+                    current_time <= initiated_at.saturating_add(PENDING_SWAP_TIMEOUT_SECS)
+                }),
+                SwapStatus::Succeeded | SwapStatus::Expired | SwapStatus::Failed => false,
+            }
+        })
+        .fold(0, |reserved_amount, swap| {
+            reserved_amount.saturating_add(swap.swap_info.qty_from)
+        })
+}
+
 impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
     fn authorize_swap(
         &self,
@@ -1282,18 +1310,22 @@ impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
             self.channel_manager.list_channels().iter(),
             self.kv_store.as_ref(),
         );
-        if params.amount > max_balance {
-            return Err(JsonRpcErrorWire::application_error(
-                ASSET_LINK_ERROR_INSUFFICIENT_LIQUIDITY,
-                "insufficient_liquidity",
-            ));
-        }
-
         let mut taker_swaps = self.taker_swaps.lock().unwrap();
         if taker_swaps.swaps.contains_key(&payment_hash) {
             return Err(JsonRpcErrorWire::application_error(
                 ASSET_LINK_ERROR_DUPLICATE_PAYMENT_HASH,
                 "duplicate_payment_hash",
+            ));
+        }
+
+        let authorization_time = get_current_timestamp();
+        let reserved_amount =
+            reserved_outbound_rgb_amount(&taker_swaps, asset_contract_id, authorization_time);
+        let available_amount = max_balance.saturating_sub(reserved_amount);
+        if params.amount > available_amount {
+            return Err(JsonRpcErrorWire::application_error(
+                ASSET_LINK_ERROR_INSUFFICIENT_LIQUIDITY,
+                "insufficient_liquidity",
             ));
         }
 
@@ -1305,16 +1337,20 @@ impl AssetLinkAuthorizer for NodeAssetLinkAuthorizer {
             qty_to: params.amount,
             from_asset: Some(asset_contract_id),
             to_asset: Some(linked_contract_id),
-            expiry: get_current_timestamp().saturating_add(expiry_sec),
+            expiry: authorization_time.saturating_add(expiry_sec),
         };
         let mut swap_data = SwapData::create_from_swap_info(&swap_info);
         swap_data.authorized_peer = Some(sender_node_id);
         taker_swaps.swaps.insert(payment_hash, swap_data);
-        self.kv_store
+        if let Err(e) = self
+            .kv_store
             .write("", "", TAKER_SWAPS_KEY, taker_swaps.encode())
-            .map_err(|e| {
-                JsonRpcErrorWire::internal_error(format!("taker_swaps_write_failed: {e}"))
-            })?;
+        {
+            taker_swaps.swaps.remove(&payment_hash);
+            return Err(JsonRpcErrorWire::internal_error(format!(
+                "taker_swaps_write_failed: {e}"
+            )));
+        }
 
         tracing::info!(
             peer = %sender_node_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod apay_merkle;
 mod args;
+mod asset_link;
 #[cfg(feature = "vss")]
 mod async_kv_store;
 mod async_order;
@@ -13,6 +14,7 @@ mod bitcoind;
 mod chain_backend;
 mod config;
 mod core_types;
+mod custom_msg_rpc;
 mod database;
 mod disk;
 mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ use crate::ldk::stop_ldk;
 #[cfg(feature = "remote-signer")]
 use crate::routes::init_external_signer;
 use crate::routes::{
-    address, asset_balance, asset_link_create, asset_metadata, async_order_new,
+    address, asset_balance, asset_link, asset_metadata, async_order_new,
     async_order_outbound_invoice, backup, btc_balance, cancel_hodl_invoice, change_password,
     check_indexer_url, check_proxy_endpoint, claim_hodl_invoice, close_channel, connect_peer,
     create_utxos, decode_ln_invoice, decode_rgb_invoice, decode_swapstring, disconnect_peer,
@@ -135,7 +135,7 @@ pub(crate) async fn app(args: UserArgs) -> Result<(Router, Arc<AppState>), AppEr
         .route("/apay/new", post(async_order_new))
         .route("/apay/outboundinvoice", post(async_order_outbound_invoice))
         .route("/assetbalance", post(asset_balance))
-        .route("/assetlink/create", post(asset_link_create))
+        .route("/assetlink", post(asset_link))
         .route("/assetmetadata", post(asset_metadata))
         .route("/backup", post(backup))
         .route("/btcbalance", post(btc_balance))

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,17 +63,17 @@ use crate::ldk::stop_ldk;
 #[cfg(feature = "remote-signer")]
 use crate::routes::init_external_signer;
 use crate::routes::{
-    address, asset_balance, asset_metadata, async_order_new, async_order_outbound_invoice, backup,
-    btc_balance, cancel_hodl_invoice, change_password, check_indexer_url, check_proxy_endpoint,
-    claim_hodl_invoice, close_channel, connect_peer, create_utxos, decode_ln_invoice,
-    decode_rgb_invoice, decode_swapstring, disconnect_peer, estimate_fee, fail_transfers,
-    get_asset_media, get_channel_id, get_payment, get_swap, inflate, init, invoice_status,
-    issue_asset_cfa, issue_asset_ifa, issue_asset_nia, issue_asset_uda, keysend, list_assets,
-    list_channels, list_payments, list_peers, list_swaps, list_transactions, list_transfers,
-    list_unspents, ln_invoice, lock, maker_execute, maker_init, network_info, node_info,
-    open_channel, post_asset_media, refresh_transfers, restore, revoke_token, rgb_invoice,
-    rotate_address, send_btc, send_onion_message, send_payment, send_rgb, shutdown, sign_message,
-    sync, taker, unlock,
+    address, asset_balance, asset_link_create, asset_metadata, async_order_new,
+    async_order_outbound_invoice, backup, btc_balance, cancel_hodl_invoice, change_password,
+    check_indexer_url, check_proxy_endpoint, claim_hodl_invoice, close_channel, connect_peer,
+    create_utxos, decode_ln_invoice, decode_rgb_invoice, decode_swapstring, disconnect_peer,
+    estimate_fee, fail_transfers, get_asset_media, get_channel_id, get_payment, get_swap, inflate,
+    init, invoice_status, issue_asset_cfa, issue_asset_ifa, issue_asset_nia, issue_asset_uda,
+    keysend, list_assets, list_channels, list_payments, list_peers, list_swaps, list_transactions,
+    list_transfers, list_unspents, ln_invoice, lock, maker_execute, maker_init, network_info,
+    node_info, open_channel, post_asset_media, refresh_transfers, restore, revoke_token,
+    rgb_invoice, rotate_address, send_btc, send_onion_message, send_payment, send_rgb, shutdown,
+    sign_message, sync, taker, unlock,
 };
 #[cfg(feature = "vss")]
 use crate::routes::{vss_backup, vss_backup_info, vss_clear_fence};
@@ -133,6 +133,7 @@ pub(crate) async fn app(args: UserArgs) -> Result<(Router, Arc<AppState>), AppEr
         .route("/apay/new", post(async_order_new))
         .route("/apay/outboundinvoice", post(async_order_outbound_invoice))
         .route("/assetbalance", post(asset_balance))
+        .route("/assetlink/create", post(asset_link_create))
         .route("/assetmetadata", post(asset_metadata))
         .route("/backup", post(backup))
         .route("/btcbalance", post(btc_balance))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod apay_merkle;
 mod args;
+mod asset_link;
 #[cfg(feature = "vss")]
 mod async_kv_store;
 mod async_order;
@@ -9,6 +10,7 @@ mod bitcoind;
 mod chain_backend;
 mod config;
 mod core_types;
+mod custom_msg_rpc;
 mod database;
 mod disk;
 mod error;
@@ -63,17 +65,17 @@ use crate::ldk::stop_ldk;
 #[cfg(feature = "remote-signer")]
 use crate::routes::init_external_signer;
 use crate::routes::{
-    address, asset_balance, asset_link_create, asset_metadata, async_order_new,
-    async_order_outbound_invoice, backup, btc_balance, cancel_hodl_invoice, change_password,
-    check_indexer_url, check_proxy_endpoint, claim_hodl_invoice, close_channel, connect_peer,
-    create_utxos, decode_ln_invoice, decode_rgb_invoice, decode_swapstring, disconnect_peer,
-    estimate_fee, fail_transfers, get_asset_media, get_channel_id, get_payment, get_swap, inflate,
-    init, invoice_status, issue_asset_cfa, issue_asset_ifa, issue_asset_nia, issue_asset_uda,
-    keysend, list_assets, list_channels, list_payments, list_peers, list_swaps, list_transactions,
-    list_transfers, list_unspents, ln_invoice, lock, maker_execute, maker_init, network_info,
-    node_info, open_channel, post_asset_media, refresh_transfers, restore, revoke_token,
-    rgb_invoice, rotate_address, send_btc, send_onion_message, send_payment, send_rgb, shutdown,
-    sign_message, sync, taker, unlock,
+    address, asset_balance, asset_link_create, asset_link_send_payment, asset_metadata,
+    async_order_new, async_order_outbound_invoice, backup, btc_balance, cancel_hodl_invoice,
+    change_password, check_indexer_url, check_proxy_endpoint, claim_hodl_invoice, close_channel,
+    connect_peer, create_utxos, decode_ln_invoice, decode_rgb_invoice, decode_swapstring,
+    disconnect_peer, estimate_fee, fail_transfers, get_asset_media, get_channel_id, get_payment,
+    get_swap, inflate, init, invoice_status, issue_asset_cfa, issue_asset_ifa, issue_asset_nia,
+    issue_asset_uda, keysend, list_assets, list_channels, list_payments, list_peers, list_swaps,
+    list_transactions, list_transfers, list_unspents, ln_invoice, lock, maker_execute, maker_init,
+    network_info, node_info, open_channel, post_asset_media, refresh_transfers, restore,
+    revoke_token, rgb_invoice, rotate_address, send_btc, send_onion_message, send_payment,
+    send_rgb, shutdown, sign_message, sync, taker, unlock,
 };
 #[cfg(feature = "vss")]
 use crate::routes::{vss_backup, vss_backup_info, vss_clear_fence};
@@ -134,6 +136,7 @@ pub(crate) async fn app(args: UserArgs) -> Result<(Router, Arc<AppState>), AppEr
         .route("/apay/outboundinvoice", post(async_order_outbound_invoice))
         .route("/assetbalance", post(asset_balance))
         .route("/assetlink/create", post(asset_link_create))
+        .route("/assetlink/sendpayment", post(asset_link_send_payment))
         .route("/assetmetadata", post(asset_metadata))
         .route("/backup", post(backup))
         .route("/btcbalance", post(btc_balance))

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,17 +65,17 @@ use crate::ldk::stop_ldk;
 #[cfg(feature = "remote-signer")]
 use crate::routes::init_external_signer;
 use crate::routes::{
-    address, asset_balance, asset_link_create, asset_link_send_payment, asset_metadata,
-    async_order_new, async_order_outbound_invoice, backup, btc_balance, cancel_hodl_invoice,
-    change_password, check_indexer_url, check_proxy_endpoint, claim_hodl_invoice, close_channel,
-    connect_peer, create_utxos, decode_ln_invoice, decode_rgb_invoice, decode_swapstring,
-    disconnect_peer, estimate_fee, fail_transfers, get_asset_media, get_channel_id, get_payment,
-    get_swap, inflate, init, invoice_status, issue_asset_cfa, issue_asset_ifa, issue_asset_nia,
-    issue_asset_uda, keysend, list_assets, list_channels, list_payments, list_peers, list_swaps,
-    list_transactions, list_transfers, list_unspents, ln_invoice, lock, maker_execute, maker_init,
-    network_info, node_info, open_channel, post_asset_media, refresh_transfers, restore,
-    revoke_token, rgb_invoice, rotate_address, send_btc, send_onion_message, send_payment,
-    send_rgb, shutdown, sign_message, sync, taker, unlock,
+    address, asset_balance, asset_link_create, asset_metadata, async_order_new,
+    async_order_outbound_invoice, backup, btc_balance, cancel_hodl_invoice, change_password,
+    check_indexer_url, check_proxy_endpoint, claim_hodl_invoice, close_channel, connect_peer,
+    create_utxos, decode_ln_invoice, decode_rgb_invoice, decode_swapstring, disconnect_peer,
+    estimate_fee, fail_transfers, get_asset_media, get_channel_id, get_payment, get_swap, inflate,
+    init, invoice_status, issue_asset_cfa, issue_asset_ifa, issue_asset_nia, issue_asset_uda,
+    keysend, list_assets, list_channels, list_payments, list_peers, list_swaps, list_transactions,
+    list_transfers, list_unspents, ln_invoice, lock, maker_execute, maker_init, network_info,
+    node_info, open_channel, post_asset_media, refresh_transfers, restore, revoke_token,
+    rgb_invoice, rotate_address, send_btc, send_onion_message, send_payment, send_rgb, shutdown,
+    sign_message, sync, taker, unlock,
 };
 #[cfg(feature = "vss")]
 use crate::routes::{vss_backup, vss_backup_info, vss_clear_fence};
@@ -136,7 +136,6 @@ pub(crate) async fn app(args: UserArgs) -> Result<(Router, Arc<AppState>), AppEr
         .route("/apay/outboundinvoice", post(async_order_outbound_invoice))
         .route("/assetbalance", post(asset_balance))
         .route("/assetlink/create", post(asset_link_create))
-        .route("/assetlink/sendpayment", post(asset_link_send_payment))
         .route("/assetmetadata", post(asset_metadata))
         .route("/backup", post(backup))
         .route("/btcbalance", post(btc_balance))

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -21,8 +21,8 @@ use rgb_lib::{
         AssetCFA, AssetIFA, AssetNIA, AssetUDA, Assets, Balance, BtcBalance, IfaIssuanceType,
         Metadata, Online, OperationResult, Outpoint, ReceiveData, Recipient, RefreshFilter,
         RefreshResult, RgbWalletOpsOffline, RgbWalletOpsOnline, SendBeginResult, SinglesigKeys,
-        SyncOptions, Transaction as RgbLibTransaction, Transfer, TransportEndpoint, Unspent,
-        Wallet as RgbLibWallet,
+        SyncOptions, Transaction as RgbLibTransaction, Transfer, TransferKind, TransportEndpoint,
+        Unspent, Wallet as RgbLibWallet,
     },
     AssetSchema, Assignment, BitcoinNetwork, ContractId, Error as RgbLibError, Fascia, RgbTransfer,
     RgbTransport, RgbTxid, UpdateRes, WitnessOrd,
@@ -287,6 +287,33 @@ impl UnlockedAppState {
             reject_list_url,
             issuance_type,
         )
+    }
+
+    pub(crate) fn rgb_find_link_right_outpoint(
+        &self,
+        contract_id: ContractId,
+    ) -> Result<Option<Outpoint>, RgbLibError> {
+        let contract_id = contract_id.to_string();
+        Ok(self
+            .rgb_list_unspents(false, false)?
+            .into_iter()
+            .find_map(|unspent| {
+                let has_link_right = unspent.rgb_allocations.iter().any(|allocation| {
+                    allocation.asset_id.as_deref() == Some(contract_id.as_str())
+                        && allocation.assignment == Assignment::LinkRight
+                });
+                has_link_right.then_some(unspent.utxo.outpoint)
+            }))
+    }
+
+    pub(crate) fn rgb_find_link_transfer(
+        &self,
+        contract_id: ContractId,
+    ) -> Result<Option<Transfer>, RgbLibError> {
+        Ok(self
+            .rgb_list_transfers(contract_id.to_string())?
+            .into_iter()
+            .find(|transfer| transfer.kind == TransferKind::Link))
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -293,17 +293,10 @@ impl UnlockedAppState {
         &self,
         contract_id: ContractId,
     ) -> Result<Option<Outpoint>, RgbLibError> {
-        let contract_id = contract_id.to_string();
+        self.rgb_list_unspents(false, false)?;
         Ok(self
-            .rgb_list_unspents(false, false)?
-            .into_iter()
-            .find_map(|unspent| {
-                let has_link_right = unspent.rgb_allocations.iter().any(|allocation| {
-                    allocation.asset_id.as_deref() == Some(contract_id.as_str())
-                        && allocation.assignment == Assignment::LinkRight
-                });
-                has_link_right.then_some(unspent.utxo.outpoint)
-            }))
+            .rgb_get_asset_metadata(contract_id)?
+            .unspent_link_right_outpoint)
     }
 
     pub(crate) fn rgb_find_link_transfer(

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -18,10 +18,10 @@ use rgb_lib::{
     bitcoin::psbt::Psbt as BitcoinPsbt,
     wallet::{
         rust_only::{check_proxy_url, ColoringInfo},
-        AssetCFA, AssetIFA, AssetNIA, AssetUDA, Assets, Balance, BtcBalance, Metadata, Online,
-        OperationResult, ReceiveData, Recipient, RefreshFilter, RefreshResult, RgbWalletOpsOffline,
-        RgbWalletOpsOnline, SendBeginResult, SinglesigKeys, SyncOptions,
-        Transaction as RgbLibTransaction, Transfer, TransportEndpoint, Unspent,
+        AssetCFA, AssetIFA, AssetNIA, AssetUDA, Assets, Balance, BtcBalance, IfaIssuanceType,
+        Metadata, Online, OperationResult, Outpoint, ReceiveData, Recipient, RefreshFilter,
+        RefreshResult, RgbWalletOpsOffline, RgbWalletOpsOnline, SendBeginResult, SinglesigKeys,
+        SyncOptions, Transaction as RgbLibTransaction, Transfer, TransportEndpoint, Unspent,
         Wallet as RgbLibWallet,
     },
     AssetSchema, Assignment, BitcoinNetwork, ContractId, Error as RgbLibError, Fascia, RgbTransfer,
@@ -276,6 +276,7 @@ impl UnlockedAppState {
         amounts: Vec<u64>,
         inflation_amounts: Vec<u64>,
         reject_list_url: Option<String>,
+        issuance_type: Option<IfaIssuanceType>,
     ) -> Result<AssetIFA, RgbLibError> {
         self.rgb_wallet_wrapper.issue_asset_ifa(
             ticker,
@@ -284,6 +285,25 @@ impl UnlockedAppState {
             amounts,
             inflation_amounts,
             reject_list_url,
+            issuance_type,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn rgb_link_ifa(
+        &self,
+        parent_contract_id: String,
+        child_contract_id: String,
+        link_right_outpoint: Outpoint,
+        fee_rate: u64,
+        min_confirmations: u8,
+    ) -> Result<OperationResult, RgbLibError> {
+        self.rgb_wallet_wrapper.link_ifa(
+            parent_contract_id,
+            child_contract_id,
+            link_right_outpoint,
+            fee_rate,
+            min_confirmations,
         )
     }
 
@@ -746,6 +766,7 @@ impl RgbLibWalletWrapper {
         amounts: Vec<u64>,
         inflation_amounts: Vec<u64>,
         reject_list_url: Option<String>,
+        issuance_type: Option<IfaIssuanceType>,
     ) -> Result<AssetIFA, RgbLibError> {
         self.get_rgb_wallet().issue_asset_ifa(
             ticker,
@@ -754,6 +775,26 @@ impl RgbLibWalletWrapper {
             amounts,
             inflation_amounts,
             reject_list_url,
+            issuance_type,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn link_ifa(
+        &self,
+        parent_contract_id: String,
+        child_contract_id: String,
+        link_right_outpoint: Outpoint,
+        fee_rate: u64,
+        min_confirmations: u8,
+    ) -> Result<OperationResult, RgbLibError> {
+        self.get_rgb_wallet().link_ifa(
+            self.online,
+            parent_contract_id,
+            child_contract_id,
+            link_right_outpoint,
+            fee_rate,
+            min_confirmations,
         )
     }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -72,8 +72,7 @@ use tokio::{
 };
 
 use crate::asset_link::{
-    AssetLinkAuthorizeParamsWire, AssetLinkAuthorizeResultWire, AssetLinkSendPaymentRequest,
-    ASSET_LINK_PROTOCOL_VERSION,
+    find_linked_asset_channel, has_sufficient_asset_channel, send_linked_asset_payment,
 };
 use crate::async_order::{
     write_async_payments_next_hash_index, AsyncOrderNewResultWire,
@@ -83,7 +82,6 @@ use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
     AsyncOrderOutboundInvoiceResponse,
 };
-use crate::custom_msg_rpc::JSONRPC_MSG_RESPONSE_TIMEOUT_SECS;
 use crate::ldk::{
     clear_rgb_payment_pending, peer_has_live_channel, start_ldk, stop_ldk, LdkBackgroundServices,
     VirtualChannelSessionStatus,
@@ -95,8 +93,8 @@ use crate::signer::read_key_source_file;
 use crate::swap::{SwapData, SwapInfo, SwapString};
 use crate::utils::{
     check_already_initialized, check_channel_id, check_password_strength, check_password_validity,
-    encrypt_and_save_mnemonic, get_max_local_rgb_amount, get_route, hex_str,
-    hex_str_to_compressed_pubkey, hex_str_to_vec, is_external_signer_mode_configured,
+    description_hash_from_invoice, encrypt_and_save_mnemonic, get_max_local_rgb_amount, get_route,
+    hex_str, hex_str_to_compressed_pubkey, hex_str_to_vec, is_external_signer_mode_configured,
     new_jsonrpc_request_id, open_database_pool, validate_and_parse_description_hash,
     validate_and_parse_payment_hash, validate_and_parse_payment_preimage, UnlockedAppState,
     UserOnionMessageContents,
@@ -1086,13 +1084,6 @@ pub(crate) struct Payment {
     pub(crate) description_hash: Option<String>,
 }
 
-pub(crate) fn description_hash_from_invoice(invoice: &Bolt11Invoice) -> Option<[u8; 32]> {
-    match invoice.description() {
-        lightning_invoice::Bolt11InvoiceDescriptionRef::Hash(hash) => Some(hash.0.to_byte_array()),
-        _ => None,
-    }
-}
-
 fn payment_type_from_invoice(invoice_type: Option<InvoiceType>) -> PaymentType {
     match invoice_type.unwrap_or(InvoiceType::AutoClaim) {
         InvoiceType::AutoClaim => PaymentType::InboundAutoClaim,
@@ -1965,262 +1956,6 @@ pub(crate) async fn asset_link_create(
         };
 
         Ok(Json(AssetLinkCreateResponse { asset_link }))
-    })
-    .await
-}
-
-pub(crate) async fn asset_link_send_payment(
-    State(state): State<Arc<AppState>>,
-    WithRejection(Json(payload), _): WithRejection<Json<AssetLinkSendPaymentRequest>, APIError>,
-) -> Result<Json<SendPaymentResponse>, APIError> {
-    no_cancel(async move {
-        let guard = state.check_unlocked().await?;
-        let unlocked_state = guard.as_ref().unwrap();
-
-        let host_pubkey =
-            PublicKey::from_str(&payload.host_pubkey).map_err(|_| APIError::InvalidPubkey)?;
-        let child_contract_id = ContractId::from_str(&payload.asset_id)
-            .map_err(|_| APIError::InvalidAssetID(payload.asset_id.clone()))?;
-
-        let invoice = Bolt11Invoice::from_str(&payload.invoice)
-            .map_err(|e| APIError::InvalidInvoice(e.to_string()))?;
-        if invoice.is_expired() {
-            return Err(APIError::InvalidInvoice(s!("invoice has expired")));
-        }
-
-        let (parent_contract_id, asset_amount) =
-            match (invoice.rgb_contract_id(), invoice.rgb_amount()) {
-                (Some(contract_id), Some(amount)) => (contract_id, amount),
-                _ => {
-                    return Err(APIError::InvalidInvoice(s!(
-                        "linked payment requires an RGB invoice with contract ID and amount"
-                    )))
-                }
-            };
-        if parent_contract_id == child_contract_id {
-            return Err(APIError::InvalidRequest(
-                "asset_id and the invoice asset must be different".to_string(),
-            ));
-        }
-        let amt_msat = match invoice.amount_milli_satoshis() {
-            Some(amt) if amt > 0 => amt,
-            _ => {
-                return Err(APIError::InvalidAmount(s!(
-                    "linked payment requires an invoice with a msat amount"
-                )))
-            }
-        };
-
-        let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());
-        let payment_secret = *invoice.payment_secret();
-        let receiver_pubkey = invoice.recover_payee_pub_key();
-
-        if host_pubkey == unlocked_state.runtime_node_id() || host_pubkey == receiver_pubkey {
-            return Err(APIError::InvalidRequest(
-                "host_pubkey must differ from this node and the invoice receiver".to_string(),
-            ));
-        }
-
-        let first_leg = get_route(
-            &unlocked_state.channel_manager,
-            &unlocked_state.router,
-            unlocked_state.kv_store.as_ref(),
-            unlocked_state.runtime_node_id(),
-            host_pubkey,
-            Some(amt_msat),
-            Some((child_contract_id, asset_amount)),
-            vec![],
-        );
-        let second_leg = get_route(
-            &unlocked_state.channel_manager,
-            &unlocked_state.router,
-            unlocked_state.kv_store.as_ref(),
-            host_pubkey,
-            receiver_pubkey,
-            Some(amt_msat),
-            Some((parent_contract_id, asset_amount)),
-            invoice.route_hints(),
-        );
-        let (mut first_leg, mut second_leg) = match (first_leg, second_leg) {
-            (Some(f), Some(s)) => (f, s),
-            _ => {
-                return Err(APIError::NoRoute);
-            }
-        };
-
-        second_leg.paths[0].hops[0].short_channel_id |= IS_SWAP_SCID;
-
-        first_leg.paths[0]
-            .hops
-            .last_mut()
-            .expect("Path not to be empty")
-            .fee_msat = 0;
-
-        let mut fullpaths = first_leg.paths[0]
-            .hops
-            .clone()
-            .into_iter()
-            .map(|mut hop| {
-                hop.rgb_payment = Some((child_contract_id, asset_amount));
-                hop
-            })
-            .chain(second_leg.paths[0].hops.clone().into_iter().map(|mut hop| {
-                hop.rgb_payment = Some((parent_contract_id, asset_amount));
-                hop
-            }))
-            .collect::<Vec<_>>();
-
-        if let Some(last_hop) = fullpaths.last_mut() {
-            last_hop.cltv_expiry_delta = last_hop
-                .cltv_expiry_delta
-                .max(invoice.min_final_cltv_expiry_delta() as u32);
-        }
-
-        let total_fee = fullpaths
-            .iter()
-            .rev()
-            .skip(1)
-            .map(|hop| hop.fee_msat)
-            .sum::<u64>();
-
-        if total_fee >= MAX_SWAP_FEE_MSAT {
-            return Err(APIError::FailedPayment(format!(
-                "Fee too high: {total_fee}"
-            )));
-        }
-
-        let mut recipient_onion = RecipientOnionFields::secret_only(payment_secret);
-        recipient_onion.payment_metadata = invoice.payment_metadata().cloned();
-
-        let mut route_params = RouteParameters::from_payment_params_and_value(
-            PaymentParameters::from_bolt11_invoice(&invoice),
-            amt_msat,
-            Some((parent_contract_id, asset_amount)),
-        );
-        route_params
-            .set_max_path_length(
-                &recipient_onion,
-                false,
-                unlocked_state.channel_manager.current_best_block().height,
-            )
-            .map_err(|()| APIError::FailedPayment(s!("onion packet size exceeded")))?;
-        let route = Route {
-            paths: vec![LnPath {
-                hops: fullpaths,
-                blinded_tail: None,
-            }],
-            route_params: Some(route_params),
-        };
-
-        let params = AssetLinkAuthorizeParamsWire {
-            protocol_version: ASSET_LINK_PROTOCOL_VERSION,
-            payment_hash: hex_str(&payment_hash.0),
-            asset_id: parent_contract_id.to_string(),
-            linked_asset_id: child_contract_id.to_string(),
-            amount: asset_amount,
-            expiry_sec: invoice.duration_until_expiry().as_secs(),
-        };
-        let request_id = new_jsonrpc_request_id();
-        let response_rx = unlocked_state
-            .asset_link_handler
-            .queue_asset_link_authorize(host_pubkey, Value::String(request_id.clone()), params)
-            .map_err(|err| APIError::InvalidRequest(err.message))?;
-        unlocked_state.peer_manager.process_events();
-        match timeout(
-            Duration::from_secs(JSONRPC_MSG_RESPONSE_TIMEOUT_SECS),
-            response_rx,
-        )
-        .await
-        {
-            Ok(Ok(Ok(result))) => {
-                let authorized = serde_json::from_value::<AssetLinkAuthorizeResultWire>(result)
-                    .map(|r| r.authorized)
-                    .unwrap_or(false);
-                if !authorized {
-                    return Err(APIError::InvalidRequest(s!(
-                        "host did not authorize the linked payment"
-                    )));
-                }
-            }
-            Ok(Ok(Err(err))) => {
-                return Err(APIError::InvalidRequest(format!(
-                    "asset_link host error {}: {}",
-                    err.code, err.message
-                )));
-            }
-            Ok(Err(_)) => {
-                return Err(APIError::Network(s!(
-                    "/assetlink/sendpayment response channel closed before the host replied"
-                )));
-            }
-            Err(_) => {
-                unlocked_state
-                    .asset_link_handler
-                    .forget_asset_link_response(host_pubkey, &request_id);
-                return Err(APIError::Network(s!(
-                    "/assetlink/sendpayment timed out waiting for host authorization"
-                )));
-            }
-        }
-
-        let created_at = get_current_timestamp();
-        let payment_id = PaymentId(payment_hash.0);
-        let mut status = HTLCStatus::Pending;
-        unlocked_state.add_outbound_payment(
-            payment_id,
-            PaymentInfo {
-                preimage: None,
-                secret: Some(payment_secret),
-                status,
-                amt_msat: Some(amt_msat),
-                created_at,
-                updated_at: created_at,
-                payee_pubkey: invoice.get_payee_pub_key(),
-                expires_at: None,
-                claim_deadline_height: None,
-                invoice_type: None,
-                description_hash: description_hash_from_invoice(&invoice),
-                payment_idx: None,
-                async_hash_index: None,
-                async_host_node_id: None,
-            },
-        )?;
-        write_rgb_payment_info_file(
-            &payment_hash,
-            child_contract_id,
-            asset_amount,
-            true,
-            false,
-            unlocked_state.kv_store.as_ref(),
-        );
-
-        match unlocked_state.channel_manager.send_payment_with_route(
-            route,
-            payment_hash,
-            recipient_onion,
-            payment_id,
-        ) {
-            Ok(()) => {
-                tracing::info!(
-                    "EVENT: sent linked-asset payment of {} to {}",
-                    asset_amount,
-                    receiver_pubkey
-                );
-            }
-            Err(e) => {
-                tracing::error!("ERROR: failed to send linked-asset payment: {:?}", e);
-                clear_rgb_payment_pending(&payment_hash, false, unlocked_state.kv_store.as_ref());
-                status = HTLCStatus::Failed;
-                unlocked_state.update_outbound_payment_status(payment_id, status);
-            }
-        }
-
-        Ok(Json(SendPaymentResponse {
-            payment_id: hex_str(&payment_id.0),
-            payment_hash: Some(hex_str(&payment_hash.0)),
-            payment_secret: Some(hex_str(&payment_secret.0)),
-            status,
-        }))
     })
     .await
 }
@@ -5227,6 +4962,9 @@ pub(crate) async fn send_payment(
                 Err(e) => return Err(APIError::InvalidInvoice(e.to_string())),
                 Ok(v) => v,
             };
+            if invoice.is_expired() {
+                return Err(APIError::InvalidInvoice(s!("invoice has expired")));
+            }
 
             let payment_id = PaymentId((*invoice.payment_hash()).to_byte_array());
             let payment_secret = Some(*invoice.payment_secret());
@@ -5289,6 +5027,41 @@ pub(crate) async fn send_payment(
                     )))
                 }
             };
+
+            if let Some((contract_id, asset_amount)) = rgb_payment {
+                if !has_sufficient_asset_channel(
+                    unlocked_state,
+                    contract_id,
+                    asset_amount,
+                    amt_msat,
+                ) {
+                    if let Some((linked_contract_id, host_pubkey)) = find_linked_asset_channel(
+                        unlocked_state,
+                        contract_id,
+                        asset_amount,
+                        amt_msat,
+                        invoice.recover_payee_pub_key(),
+                    ) {
+                        let linked_payment = send_linked_asset_payment(
+                            unlocked_state,
+                            &invoice,
+                            contract_id,
+                            linked_contract_id,
+                            asset_amount,
+                            amt_msat,
+                            host_pubkey,
+                        )
+                        .await?;
+
+                        return Ok(Json(SendPaymentResponse {
+                            payment_id: hex_str(&linked_payment.payment_id.0),
+                            payment_hash: Some(hex_str(&linked_payment.payment_hash.0)),
+                            payment_secret: Some(hex_str(&linked_payment.payment_secret.0)),
+                            status: linked_payment.status,
+                        }));
+                    }
+                }
+            }
 
             if rgb_payment.is_none() {
                 let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());
@@ -5879,6 +5652,7 @@ mod external_signer_auth_tests {
 
         Arc::new(AppState {
             static_state: Arc::new(StaticState {
+                config: Default::default(),
                 ldk_peer_listening_port: 9735,
                 network: rgb_lib::BitcoinNetwork::Regtest,
                 storage_dir_path: path.clone(),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -72,7 +72,8 @@ use tokio::{
 };
 
 use crate::asset_link::{
-    AssetLinkAuthorizeParamsWire, AssetLinkSendPaymentRequest, ASSET_LINK_PROTOCOL_VERSION,
+    AssetLinkAuthorizeParamsWire, AssetLinkAuthorizeResultWire, AssetLinkSendPaymentRequest,
+    ASSET_LINK_PROTOCOL_VERSION,
 };
 use crate::async_order::{
     write_async_payments_next_hash_index, AsyncOrderNewResultWire,
@@ -1962,6 +1963,10 @@ pub(crate) async fn asset_link_send_payment(
 
         let invoice = Bolt11Invoice::from_str(&payload.invoice)
             .map_err(|e| APIError::InvalidInvoice(e.to_string()))?;
+        if invoice.is_expired() {
+            return Err(APIError::InvalidInvoice(s!("invoice has expired")));
+        }
+
         let (linked_contract_id, asset_amount) =
             match (invoice.rgb_contract_id(), invoice.rgb_amount()) {
                 (Some(contract_id), Some(amount)) => (contract_id, amount),
@@ -1989,46 +1994,10 @@ pub(crate) async fn asset_link_send_payment(
         let payment_secret = *invoice.payment_secret();
         let receiver_pubkey = invoice.recover_payee_pub_key();
 
-        let params = AssetLinkAuthorizeParamsWire {
-            protocol_version: ASSET_LINK_PROTOCOL_VERSION,
-            payment_hash: hex_str(&payment_hash.0),
-            asset_id: payload.asset_id.clone(),
-            linked_asset_id: linked_contract_id.to_string(),
-            amount: asset_amount,
-            expiry_sec: invoice.expiry_time().as_secs(),
-        };
-        let request_id = new_jsonrpc_request_id();
-        let response_rx = unlocked_state
-            .asset_link_handler
-            .queue_asset_link_authorize(host_pubkey, Value::String(request_id.clone()), params)
-            .map_err(|err| APIError::InvalidRequest(err.message))?;
-        unlocked_state.peer_manager.process_events();
-        match timeout(
-            Duration::from_secs(JSONRPC_MSG_RESPONSE_TIMEOUT_SECS),
-            response_rx,
-        )
-        .await
-        {
-            Ok(Ok(Ok(_result))) => {}
-            Ok(Ok(Err(err))) => {
-                return Err(APIError::InvalidRequest(format!(
-                    "asset_link host error {}: {}",
-                    err.code, err.message
-                )));
-            }
-            Ok(Err(_)) => {
-                return Err(APIError::Network(s!(
-                    "/assetlink/sendpayment response channel closed before the host replied"
-                )));
-            }
-            Err(_) => {
-                unlocked_state
-                    .asset_link_handler
-                    .forget_asset_link_response(host_pubkey, &request_id);
-                return Err(APIError::Network(s!(
-                    "/assetlink/sendpayment timed out waiting for host authorization"
-                )));
-            }
+        if host_pubkey == unlocked_state.runtime_node_id() || host_pubkey == receiver_pubkey {
+            return Err(APIError::InvalidRequest(
+                "host_pubkey must differ from this node and the invoice receiver".to_string(),
+            ));
         }
 
         let first_leg = get_route(
@@ -2066,7 +2035,7 @@ pub(crate) async fn asset_link_send_payment(
             .expect("Path not to be empty")
             .fee_msat = 0;
 
-        let fullpaths = first_leg.paths[0]
+        let mut fullpaths = first_leg.paths[0]
             .hops
             .clone()
             .into_iter()
@@ -2079,6 +2048,12 @@ pub(crate) async fn asset_link_send_payment(
                 hop
             }))
             .collect::<Vec<_>>();
+
+        if let Some(last_hop) = fullpaths.last_mut() {
+            last_hop.cltv_expiry_delta = last_hop
+                .cltv_expiry_delta
+                .max(invoice.min_final_cltv_expiry_delta() as u32);
+        }
 
         let total_fee = fullpaths
             .iter()
@@ -2093,13 +2068,79 @@ pub(crate) async fn asset_link_send_payment(
             )));
         }
 
+        let mut recipient_onion = RecipientOnionFields::secret_only(payment_secret);
+        recipient_onion.payment_metadata = invoice.payment_metadata().cloned();
+
+        let mut route_params = RouteParameters::from_payment_params_and_value(
+            PaymentParameters::from_bolt11_invoice(&invoice),
+            amt_msat,
+            Some((linked_contract_id, asset_amount)),
+        );
+        route_params
+            .set_max_path_length(
+                &recipient_onion,
+                false,
+                unlocked_state.channel_manager.current_best_block().height,
+            )
+            .map_err(|()| APIError::FailedPayment(s!("onion packet size exceeded")))?;
         let route = Route {
             paths: vec![LnPath {
                 hops: fullpaths,
                 blinded_tail: None,
             }],
-            route_params: None,
+            route_params: Some(route_params),
         };
+
+        let params = AssetLinkAuthorizeParamsWire {
+            protocol_version: ASSET_LINK_PROTOCOL_VERSION,
+            payment_hash: hex_str(&payment_hash.0),
+            asset_id: payload.asset_id.clone(),
+            linked_asset_id: linked_contract_id.to_string(),
+            amount: asset_amount,
+            expiry_sec: invoice.duration_until_expiry().as_secs(),
+        };
+        let request_id = new_jsonrpc_request_id();
+        let response_rx = unlocked_state
+            .asset_link_handler
+            .queue_asset_link_authorize(host_pubkey, Value::String(request_id.clone()), params)
+            .map_err(|err| APIError::InvalidRequest(err.message))?;
+        unlocked_state.peer_manager.process_events();
+        match timeout(
+            Duration::from_secs(JSONRPC_MSG_RESPONSE_TIMEOUT_SECS),
+            response_rx,
+        )
+        .await
+        {
+            Ok(Ok(Ok(result))) => {
+                let authorized = serde_json::from_value::<AssetLinkAuthorizeResultWire>(result)
+                    .map(|r| r.authorized)
+                    .unwrap_or(false);
+                if !authorized {
+                    return Err(APIError::InvalidRequest(s!(
+                        "host did not authorize the linked payment"
+                    )));
+                }
+            }
+            Ok(Ok(Err(err))) => {
+                return Err(APIError::InvalidRequest(format!(
+                    "asset_link host error {}: {}",
+                    err.code, err.message
+                )));
+            }
+            Ok(Err(_)) => {
+                return Err(APIError::Network(s!(
+                    "/assetlink/sendpayment response channel closed before the host replied"
+                )));
+            }
+            Err(_) => {
+                unlocked_state
+                    .asset_link_handler
+                    .forget_asset_link_response(host_pubkey, &request_id);
+                return Err(APIError::Network(s!(
+                    "/assetlink/sendpayment timed out waiting for host authorization"
+                )));
+            }
+        }
 
         let created_at = get_current_timestamp();
         let payment_id = PaymentId(payment_hash.0);
@@ -2127,7 +2168,7 @@ pub(crate) async fn asset_link_send_payment(
             &payment_hash,
             asset_contract_id,
             asset_amount,
-            false,
+            true,
             false,
             unlocked_state.kv_store.as_ref(),
         );
@@ -2135,7 +2176,7 @@ pub(crate) async fn asset_link_send_payment(
         match unlocked_state.channel_manager.send_payment_with_route(
             route,
             payment_hash,
-            RecipientOnionFields::secret_only(payment_secret),
+            recipient_onion,
             payment_id,
         ) {
             Ok(()) => {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -49,7 +49,8 @@ use rgb_lib::{
         },
         AssetCFA as RgbLibAssetCFA, AssetIFA as RgbLibAssetIFA, AssetNIA as RgbLibAssetNIA,
         AssetUDA as RgbLibAssetUDA, Balance as RgbLibBalance, EmbeddedMedia as RgbLibEmbeddedMedia,
-        Invoice as RgbLibInvoice, Media as RgbLibMedia, ProofOfReserves as RgbLibProofOfReserves,
+        IfaIssuanceType as RgbLibIfaIssuanceType, Invoice as RgbLibInvoice, Media as RgbLibMedia,
+        Outpoint as RgbLibOutpoint, ProofOfReserves as RgbLibProofOfReserves,
         Recipient as RgbLibRecipient, RecipientInfo, RecipientType as RgbLibRecipientType,
         RefreshFilter as RgbLibRefreshFilter, RefreshTransferStatus as RgbLibRefreshTransferStatus,
         SyncKeychain as RgbLibSyncKeychain, SyncOptions as RgbLibSyncOptions,
@@ -116,7 +117,6 @@ use crate::{
 
 const VIRTUAL_OPEN_MODE_TRUSTED_NO_BROADCAST: &str = "trusted_no_broadcast";
 const ASSET_LINK_NAMESPACE: &str = "asset_link";
-const ASSET_LINK_SIGNATURE_DOMAIN: &str = "RLN_ASSET_LINK_V1";
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct AddressResponse {
@@ -193,6 +193,7 @@ pub(crate) struct AssetIFA {
     pub(crate) balance: AssetBalanceResponse,
     pub(crate) media: Option<Media>,
     pub(crate) reject_list_url: Option<String>,
+    pub(crate) link_right_outpoint: Option<RgbLibOutpoint>,
 }
 
 impl From<RgbLibAssetIFA> for AssetIFA {
@@ -211,6 +212,7 @@ impl From<RgbLibAssetIFA> for AssetIFA {
             balance: value.balance.into(),
             media: value.media.map(|m| m.into()),
             reject_list_url: value.reject_list_url,
+            link_right_outpoint: value.link_right_outpoint,
         }
     }
 }
@@ -219,15 +221,17 @@ impl From<RgbLibAssetIFA> for AssetIFA {
 pub(crate) struct AssetLink {
     pub(crate) asset_id: String,
     pub(crate) linked_asset_id: Option<String>,
-    pub(crate) issuer_pubkey: String,
-    pub(crate) signature: Option<String>,
     pub(crate) created_at: Option<u64>,
+    pub(crate) link_right_outpoint: Option<RgbLibOutpoint>,
+    pub(crate) txid: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct AssetLinkCreateRequest {
     pub(crate) asset_id: String,
     pub(crate) linked_asset_id: String,
+    pub(crate) fee_rate: u64,
+    pub(crate) min_confirmations: u8,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -264,6 +268,22 @@ fn asset_link_write_record(
                 "asset link write failed: {e}"
             )))
         })
+}
+
+fn asset_link_write_reverse_record(
+    kv_store: &dyn KVStoreSync,
+    parent_asset_id: &str,
+    child_asset_id: &str,
+    txid: Option<String>,
+) -> Result<(), APIError> {
+    let reverse_asset_link = AssetLink {
+        asset_id: child_asset_id.to_string(),
+        linked_asset_id: Some(parent_asset_id.to_string()),
+        created_at: None,
+        link_right_outpoint: None,
+        txid,
+    };
+    asset_link_write_record(kv_store, &reverse_asset_link)
 }
 
 #[derive(Deserialize, Serialize)]
@@ -382,6 +402,7 @@ pub(crate) enum Assignment {
     NonFungible,
     InflationRight(u64),
     Any,
+    LinkRight,
 }
 
 impl From<RgbLibAssignment> for Assignment {
@@ -391,6 +412,7 @@ impl From<RgbLibAssignment> for Assignment {
             RgbLibAssignment::NonFungible => Self::NonFungible,
             RgbLibAssignment::InflationRight(amt) => Self::InflationRight(amt),
             RgbLibAssignment::Any => Self::Any,
+            RgbLibAssignment::LinkRight => Self::LinkRight,
         }
     }
 }
@@ -402,6 +424,7 @@ impl From<Assignment> for RgbLibAssignment {
             Assignment::NonFungible => Self::NonFungible,
             Assignment::InflationRight(amt) => Self::InflationRight(amt),
             Assignment::Any => Self::Any,
+            Assignment::LinkRight => Self::LinkRight,
         }
     }
 }
@@ -781,6 +804,8 @@ pub(crate) struct IssueAssetIFARequest {
     pub(crate) name: String,
     pub(crate) precision: u8,
     pub(crate) reject_list_url: Option<String>,
+    #[serde(default)]
+    pub(crate) issuance_type: Option<RgbLibIfaIssuanceType>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1486,6 +1511,7 @@ pub(crate) enum TransferKind {
     Send,
     Inflation,
     Burn,
+    Link,
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
@@ -1881,71 +1907,84 @@ pub(crate) async fn asset_link_create(
     State(state): State<Arc<AppState>>,
     WithRejection(Json(payload), _): WithRejection<Json<AssetLinkCreateRequest>, APIError>,
 ) -> Result<Json<AssetLinkCreateResponse>, APIError> {
-    let guard = state.check_unlocked().await?;
-    let unlocked_state = guard.as_ref().unwrap();
-    let issuer_pubkey = unlocked_state.runtime_node_pubkey();
+    no_cancel(async move {
+        let guard = state.check_unlocked().await?;
+        let unlocked_state = guard.as_ref().unwrap();
+        if unlocked_state.external_signer_mode {
+            return Err(APIError::UnsupportedInExternalSignerMode(
+                "asset linking is not supported in external signer mode".to_string(),
+            ));
+        }
 
-    let asset_id = payload.asset_id.trim().to_string();
-    let linked_asset_id = payload.linked_asset_id.trim().to_string();
+        let asset_id = payload.asset_id.trim().to_string();
+        let linked_asset_id = payload.linked_asset_id.trim().to_string();
 
-    let contract_id =
-        ContractId::from_str(&asset_id).map_err(|_| APIError::InvalidAssetID(asset_id.clone()))?;
-    let linked_contract_id = ContractId::from_str(&linked_asset_id)
-        .map_err(|_| APIError::InvalidAssetID(linked_asset_id.clone()))?;
+        let contract_id = ContractId::from_str(&asset_id)
+            .map_err(|_| APIError::InvalidAssetID(asset_id.clone()))?;
+        let linked_contract_id = ContractId::from_str(&linked_asset_id)
+            .map_err(|_| APIError::InvalidAssetID(linked_asset_id.clone()))?;
 
-    if contract_id == linked_contract_id {
-        return Err(APIError::InvalidRequest(
-            "asset_id and linked_asset_id must be different".to_string(),
-        ));
-    }
+        if contract_id == linked_contract_id {
+            return Err(APIError::InvalidRequest(
+                "asset_id and linked_asset_id must be different".to_string(),
+            ));
+        }
 
-    unlocked_state.rgb_get_asset_metadata(contract_id)?;
-    unlocked_state.rgb_get_asset_metadata(linked_contract_id)?;
+        let asset_record = asset_link_read_record(unlocked_state.kv_store.as_ref(), &asset_id)?;
 
-    let asset_record = asset_link_read_record(unlocked_state.kv_store.as_ref(), &asset_id)?;
-    let linked_asset_record =
-        asset_link_read_record(unlocked_state.kv_store.as_ref(), &linked_asset_id)?;
-
-    if asset_record.issuer_pubkey != issuer_pubkey
-        || linked_asset_record.issuer_pubkey != issuer_pubkey
-    {
-        return Err(APIError::InvalidRequest(
-            "asset link requires both assets to be issued by this node".to_string(),
-        ));
-    }
-
-    match asset_record.linked_asset_id.as_deref() {
-        None => {}
-        Some(existing_linked_asset_id) if existing_linked_asset_id == linked_asset_id => {
-            if asset_record.signature.is_some() && asset_record.created_at.is_some() {
-                return Ok(Json(AssetLinkCreateResponse {
-                    asset_link: asset_record,
-                }));
+        match asset_record.linked_asset_id.as_deref() {
+            None => {}
+            Some(existing_linked_asset_id) if existing_linked_asset_id == linked_asset_id => {
+                if asset_record.link_right_outpoint.is_none() && asset_record.created_at.is_some() {
+                    return Ok(Json(AssetLinkCreateResponse {
+                        asset_link: asset_record,
+                    }));
+                }
+                return Err(APIError::InvalidRequest(format!(
+                    "asset link record for asset_id {asset_id} is partially populated"
+                )));
             }
-            return Err(APIError::InvalidRequest(format!(
-                "asset link record for asset_id {asset_id} is partially populated"
-            )));
+            Some(_) => {
+                return Err(APIError::InvalidRequest(format!(
+                    "asset link already exists for asset_id {asset_id}"
+                )));
+            }
         }
-        Some(_) => {
-            return Err(APIError::InvalidRequest(format!(
-                "asset link already exists for asset_id {asset_id}"
-            )));
-        }
-    }
 
-    let network = format!("{:?}", state.static_state.network);
-    let message = format!("{ASSET_LINK_SIGNATURE_DOMAIN}:{network}:{asset_id}:{linked_asset_id}");
-    let signature = unlocked_state.sign_node_message(message.as_bytes())?;
-    let asset_link = AssetLink {
-        asset_id: asset_id.clone(),
-        linked_asset_id: Some(linked_asset_id),
-        issuer_pubkey,
-        signature: Some(signature),
-        created_at: Some(get_current_timestamp()),
-    };
-    asset_link_write_record(unlocked_state.kv_store.as_ref(), &asset_link)?;
+        let link_right_outpoint = asset_record.link_right_outpoint.clone().ok_or_else(|| {
+            APIError::InvalidRequest(format!(
+                "asset link record for asset_id {asset_id} is missing link_right_outpoint"
+            ))
+        })?;
 
-    Ok(Json(AssetLinkCreateResponse { asset_link }))
+        let link_ifa = unlocked_state.rgb_link_ifa(
+            asset_id.clone(),
+            linked_asset_id.clone(),
+            link_right_outpoint,
+            payload.fee_rate,
+            payload.min_confirmations,
+        )?;
+        let asset_link = AssetLink {
+            asset_id: asset_id.clone(),
+            linked_asset_id: Some(linked_asset_id),
+            created_at: Some(get_current_timestamp()),
+            link_right_outpoint: None,
+            txid: Some(link_ifa.txid),
+        };
+        asset_link_write_record(unlocked_state.kv_store.as_ref(), &asset_link)?;
+        asset_link_write_reverse_record(
+            unlocked_state.kv_store.as_ref(),
+            &asset_link.asset_id,
+            asset_link
+                .linked_asset_id
+                .as_deref()
+                .expect("linked asset id"),
+            asset_link.txid.clone(),
+        )?;
+
+        Ok(Json(AssetLinkCreateResponse { asset_link }))
+    })
+    .await
 }
 
 pub(crate) async fn asset_link_send_payment(
@@ -3224,7 +3263,17 @@ pub(crate) async fn issue_asset_ifa(
             payload.amounts,
             payload.inflation_amounts,
             payload.reject_list_url,
+            payload.issuance_type,
         )?;
+
+        let no_asset_link = AssetLink {
+            asset_id: asset.asset_id.clone(),
+            linked_asset_id: None,
+            created_at: None,
+            link_right_outpoint: asset.link_right_outpoint.clone(),
+            txid: None,
+        };
+        asset_link_write_record(unlocked_state.kv_store.as_ref(), &no_asset_link)?;
 
         Ok(Json(IssueAssetIFAResponse {
             asset: asset.into(),
@@ -3252,14 +3301,6 @@ pub(crate) async fn issue_asset_nia(
             payload.precision,
             payload.amounts,
         )?;
-        let no_asset_link = AssetLink {
-            asset_id: asset.asset_id.clone(),
-            linked_asset_id: None,
-            issuer_pubkey: unlocked_state.runtime_node_pubkey(),
-            signature: None,
-            created_at: None,
-        };
-        asset_link_write_record(unlocked_state.kv_store.as_ref(), &no_asset_link)?;
 
         Ok(Json(IssueAssetNIAResponse {
             asset: asset.into(),
@@ -3858,6 +3899,7 @@ pub(crate) async fn list_transfers(
                 rgb_lib::wallet::TransferKind::Send => TransferKind::Send,
                 rgb_lib::wallet::TransferKind::Inflation => TransferKind::Inflation,
                 rgb_lib::wallet::TransferKind::Burn => TransferKind::Burn,
+                rgb_lib::wallet::TransferKind::Link => TransferKind::Link,
             },
             txid: transfer.txid,
             recipient_id: transfer.recipient_id,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -33,7 +33,6 @@ use lightning::{
         router::{PaymentParameters, RouteParameters},
     },
     util::config::{ChannelHandshakeConfig, ChannelHandshakeLimits, UserConfig},
-    util::persist::KVStoreSync,
     util::{errors::APIError as LDKAPIError, IS_SWAP_SCID},
 };
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description, PaymentSecret};
@@ -116,7 +115,6 @@ use crate::{
 };
 
 const VIRTUAL_OPEN_MODE_TRUSTED_NO_BROADCAST: &str = "trusted_no_broadcast";
-const ASSET_LINK_NAMESPACE: &str = "asset_link";
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct AddressResponse {
@@ -194,6 +192,8 @@ pub(crate) struct AssetIFA {
     pub(crate) media: Option<Media>,
     pub(crate) reject_list_url: Option<String>,
     pub(crate) link_right_outpoint: Option<RgbLibOutpoint>,
+    pub(crate) linked_from_asset_id: Option<String>,
+    pub(crate) linked_to_asset_id: Option<String>,
 }
 
 impl From<RgbLibAssetIFA> for AssetIFA {
@@ -213,6 +213,8 @@ impl From<RgbLibAssetIFA> for AssetIFA {
             media: value.media.map(|m| m.into()),
             reject_list_url: value.reject_list_url,
             link_right_outpoint: value.link_right_outpoint,
+            linked_from_asset_id: value.linked_from_asset_id,
+            linked_to_asset_id: value.linked_to_asset_id,
         }
     }
 }
@@ -239,53 +241,6 @@ pub(crate) struct AssetLinkCreateResponse {
     pub(crate) asset_link: AssetLink,
 }
 
-pub(crate) fn asset_link_read_record(
-    kv_store: &dyn KVStoreSync,
-    asset_id: &str,
-) -> Result<AssetLink, APIError> {
-    match kv_store.read(ASSET_LINK_NAMESPACE, "", asset_id) {
-        Ok(bytes) => serde_json::from_slice(&bytes)
-            .map_err(|e| APIError::Unexpected(format!("invalid persisted asset link: {e}"))),
-        Err(e) if e.kind() == bitcoin::io::ErrorKind::NotFound => Err(APIError::InvalidRequest(
-            format!("asset link record for {asset_id} is missing"),
-        )),
-        Err(e) => Err(APIError::IO(std::io::Error::other(format!(
-            "asset link read failed: {e}"
-        )))),
-    }
-}
-
-fn asset_link_write_record(
-    kv_store: &dyn KVStoreSync,
-    asset_link: &AssetLink,
-) -> Result<(), APIError> {
-    let encoded = serde_json::to_vec(asset_link)
-        .map_err(|e| APIError::Unexpected(format!("failed to serialize asset link: {e}")))?;
-    kv_store
-        .write(ASSET_LINK_NAMESPACE, "", &asset_link.asset_id, encoded)
-        .map_err(|e| {
-            APIError::IO(std::io::Error::other(format!(
-                "asset link write failed: {e}"
-            )))
-        })
-}
-
-fn asset_link_write_reverse_record(
-    kv_store: &dyn KVStoreSync,
-    parent_asset_id: &str,
-    child_asset_id: &str,
-    txid: Option<String>,
-) -> Result<(), APIError> {
-    let reverse_asset_link = AssetLink {
-        asset_id: child_asset_id.to_string(),
-        linked_asset_id: Some(parent_asset_id.to_string()),
-        created_at: None,
-        link_right_outpoint: None,
-        txid,
-    };
-    asset_link_write_record(kv_store, &reverse_asset_link)
-}
-
 #[derive(Deserialize, Serialize)]
 pub(crate) struct AssetMetadataRequest {
     pub(crate) asset_id: String,
@@ -303,6 +258,8 @@ pub(crate) struct AssetMetadataResponse {
     pub(crate) ticker: Option<String>,
     pub(crate) details: Option<String>,
     pub(crate) token: Option<Token>,
+    pub(crate) linked_from_asset_id: Option<String>,
+    pub(crate) linked_to_asset_id: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1930,32 +1887,62 @@ pub(crate) async fn asset_link_create(
             ));
         }
 
-        let asset_record = asset_link_read_record(unlocked_state.kv_store.as_ref(), &asset_id)?;
+        let parent_metadata = unlocked_state.rgb_get_asset_metadata(contract_id)?;
+        let child_metadata = unlocked_state.rgb_get_asset_metadata(linked_contract_id)?;
 
-        match asset_record.linked_asset_id.as_deref() {
-            None => {}
-            Some(existing_linked_asset_id) if existing_linked_asset_id == linked_asset_id => {
-                if asset_record.link_right_outpoint.is_none() && asset_record.created_at.is_some() {
-                    return Ok(Json(AssetLinkCreateResponse {
-                        asset_link: asset_record,
-                    }));
-                }
-                return Err(APIError::InvalidRequest(format!(
-                    "asset link record for asset_id {asset_id} is partially populated"
+        if parent_metadata.asset_schema != RgbLibAssetSchema::Ifa
+            || child_metadata.asset_schema != RgbLibAssetSchema::Ifa
+        {
+            return Err(APIError::InvalidContractLink(
+                "asset linking is only supported for IFA assets".to_string(),
+            ));
+        }
+
+        match child_metadata.linked_from_asset_id.as_deref() {
+            Some(existing_parent_id) if existing_parent_id == asset_id => {}
+            Some(existing_parent_id) => {
+                return Err(APIError::InvalidContractLink(format!(
+                    "linked_asset_id {linked_asset_id} is already linked from {existing_parent_id}"
                 )));
             }
-            Some(_) => {
-                return Err(APIError::InvalidRequest(format!(
-                    "asset link already exists for asset_id {asset_id}"
+            None => {
+                return Err(APIError::InvalidContractLink(format!(
+                    "linked_asset_id {linked_asset_id} does not declare asset_id {asset_id} as its parent"
                 )));
             }
         }
 
-        let link_right_outpoint = asset_record.link_right_outpoint.clone().ok_or_else(|| {
-            APIError::InvalidRequest(format!(
-                "asset link record for asset_id {asset_id} is missing link_right_outpoint"
-            ))
-        })?;
+        match parent_metadata.linked_to_asset_id.as_deref() {
+            Some(existing_linked_asset_id) if existing_linked_asset_id == linked_asset_id => {
+                let link_transfer = unlocked_state.rgb_find_link_transfer(contract_id)?;
+                let created_at = link_transfer
+                    .as_ref()
+                    .map(|transfer| transfer.created_at.max(0) as u64)
+                    .unwrap_or_else(get_current_timestamp);
+                let asset_link = AssetLink {
+                    asset_id: asset_id.clone(),
+                    linked_asset_id: Some(linked_asset_id),
+                    created_at: Some(created_at),
+                    link_right_outpoint: None,
+                    txid: link_transfer.and_then(|transfer| transfer.txid),
+                };
+                return Ok(Json(AssetLinkCreateResponse { asset_link }));
+            }
+            Some(existing_linked_asset_id) => {
+                return Err(APIError::InvalidContractLink(format!(
+                    "asset_id {asset_id} is already linked to {existing_linked_asset_id}"
+                )));
+            }
+            None => {}
+        }
+
+        let link_right_outpoint = unlocked_state
+            .rgb_find_link_right_outpoint(contract_id)?
+            .ok_or_else(|| {
+                APIError::InvalidRequest(format!(
+                    "missing link_right_outpoint for asset_id {asset_id}"
+                ))
+            })?;
 
         let link_ifa = unlocked_state.rgb_link_ifa(
             asset_id.clone(),
@@ -1964,23 +1951,18 @@ pub(crate) async fn asset_link_create(
             payload.fee_rate,
             payload.min_confirmations,
         )?;
+        let link_transfer = unlocked_state.rgb_find_link_transfer(contract_id)?;
+        let created_at = link_transfer
+            .as_ref()
+            .map(|transfer| transfer.created_at.max(0) as u64)
+            .unwrap_or_else(get_current_timestamp);
         let asset_link = AssetLink {
             asset_id: asset_id.clone(),
             linked_asset_id: Some(linked_asset_id),
-            created_at: Some(get_current_timestamp()),
+            created_at: Some(created_at),
             link_right_outpoint: None,
             txid: Some(link_ifa.txid),
         };
-        asset_link_write_record(unlocked_state.kv_store.as_ref(), &asset_link)?;
-        asset_link_write_reverse_record(
-            unlocked_state.kv_store.as_ref(),
-            &asset_link.asset_id,
-            asset_link
-                .linked_asset_id
-                .as_deref()
-                .expect("linked asset id"),
-            asset_link.txid.clone(),
-        )?;
 
         Ok(Json(AssetLinkCreateResponse { asset_link }))
     })
@@ -2268,6 +2250,8 @@ pub(crate) async fn asset_metadata(
         ticker: metadata.ticker,
         details: metadata.details,
         token: metadata.token.map(|t| t.into()),
+        linked_from_asset_id: metadata.linked_from_asset_id,
+        linked_to_asset_id: metadata.linked_to_asset_id,
     }))
 }
 
@@ -3265,15 +3249,6 @@ pub(crate) async fn issue_asset_ifa(
             payload.reject_list_url,
             payload.issuance_type,
         )?;
-
-        let no_asset_link = AssetLink {
-            asset_id: asset.asset_id.clone(),
-            linked_asset_id: None,
-            created_at: None,
-            link_right_outpoint: asset.link_right_outpoint.clone(),
-            txid: None,
-        };
-        asset_link_write_record(unlocked_state.kv_store.as_ref(), &no_asset_link)?;
 
         Ok(Json(IssueAssetIFAResponse {
             asset: asset.into(),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -33,6 +33,7 @@ use lightning::{
         router::{PaymentParameters, RouteParameters},
     },
     util::config::{ChannelHandshakeConfig, ChannelHandshakeLimits, UserConfig},
+    util::persist::KVStoreSync,
     util::{errors::APIError as LDKAPIError, IS_SWAP_SCID},
 };
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description, PaymentSecret};
@@ -109,6 +110,8 @@ use crate::{
 };
 
 const VIRTUAL_OPEN_MODE_TRUSTED_NO_BROADCAST: &str = "trusted_no_broadcast";
+const ASSET_LINK_NAMESPACE: &str = "asset_link";
+const ASSET_LINK_SIGNATURE_DOMAIN: &str = "RLN_ASSET_LINK_V1";
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct AddressResponse {
@@ -205,6 +208,57 @@ impl From<RgbLibAssetIFA> for AssetIFA {
             reject_list_url: value.reject_list_url,
         }
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub(crate) struct AssetLink {
+    pub(crate) asset_id: String,
+    pub(crate) linked_asset_id: Option<String>,
+    pub(crate) issuer_pubkey: String,
+    pub(crate) signature: Option<String>,
+    pub(crate) created_at: Option<u64>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct AssetLinkCreateRequest {
+    pub(crate) asset_id: String,
+    pub(crate) linked_asset_id: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct AssetLinkCreateResponse {
+    pub(crate) asset_link: AssetLink,
+}
+
+fn asset_link_read_record(
+    kv_store: &dyn KVStoreSync,
+    asset_id: &str,
+) -> Result<AssetLink, APIError> {
+    match kv_store.read(ASSET_LINK_NAMESPACE, "", asset_id) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .map_err(|e| APIError::Unexpected(format!("invalid persisted asset link: {e}"))),
+        Err(e) if e.kind() == bitcoin::io::ErrorKind::NotFound => Err(APIError::InvalidRequest(
+            format!("asset link record for {asset_id} is missing"),
+        )),
+        Err(e) => Err(APIError::IO(std::io::Error::other(format!(
+            "asset link read failed: {e}"
+        )))),
+    }
+}
+
+fn asset_link_write_record(
+    kv_store: &dyn KVStoreSync,
+    asset_link: &AssetLink,
+) -> Result<(), APIError> {
+    let encoded = serde_json::to_vec(asset_link)
+        .map_err(|e| APIError::Unexpected(format!("failed to serialize asset link: {e}")))?;
+    kv_store
+        .write(ASSET_LINK_NAMESPACE, "", &asset_link.asset_id, encoded)
+        .map_err(|e| {
+            APIError::IO(std::io::Error::other(format!(
+                "asset link write failed: {e}"
+            )))
+        })
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1818,6 +1872,77 @@ pub(crate) async fn asset_balance(
     }))
 }
 
+pub(crate) async fn asset_link_create(
+    State(state): State<Arc<AppState>>,
+    WithRejection(Json(payload), _): WithRejection<Json<AssetLinkCreateRequest>, APIError>,
+) -> Result<Json<AssetLinkCreateResponse>, APIError> {
+    let guard = state.check_unlocked().await?;
+    let unlocked_state = guard.as_ref().unwrap();
+    let issuer_pubkey = unlocked_state.runtime_node_pubkey();
+
+    let asset_id = payload.asset_id.trim().to_string();
+    let linked_asset_id = payload.linked_asset_id.trim().to_string();
+
+    let contract_id =
+        ContractId::from_str(&asset_id).map_err(|_| APIError::InvalidAssetID(asset_id.clone()))?;
+    let linked_contract_id = ContractId::from_str(&linked_asset_id)
+        .map_err(|_| APIError::InvalidAssetID(linked_asset_id.clone()))?;
+
+    if contract_id == linked_contract_id {
+        return Err(APIError::InvalidRequest(
+            "asset_id and linked_asset_id must be different".to_string(),
+        ));
+    }
+
+    unlocked_state.rgb_get_asset_metadata(contract_id)?;
+    unlocked_state.rgb_get_asset_metadata(linked_contract_id)?;
+
+    let asset_record = asset_link_read_record(unlocked_state.kv_store.as_ref(), &asset_id)?;
+    let linked_asset_record =
+        asset_link_read_record(unlocked_state.kv_store.as_ref(), &linked_asset_id)?;
+
+    if asset_record.issuer_pubkey != issuer_pubkey
+        || linked_asset_record.issuer_pubkey != issuer_pubkey
+    {
+        return Err(APIError::InvalidRequest(
+            "asset link requires both assets to be issued by this node".to_string(),
+        ));
+    }
+
+    match asset_record.linked_asset_id.as_deref() {
+        None => {}
+        Some(existing_linked_asset_id) if existing_linked_asset_id == linked_asset_id => {
+            if asset_record.signature.is_some() && asset_record.created_at.is_some() {
+                return Ok(Json(AssetLinkCreateResponse {
+                    asset_link: asset_record,
+                }));
+            }
+            return Err(APIError::InvalidRequest(format!(
+                "asset link record for asset_id {asset_id} is partially populated"
+            )));
+        }
+        Some(_) => {
+            return Err(APIError::InvalidRequest(format!(
+                "asset link already exists for asset_id {asset_id}"
+            )));
+        }
+    }
+
+    let network = format!("{:?}", state.static_state.network);
+    let message = format!("{ASSET_LINK_SIGNATURE_DOMAIN}:{network}:{asset_id}:{linked_asset_id}");
+    let signature = unlocked_state.sign_node_message(message.as_bytes())?;
+    let asset_link = AssetLink {
+        asset_id: asset_id.clone(),
+        linked_asset_id: Some(linked_asset_id),
+        issuer_pubkey,
+        signature: Some(signature),
+        created_at: Some(get_current_timestamp()),
+    };
+    asset_link_write_record(unlocked_state.kv_store.as_ref(), &asset_link)?;
+
+    Ok(Json(AssetLinkCreateResponse { asset_link }))
+}
+
 pub(crate) async fn asset_metadata(
     State(state): State<Arc<AppState>>,
     WithRejection(Json(payload), _): WithRejection<Json<AssetMetadataRequest>, APIError>,
@@ -2866,6 +2991,14 @@ pub(crate) async fn issue_asset_nia(
             payload.precision,
             payload.amounts,
         )?;
+        let no_asset_link = AssetLink {
+            asset_id: asset.asset_id.clone(),
+            linked_asset_id: None,
+            issuer_pubkey: unlocked_state.runtime_node_pubkey(),
+            signature: None,
+            created_at: None,
+        };
+        asset_link_write_record(unlocked_state.kv_store.as_ref(), &no_asset_link)?;
 
         Ok(Json(IssueAssetNIAResponse {
             asset: asset.into(),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -71,6 +71,9 @@ use tokio::{
     time::timeout,
 };
 
+use crate::asset_link::{
+    AssetLinkAuthorizeParamsWire, AssetLinkSendPaymentRequest, ASSET_LINK_PROTOCOL_VERSION,
+};
 use crate::async_order::{
     write_async_payments_next_hash_index, AsyncOrderNewResultWire,
     AsyncOrderOutboundInvoiceResultWire,
@@ -79,6 +82,7 @@ use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
     AsyncOrderOutboundInvoiceResponse,
 };
+use crate::custom_msg_rpc::JSONRPC_MSG_RESPONSE_TIMEOUT_SECS;
 use crate::ldk::{
     clear_rgb_payment_pending, peer_has_live_channel, start_ldk, stop_ldk, LdkBackgroundServices,
     VirtualChannelSessionStatus,
@@ -230,7 +234,7 @@ pub(crate) struct AssetLinkCreateResponse {
     pub(crate) asset_link: AssetLink,
 }
 
-fn asset_link_read_record(
+pub(crate) fn asset_link_read_record(
     kv_store: &dyn KVStoreSync,
     asset_id: &str,
 ) -> Result<AssetLink, APIError> {
@@ -1941,6 +1945,222 @@ pub(crate) async fn asset_link_create(
     asset_link_write_record(unlocked_state.kv_store.as_ref(), &asset_link)?;
 
     Ok(Json(AssetLinkCreateResponse { asset_link }))
+}
+
+pub(crate) async fn asset_link_send_payment(
+    State(state): State<Arc<AppState>>,
+    WithRejection(Json(payload), _): WithRejection<Json<AssetLinkSendPaymentRequest>, APIError>,
+) -> Result<Json<SendPaymentResponse>, APIError> {
+    no_cancel(async move {
+        let guard = state.check_unlocked().await?;
+        let unlocked_state = guard.as_ref().unwrap();
+
+        let host_pubkey =
+            PublicKey::from_str(&payload.host_pubkey).map_err(|_| APIError::InvalidPubkey)?;
+        let asset_contract_id = ContractId::from_str(&payload.asset_id)
+            .map_err(|_| APIError::InvalidAssetID(payload.asset_id.clone()))?;
+
+        let invoice = Bolt11Invoice::from_str(&payload.invoice)
+            .map_err(|e| APIError::InvalidInvoice(e.to_string()))?;
+        let (linked_contract_id, asset_amount) =
+            match (invoice.rgb_contract_id(), invoice.rgb_amount()) {
+                (Some(contract_id), Some(amount)) => (contract_id, amount),
+                _ => {
+                    return Err(APIError::InvalidInvoice(s!(
+                        "linked payment requires an RGB invoice with contract ID and amount"
+                    )))
+                }
+            };
+        if linked_contract_id == asset_contract_id {
+            return Err(APIError::InvalidRequest(
+                "asset_id and the invoice asset must be different".to_string(),
+            ));
+        }
+        let amt_msat = match invoice.amount_milli_satoshis() {
+            Some(amt) if amt > 0 => amt,
+            _ => {
+                return Err(APIError::InvalidAmount(s!(
+                    "linked payment requires an invoice with a msat amount"
+                )))
+            }
+        };
+
+        let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());
+        let payment_secret = *invoice.payment_secret();
+        let receiver_pubkey = invoice.recover_payee_pub_key();
+
+        let params = AssetLinkAuthorizeParamsWire {
+            protocol_version: ASSET_LINK_PROTOCOL_VERSION,
+            payment_hash: hex_str(&payment_hash.0),
+            asset_id: payload.asset_id.clone(),
+            linked_asset_id: linked_contract_id.to_string(),
+            amount: asset_amount,
+            expiry_sec: invoice.expiry_time().as_secs(),
+        };
+        let request_id = new_jsonrpc_request_id();
+        let response_rx = unlocked_state
+            .asset_link_handler
+            .queue_asset_link_authorize(host_pubkey, Value::String(request_id.clone()), params)
+            .map_err(|err| APIError::InvalidRequest(err.message))?;
+        unlocked_state.peer_manager.process_events();
+        match timeout(
+            Duration::from_secs(JSONRPC_MSG_RESPONSE_TIMEOUT_SECS),
+            response_rx,
+        )
+        .await
+        {
+            Ok(Ok(Ok(_result))) => {}
+            Ok(Ok(Err(err))) => {
+                return Err(APIError::InvalidRequest(format!(
+                    "asset_link host error {}: {}",
+                    err.code, err.message
+                )));
+            }
+            Ok(Err(_)) => {
+                return Err(APIError::Network(s!(
+                    "/assetlink/sendpayment response channel closed before the host replied"
+                )));
+            }
+            Err(_) => {
+                unlocked_state
+                    .asset_link_handler
+                    .forget_asset_link_response(host_pubkey, &request_id);
+                return Err(APIError::Network(s!(
+                    "/assetlink/sendpayment timed out waiting for host authorization"
+                )));
+            }
+        }
+
+        let first_leg = get_route(
+            &unlocked_state.channel_manager,
+            &unlocked_state.router,
+            unlocked_state.kv_store.as_ref(),
+            unlocked_state.runtime_node_id(),
+            host_pubkey,
+            Some(amt_msat),
+            Some((asset_contract_id, asset_amount)),
+            vec![],
+        );
+        let second_leg = get_route(
+            &unlocked_state.channel_manager,
+            &unlocked_state.router,
+            unlocked_state.kv_store.as_ref(),
+            host_pubkey,
+            receiver_pubkey,
+            Some(amt_msat),
+            Some((linked_contract_id, asset_amount)),
+            invoice.route_hints(),
+        );
+        let (mut first_leg, mut second_leg) = match (first_leg, second_leg) {
+            (Some(f), Some(s)) => (f, s),
+            _ => {
+                return Err(APIError::NoRoute);
+            }
+        };
+
+        second_leg.paths[0].hops[0].short_channel_id |= IS_SWAP_SCID;
+
+        first_leg.paths[0]
+            .hops
+            .last_mut()
+            .expect("Path not to be empty")
+            .fee_msat = 0;
+
+        let fullpaths = first_leg.paths[0]
+            .hops
+            .clone()
+            .into_iter()
+            .map(|mut hop| {
+                hop.rgb_payment = Some((asset_contract_id, asset_amount));
+                hop
+            })
+            .chain(second_leg.paths[0].hops.clone().into_iter().map(|mut hop| {
+                hop.rgb_payment = Some((linked_contract_id, asset_amount));
+                hop
+            }))
+            .collect::<Vec<_>>();
+
+        let total_fee = fullpaths
+            .iter()
+            .rev()
+            .skip(1)
+            .map(|hop| hop.fee_msat)
+            .sum::<u64>();
+
+        if total_fee >= MAX_SWAP_FEE_MSAT {
+            return Err(APIError::FailedPayment(format!(
+                "Fee too high: {total_fee}"
+            )));
+        }
+
+        let route = Route {
+            paths: vec![LnPath {
+                hops: fullpaths,
+                blinded_tail: None,
+            }],
+            route_params: None,
+        };
+
+        let created_at = get_current_timestamp();
+        let payment_id = PaymentId(payment_hash.0);
+        let mut status = HTLCStatus::Pending;
+        unlocked_state.add_outbound_payment(
+            payment_id,
+            PaymentInfo {
+                preimage: None,
+                secret: Some(payment_secret),
+                status,
+                amt_msat: Some(amt_msat),
+                created_at,
+                updated_at: created_at,
+                payee_pubkey: invoice.get_payee_pub_key(),
+                expires_at: None,
+                claim_deadline_height: None,
+                invoice_type: None,
+                description_hash: description_hash_from_invoice(&invoice),
+                payment_idx: None,
+                async_hash_index: None,
+                async_host_node_id: None,
+            },
+        )?;
+        write_rgb_payment_info_file(
+            &payment_hash,
+            asset_contract_id,
+            asset_amount,
+            false,
+            false,
+            unlocked_state.kv_store.as_ref(),
+        );
+
+        match unlocked_state.channel_manager.send_payment_with_route(
+            route,
+            payment_hash,
+            RecipientOnionFields::secret_only(payment_secret),
+            payment_id,
+        ) {
+            Ok(()) => {
+                tracing::info!(
+                    "EVENT: sent linked-asset payment of {} to {}",
+                    asset_amount,
+                    receiver_pubkey
+                );
+            }
+            Err(e) => {
+                tracing::error!("ERROR: failed to send linked-asset payment: {:?}", e);
+                clear_rgb_payment_pending(&payment_hash, false, unlocked_state.kv_store.as_ref());
+                status = HTLCStatus::Failed;
+                unlocked_state.update_outbound_payment_status(payment_id, status);
+            }
+        }
+
+        Ok(Json(SendPaymentResponse {
+            payment_id: hex_str(&payment_id.0),
+            payment_hash: Some(hex_str(&payment_hash.0)),
+            payment_secret: Some(hex_str(&payment_secret.0)),
+            status,
+        }))
+    })
+    .await
 }
 
 pub(crate) async fn asset_metadata(

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -101,7 +101,9 @@ use crate::utils::{
 };
 use crate::{
     backup::{do_backup, restore_backup},
-    core_types::{HTLCStatus, SwapStatus, UnlockRequest as CoreUnlockRequest},
+    core_types::{
+        HTLCStatus, SwapStatus, UnlockRequest as CoreUnlockRequest, PENDING_SWAP_TIMEOUT_SECS,
+    },
     rgb::{check_rgb_proxy_endpoint, get_rgb_channel_info_optional},
 };
 use crate::{
@@ -2729,7 +2731,7 @@ pub(crate) async fn get_swap(
         if status == SwapStatus::Waiting && get_current_timestamp() > swap_data.swap_info.expiry {
             status = SwapStatus::Expired;
         } else if status == SwapStatus::Pending
-            && get_current_timestamp() > swap_data.initiated_at.unwrap() + 86400
+            && get_current_timestamp() > swap_data.initiated_at.unwrap() + PENDING_SWAP_TIMEOUT_SECS
         {
             status = SwapStatus::Failed;
         }
@@ -3466,7 +3468,7 @@ pub(crate) async fn list_swaps(
         if status == SwapStatus::Waiting && get_current_timestamp() > swap_data.swap_info.expiry {
             status = SwapStatus::Expired;
         } else if status == SwapStatus::Pending
-            && get_current_timestamp() > swap_data.initiated_at.unwrap() + 86400
+            && get_current_timestamp() > swap_data.initiated_at.unwrap() + PENDING_SWAP_TIMEOUT_SECS
         {
             status = SwapStatus::Failed;
         }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -221,8 +221,8 @@ impl From<RgbLibAssetIFA> for AssetIFA {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub(crate) struct AssetLink {
-    pub(crate) asset_id: String,
-    pub(crate) linked_asset_id: Option<String>,
+    pub(crate) parent_asset_id: String,
+    pub(crate) child_asset_id: Option<String>,
     pub(crate) created_at: Option<u64>,
     pub(crate) link_right_outpoint: Option<RgbLibOutpoint>,
     pub(crate) txid: Option<String>,
@@ -230,8 +230,8 @@ pub(crate) struct AssetLink {
 
 #[derive(Deserialize, Serialize)]
 pub(crate) struct AssetLinkCreateRequest {
-    pub(crate) asset_id: String,
-    pub(crate) linked_asset_id: String,
+    pub(crate) parent_asset_id: String,
+    pub(crate) child_asset_id: String,
     pub(crate) fee_rate: u64,
     pub(crate) min_confirmations: u8,
 }
@@ -1873,22 +1873,22 @@ pub(crate) async fn asset_link_create(
             ));
         }
 
-        let asset_id = payload.asset_id.trim().to_string();
-        let linked_asset_id = payload.linked_asset_id.trim().to_string();
+        let parent_id = payload.parent_asset_id.trim().to_string();
+        let child_id = payload.child_asset_id.trim().to_string();
 
-        let contract_id = ContractId::from_str(&asset_id)
-            .map_err(|_| APIError::InvalidAssetID(asset_id.clone()))?;
-        let linked_contract_id = ContractId::from_str(&linked_asset_id)
-            .map_err(|_| APIError::InvalidAssetID(linked_asset_id.clone()))?;
+        let parent_contract_id = ContractId::from_str(&parent_id)
+            .map_err(|_| APIError::InvalidAssetID(parent_id.clone()))?;
+        let child_contract_id = ContractId::from_str(&child_id)
+            .map_err(|_| APIError::InvalidAssetID(child_id.clone()))?;
 
-        if contract_id == linked_contract_id {
+        if parent_contract_id == child_contract_id {
             return Err(APIError::InvalidRequest(
-                "asset_id and linked_asset_id must be different".to_string(),
+                "parent and child contracts must be different".to_string(),
             ));
         }
 
-        let parent_metadata = unlocked_state.rgb_get_asset_metadata(contract_id)?;
-        let child_metadata = unlocked_state.rgb_get_asset_metadata(linked_contract_id)?;
+        let parent_metadata = unlocked_state.rgb_get_asset_metadata(parent_contract_id)?;
+        let child_metadata = unlocked_state.rgb_get_asset_metadata(child_contract_id)?;
 
         if parent_metadata.asset_schema != RgbLibAssetSchema::Ifa
             || child_metadata.asset_schema != RgbLibAssetSchema::Ifa
@@ -1899,29 +1899,29 @@ pub(crate) async fn asset_link_create(
         }
 
         match child_metadata.linked_from_asset_id.as_deref() {
-            Some(existing_parent_id) if existing_parent_id == asset_id => {}
+            Some(existing_parent_id) if existing_parent_id == parent_id => {}
             Some(existing_parent_id) => {
                 return Err(APIError::InvalidContractLink(format!(
-                    "linked_asset_id {linked_asset_id} is already linked from {existing_parent_id}"
+                    "child_asset_id {child_id} is already linked from {existing_parent_id}"
                 )));
             }
             None => {
                 return Err(APIError::InvalidContractLink(format!(
-                    "linked_asset_id {linked_asset_id} does not declare asset_id {asset_id} as its parent"
+                    "child_asset_id {child_id} does not declare parent_asset_id {parent_id} as its parent"
                 )));
             }
         }
 
         match parent_metadata.linked_to_asset_id.as_deref() {
-            Some(existing_linked_asset_id) if existing_linked_asset_id == linked_asset_id => {
-                let link_transfer = unlocked_state.rgb_find_link_transfer(contract_id)?;
+            Some(existing_linked_asset_id) if existing_linked_asset_id == child_id => {
+                let link_transfer = unlocked_state.rgb_find_link_transfer(parent_contract_id)?;
                 let created_at = link_transfer
                     .as_ref()
                     .map(|transfer| transfer.created_at.max(0) as u64)
                     .unwrap_or_else(get_current_timestamp);
                 let asset_link = AssetLink {
-                    asset_id: asset_id.clone(),
-                    linked_asset_id: Some(linked_asset_id),
+                    parent_asset_id: parent_id.clone(),
+                    child_asset_id: Some(child_id),
                     created_at: Some(created_at),
                     link_right_outpoint: None,
                     txid: link_transfer.and_then(|transfer| transfer.txid),
@@ -1930,35 +1930,35 @@ pub(crate) async fn asset_link_create(
             }
             Some(existing_linked_asset_id) => {
                 return Err(APIError::InvalidContractLink(format!(
-                    "asset_id {asset_id} is already linked to {existing_linked_asset_id}"
+                    "parent_asset_id {parent_id} is already linked to {existing_linked_asset_id}"
                 )));
             }
             None => {}
         }
 
         let link_right_outpoint = unlocked_state
-            .rgb_find_link_right_outpoint(contract_id)?
+            .rgb_find_link_right_outpoint(parent_contract_id)?
             .ok_or_else(|| {
                 APIError::InvalidRequest(format!(
-                    "missing link_right_outpoint for asset_id {asset_id}"
+                    "missing link_right_outpoint for parent_asset_id {parent_id}"
                 ))
             })?;
 
         let link_ifa = unlocked_state.rgb_link_ifa(
-            asset_id.clone(),
-            linked_asset_id.clone(),
+            parent_id.clone(),
+            child_id.clone(),
             link_right_outpoint,
             payload.fee_rate,
             payload.min_confirmations,
         )?;
-        let link_transfer = unlocked_state.rgb_find_link_transfer(contract_id)?;
+        let link_transfer = unlocked_state.rgb_find_link_transfer(parent_contract_id)?;
         let created_at = link_transfer
             .as_ref()
             .map(|transfer| transfer.created_at.max(0) as u64)
             .unwrap_or_else(get_current_timestamp);
         let asset_link = AssetLink {
-            asset_id: asset_id.clone(),
-            linked_asset_id: Some(linked_asset_id),
+            parent_asset_id: parent_id.clone(),
+            child_asset_id: Some(child_id),
             created_at: Some(created_at),
             link_right_outpoint: None,
             txid: Some(link_ifa.txid),
@@ -1979,7 +1979,7 @@ pub(crate) async fn asset_link_send_payment(
 
         let host_pubkey =
             PublicKey::from_str(&payload.host_pubkey).map_err(|_| APIError::InvalidPubkey)?;
-        let asset_contract_id = ContractId::from_str(&payload.asset_id)
+        let child_contract_id = ContractId::from_str(&payload.asset_id)
             .map_err(|_| APIError::InvalidAssetID(payload.asset_id.clone()))?;
 
         let invoice = Bolt11Invoice::from_str(&payload.invoice)
@@ -1988,7 +1988,7 @@ pub(crate) async fn asset_link_send_payment(
             return Err(APIError::InvalidInvoice(s!("invoice has expired")));
         }
 
-        let (linked_contract_id, asset_amount) =
+        let (parent_contract_id, asset_amount) =
             match (invoice.rgb_contract_id(), invoice.rgb_amount()) {
                 (Some(contract_id), Some(amount)) => (contract_id, amount),
                 _ => {
@@ -1997,7 +1997,7 @@ pub(crate) async fn asset_link_send_payment(
                     )))
                 }
             };
-        if linked_contract_id == asset_contract_id {
+        if parent_contract_id == child_contract_id {
             return Err(APIError::InvalidRequest(
                 "asset_id and the invoice asset must be different".to_string(),
             ));
@@ -2028,7 +2028,7 @@ pub(crate) async fn asset_link_send_payment(
             unlocked_state.runtime_node_id(),
             host_pubkey,
             Some(amt_msat),
-            Some((asset_contract_id, asset_amount)),
+            Some((child_contract_id, asset_amount)),
             vec![],
         );
         let second_leg = get_route(
@@ -2038,7 +2038,7 @@ pub(crate) async fn asset_link_send_payment(
             host_pubkey,
             receiver_pubkey,
             Some(amt_msat),
-            Some((linked_contract_id, asset_amount)),
+            Some((parent_contract_id, asset_amount)),
             invoice.route_hints(),
         );
         let (mut first_leg, mut second_leg) = match (first_leg, second_leg) {
@@ -2061,11 +2061,11 @@ pub(crate) async fn asset_link_send_payment(
             .clone()
             .into_iter()
             .map(|mut hop| {
-                hop.rgb_payment = Some((asset_contract_id, asset_amount));
+                hop.rgb_payment = Some((child_contract_id, asset_amount));
                 hop
             })
             .chain(second_leg.paths[0].hops.clone().into_iter().map(|mut hop| {
-                hop.rgb_payment = Some((linked_contract_id, asset_amount));
+                hop.rgb_payment = Some((parent_contract_id, asset_amount));
                 hop
             }))
             .collect::<Vec<_>>();
@@ -2095,7 +2095,7 @@ pub(crate) async fn asset_link_send_payment(
         let mut route_params = RouteParameters::from_payment_params_and_value(
             PaymentParameters::from_bolt11_invoice(&invoice),
             amt_msat,
-            Some((linked_contract_id, asset_amount)),
+            Some((parent_contract_id, asset_amount)),
         );
         route_params
             .set_max_path_length(
@@ -2115,8 +2115,8 @@ pub(crate) async fn asset_link_send_payment(
         let params = AssetLinkAuthorizeParamsWire {
             protocol_version: ASSET_LINK_PROTOCOL_VERSION,
             payment_hash: hex_str(&payment_hash.0),
-            asset_id: payload.asset_id.clone(),
-            linked_asset_id: linked_contract_id.to_string(),
+            asset_id: parent_contract_id.to_string(),
+            linked_asset_id: child_contract_id.to_string(),
             amount: asset_amount,
             expiry_sec: invoice.duration_until_expiry().as_secs(),
         };
@@ -2187,7 +2187,7 @@ pub(crate) async fn asset_link_send_payment(
         )?;
         write_rgb_payment_info_file(
             &payment_hash,
-            asset_contract_id,
+            child_contract_id,
             asset_amount,
             true,
             false,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -193,7 +193,7 @@ pub(crate) struct AssetIFA {
     pub(crate) balance: AssetBalanceResponse,
     pub(crate) media: Option<Media>,
     pub(crate) reject_list_url: Option<String>,
-    pub(crate) link_right_outpoint: Option<RgbLibOutpoint>,
+    pub(crate) issuance_link_right_outpoint: Option<RgbLibOutpoint>,
     pub(crate) linked_from_asset_id: Option<String>,
     pub(crate) linked_to_asset_id: Option<String>,
 }
@@ -214,7 +214,7 @@ impl From<RgbLibAssetIFA> for AssetIFA {
             balance: value.balance.into(),
             media: value.media.map(|m| m.into()),
             reject_list_url: value.reject_list_url,
-            link_right_outpoint: value.link_right_outpoint,
+            issuance_link_right_outpoint: value.issuance_link_right_outpoint,
             linked_from_asset_id: value.linked_from_asset_id,
             linked_to_asset_id: value.linked_to_asset_id,
         }
@@ -238,6 +238,7 @@ pub(crate) struct AssetMetadataResponse {
     pub(crate) ticker: Option<String>,
     pub(crate) details: Option<String>,
     pub(crate) token: Option<Token>,
+    pub(crate) unspent_link_right_outpoint: Option<RgbLibOutpoint>,
     pub(crate) linked_from_asset_id: Option<String>,
     pub(crate) linked_to_asset_id: Option<String>,
 }
@@ -548,6 +549,7 @@ pub(crate) struct DecodeRGBInvoiceRequest {
 #[derive(Deserialize, Serialize)]
 pub(crate) struct DecodeRGBInvoiceResponse {
     pub(crate) recipient_id: String,
+    pub(crate) proxy_recipient_id: String,
     pub(crate) recipient_type: RecipientType,
     pub(crate) asset_schema: Option<AssetSchema>,
     pub(crate) asset_id: Option<String>,
@@ -1427,6 +1429,7 @@ pub(crate) struct Transfer {
     pub(crate) kind: TransferKind,
     pub(crate) txid: Option<String>,
     pub(crate) recipient_id: Option<String>,
+    pub(crate) proxy_recipient_id: Option<String>,
     pub(crate) receive_utxo: Option<String>,
     pub(crate) change_utxo: Option<String>,
     pub(crate) expiration_timestamp: Option<u64>,
@@ -1872,6 +1875,7 @@ pub(crate) async fn asset_metadata(
         ticker: metadata.ticker,
         details: metadata.details,
         token: metadata.token.map(|t| t.into()),
+        unspent_link_right_outpoint: metadata.unspent_link_right_outpoint,
         linked_from_asset_id: metadata.linked_from_asset_id,
         linked_to_asset_id: metadata.linked_to_asset_id,
     }))
@@ -2378,6 +2382,7 @@ pub(crate) async fn decode_rgb_invoice(
 
     Ok(Json(DecodeRGBInvoiceResponse {
         recipient_id: invoice_data.recipient_id,
+        proxy_recipient_id: invoice_data.proxy_recipient_id,
         recipient_type: recipient_info.recipient_type.into(),
         asset_schema: invoice_data.asset_schema.map(|s| s.into()),
         asset_id: invoice_data.asset_id,
@@ -3500,6 +3505,7 @@ pub(crate) async fn list_transfers(
             },
             txid: transfer.txid,
             recipient_id: transfer.recipient_id,
+            proxy_recipient_id: transfer.proxy_recipient_id,
             receive_utxo: transfer.receive_utxo.map(|u| u.to_string()),
             change_utxo: transfer.change_utxo.map(|u| u.to_string()),
             expiration_timestamp: transfer.expiration_timestamp,
@@ -5318,6 +5324,7 @@ pub(crate) async fn vss_backup_info(
         "backup_exists": info.backup_exists,
         "server_version": info.server_version,
         "backup_required": info.backup_required,
+        "last_auto_backup_error": info.last_auto_backup_error,
         "pending_kv_writes": pending_kv_writes,
     })))
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -72,12 +72,14 @@ use tokio::{
 };
 
 use crate::asset_link::{
-    find_linked_asset_channel, has_sufficient_asset_channel, send_linked_asset_payment,
+    create_asset_link, find_linked_asset_channel, has_sufficient_asset_channel,
+    send_linked_asset_payment,
 };
 use crate::async_order::{
     write_async_payments_next_hash_index, AsyncOrderNewResultWire,
     AsyncOrderOutboundInvoiceResultWire,
 };
+use crate::core_types::asset_link::{AssetLinkRequest, AssetLinkResponse};
 use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
     AsyncOrderOutboundInvoiceResponse,
@@ -217,28 +219,6 @@ impl From<RgbLibAssetIFA> for AssetIFA {
             linked_to_asset_id: value.linked_to_asset_id,
         }
     }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub(crate) struct AssetLink {
-    pub(crate) parent_asset_id: String,
-    pub(crate) child_asset_id: Option<String>,
-    pub(crate) created_at: Option<u64>,
-    pub(crate) link_right_outpoint: Option<RgbLibOutpoint>,
-    pub(crate) txid: Option<String>,
-}
-
-#[derive(Deserialize, Serialize)]
-pub(crate) struct AssetLinkCreateRequest {
-    pub(crate) parent_asset_id: String,
-    pub(crate) child_asset_id: String,
-    pub(crate) fee_rate: u64,
-    pub(crate) min_confirmations: u8,
-}
-
-#[derive(Deserialize, Serialize)]
-pub(crate) struct AssetLinkCreateResponse {
-    pub(crate) asset_link: AssetLink,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1853,111 +1833,16 @@ pub(crate) async fn asset_balance(
     }))
 }
 
-pub(crate) async fn asset_link_create(
+pub(crate) async fn asset_link(
     State(state): State<Arc<AppState>>,
-    WithRejection(Json(payload), _): WithRejection<Json<AssetLinkCreateRequest>, APIError>,
-) -> Result<Json<AssetLinkCreateResponse>, APIError> {
+    WithRejection(Json(payload), _): WithRejection<Json<AssetLinkRequest>, APIError>,
+) -> Result<Json<AssetLinkResponse>, APIError> {
     no_cancel(async move {
         let guard = state.check_unlocked().await?;
         let unlocked_state = guard.as_ref().unwrap();
-        if unlocked_state.external_signer_mode {
-            return Err(APIError::UnsupportedInExternalSignerMode(
-                "asset linking is not supported in external signer mode".to_string(),
-            ));
-        }
+        let asset_link = create_asset_link(unlocked_state, payload)?;
 
-        let parent_id = payload.parent_asset_id.trim().to_string();
-        let child_id = payload.child_asset_id.trim().to_string();
-
-        let parent_contract_id = ContractId::from_str(&parent_id)
-            .map_err(|_| APIError::InvalidAssetID(parent_id.clone()))?;
-        let child_contract_id = ContractId::from_str(&child_id)
-            .map_err(|_| APIError::InvalidAssetID(child_id.clone()))?;
-
-        if parent_contract_id == child_contract_id {
-            return Err(APIError::InvalidRequest(
-                "parent and child contracts must be different".to_string(),
-            ));
-        }
-
-        let parent_metadata = unlocked_state.rgb_get_asset_metadata(parent_contract_id)?;
-        let child_metadata = unlocked_state.rgb_get_asset_metadata(child_contract_id)?;
-
-        if parent_metadata.asset_schema != RgbLibAssetSchema::Ifa
-            || child_metadata.asset_schema != RgbLibAssetSchema::Ifa
-        {
-            return Err(APIError::InvalidContractLink(
-                "asset linking is only supported for IFA assets".to_string(),
-            ));
-        }
-
-        match child_metadata.linked_from_asset_id.as_deref() {
-            Some(existing_parent_id) if existing_parent_id == parent_id => {}
-            Some(existing_parent_id) => {
-                return Err(APIError::InvalidContractLink(format!(
-                    "child_asset_id {child_id} is already linked from {existing_parent_id}"
-                )));
-            }
-            None => {
-                return Err(APIError::InvalidContractLink(format!(
-                    "child_asset_id {child_id} does not declare parent_asset_id {parent_id} as its parent"
-                )));
-            }
-        }
-
-        match parent_metadata.linked_to_asset_id.as_deref() {
-            Some(existing_linked_asset_id) if existing_linked_asset_id == child_id => {
-                let link_transfer = unlocked_state.rgb_find_link_transfer(parent_contract_id)?;
-                let created_at = link_transfer
-                    .as_ref()
-                    .map(|transfer| transfer.created_at.max(0) as u64)
-                    .unwrap_or_else(get_current_timestamp);
-                let asset_link = AssetLink {
-                    parent_asset_id: parent_id.clone(),
-                    child_asset_id: Some(child_id),
-                    created_at: Some(created_at),
-                    link_right_outpoint: None,
-                    txid: link_transfer.and_then(|transfer| transfer.txid),
-                };
-                return Ok(Json(AssetLinkCreateResponse { asset_link }));
-            }
-            Some(existing_linked_asset_id) => {
-                return Err(APIError::InvalidContractLink(format!(
-                    "parent_asset_id {parent_id} is already linked to {existing_linked_asset_id}"
-                )));
-            }
-            None => {}
-        }
-
-        let link_right_outpoint = unlocked_state
-            .rgb_find_link_right_outpoint(parent_contract_id)?
-            .ok_or_else(|| {
-                APIError::InvalidRequest(format!(
-                    "missing link_right_outpoint for parent_asset_id {parent_id}"
-                ))
-            })?;
-
-        let link_ifa = unlocked_state.rgb_link_ifa(
-            parent_id.clone(),
-            child_id.clone(),
-            link_right_outpoint,
-            payload.fee_rate,
-            payload.min_confirmations,
-        )?;
-        let link_transfer = unlocked_state.rgb_find_link_transfer(parent_contract_id)?;
-        let created_at = link_transfer
-            .as_ref()
-            .map(|transfer| transfer.created_at.max(0) as u64)
-            .unwrap_or_else(get_current_timestamp);
-        let asset_link = AssetLink {
-            parent_asset_id: parent_id.clone(),
-            child_asset_id: Some(child_id),
-            created_at: Some(created_at),
-            link_right_outpoint: None,
-            txid: Some(link_ifa.txid),
-        };
-
-        Ok(Json(AssetLinkCreateResponse { asset_link }))
+        Ok(Json(asset_link))
     })
     .await
 }

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -58,6 +58,7 @@ use lightning::util::config::{
 };
 use lightning::util::errors::APIError as LDKAPIError;
 use lightning::util::message_signing;
+use lightning::util::persist::KVStoreSync;
 use lightning::util::IS_SWAP_SCID;
 use lightning::{
     onion_message::messenger::Destination, onion_message::messenger::MessageSendInstructions,
@@ -88,14 +89,17 @@ use rgb_lib::wallet::rust_only::IndexerProtocol as RgbLibIndexerProtocol;
 use rgb_lib::wallet::RecipientType as RgbLibRecipientType;
 use rgb_lib::wallet::{
     AssetCFA as RgbLibAssetCFA, AssetIFA as RgbLibAssetIFA, AssetNIA as RgbLibAssetNIA,
-    AssetUDA as RgbLibAssetUDA, EmbeddedMedia as RgbLibEmbeddedMedia, Media as RgbLibMedia,
+    AssetUDA as RgbLibAssetUDA, EmbeddedMedia as RgbLibEmbeddedMedia,
+    IfaIssuanceType as RgbLibIfaIssuanceType, Media as RgbLibMedia, Outpoint as RgbLibOutpoint,
     ProofOfReserves as RgbLibProofOfReserves, Token as RgbLibToken, TokenLight as RgbLibTokenLight,
 };
 use rgb_lib::BitcoinNetwork as RgbBitcoinNetwork;
 use rgb_lib::{AssetSchema as RgbLibAssetSchema, Assignment as RgbLibAssignment};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 const SDK_VIRTUAL_OPEN_MODE_TRUSTED_NO_BROADCAST: &str = "trusted_no_broadcast";
+const ASSET_LINK_NAMESPACE: &str = "asset_link";
 
 struct OpenChannelVirtualIntentGuard {
     unlocked_state: Arc<crate::utils::UnlockedAppState>,
@@ -463,6 +467,7 @@ pub(crate) struct IssueAssetIFARequestData {
     pub(crate) name: String,
     pub(crate) precision: u8,
     pub(crate) reject_list_url: Option<String>,
+    pub(crate) issuance_type: Option<RgbLibIfaIssuanceType>,
 }
 
 pub(crate) struct IssueAssetUdaRequestData {
@@ -746,6 +751,7 @@ pub(crate) enum TransferKind {
     Send,
     Inflation,
     Burn,
+    Link,
 }
 
 #[derive(Debug, PartialEq)]
@@ -993,6 +999,16 @@ pub(crate) struct AssetIFA {
     pub(crate) balance: AssetBalance,
     pub(crate) media: Option<Media>,
     pub(crate) reject_list_url: Option<String>,
+    pub(crate) link_right_outpoint: Option<RgbLibOutpoint>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct AssetLink {
+    asset_id: String,
+    linked_asset_id: Option<String>,
+    created_at: Option<u64>,
+    link_right_outpoint: Option<RgbLibOutpoint>,
+    txid: Option<String>,
 }
 
 impl From<RgbLibAssetIFA> for AssetIFA {
@@ -1017,8 +1033,24 @@ impl From<RgbLibAssetIFA> for AssetIFA {
             },
             media: value.media.map(Into::into),
             reject_list_url: value.reject_list_url,
+            link_right_outpoint: value.link_right_outpoint,
         }
     }
+}
+
+fn asset_link_write_record(
+    kv_store: &dyn KVStoreSync,
+    asset_link: &AssetLink,
+) -> Result<(), APIError> {
+    let encoded = serde_json::to_vec(asset_link)
+        .map_err(|e| APIError::Unexpected(format!("failed to serialize asset link: {e}")))?;
+    kv_store
+        .write(ASSET_LINK_NAMESPACE, "", &asset_link.asset_id, encoded)
+        .map_err(|e| {
+            APIError::IO(std::io::Error::other(format!(
+                "asset link write failed: {e}"
+            )))
+        })
 }
 
 /*
@@ -2474,7 +2506,17 @@ pub(crate) async fn issue_asset_ifa(
         request.amounts,
         request.inflation_amounts,
         request.reject_list_url,
+        request.issuance_type,
     )?;
+
+    let no_asset_link = AssetLink {
+        asset_id: asset.asset_id.clone(),
+        linked_asset_id: None,
+        created_at: None,
+        link_right_outpoint: asset.link_right_outpoint.clone(),
+        txid: None,
+    };
+    asset_link_write_record(unlocked_state.kv_store.as_ref(), &no_asset_link)?;
 
     Ok(asset.into())
 }
@@ -4259,6 +4301,7 @@ fn to_transfer_data(transfer: rgb_lib::wallet::Transfer) -> TransferData {
             rgb_lib::wallet::TransferKind::Send => TransferKind::Send,
             rgb_lib::wallet::TransferKind::Inflation => TransferKind::Inflation,
             rgb_lib::wallet::TransferKind::Burn => TransferKind::Burn,
+            rgb_lib::wallet::TransferKind::Link => TransferKind::Link,
         },
         txid: transfer.txid,
         recipient_id: transfer.recipient_id,
@@ -4930,6 +4973,7 @@ mod tests {
                 name: "IFA".to_string(),
                 precision: 0,
                 reject_list_url: None,
+                issuance_type: None,
             },
         )
         .await;

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -24,11 +24,12 @@ use crate::signer::{
 use crate::swap::{SwapData, SwapInfo, SwapString};
 use crate::utils::{
     check_already_initialized, check_channel_id, check_password_strength, check_password_validity,
-    connect_peer_if_necessary, encrypt_and_save_mnemonic, get_current_timestamp,
-    get_max_local_rgb_amount, get_route, hex_str, hex_str_to_compressed_pubkey, hex_str_to_vec,
-    is_external_signer_mode_configured, new_jsonrpc_request_id, parse_peer_info,
-    validate_and_parse_description_hash, validate_and_parse_payment_hash,
-    validate_and_parse_payment_preimage, AppState, UserOnionMessageContents,
+    connect_peer_if_necessary, description_hash_from_invoice, encrypt_and_save_mnemonic,
+    get_current_timestamp, get_max_local_rgb_amount, get_route, hex_str,
+    hex_str_to_compressed_pubkey, hex_str_to_vec, is_external_signer_mode_configured,
+    new_jsonrpc_request_id, parse_peer_info, validate_and_parse_description_hash,
+    validate_and_parse_payment_hash, validate_and_parse_payment_preimage, AppState,
+    UserOnionMessageContents,
 };
 use amplify::{map, s};
 use bitcoin::hashes::sha256::Hash as Sha256;
@@ -3159,6 +3160,9 @@ pub(crate) async fn send_payment(
     } else {
         let invoice = Bolt11Invoice::from_str(&request.invoice)
             .map_err(|e| APIError::InvalidInvoice(e.to_string()))?;
+        if invoice.is_expired() {
+            return Err(APIError::InvalidInvoice(s!("invoice has expired")));
+        }
 
         let payment_id = PaymentId((*invoice.payment_hash()).to_byte_array());
         let payment_secret = Some(*invoice.payment_secret());
@@ -3234,7 +3238,7 @@ pub(crate) async fn send_payment(
                 payee_pubkey: invoice.get_payee_pub_key(),
                 expires_at: None,
                 invoice_type: None,
-                description_hash: crate::routes::description_hash_from_invoice(&invoice),
+                description_hash: description_hash_from_invoice(&invoice),
                 payment_idx: None,
                 async_hash_index: None,
                 async_host_node_id: None,
@@ -3856,7 +3860,7 @@ pub(crate) async fn create_ln_invoice(
             payee_pubkey: unlocked_state.runtime_node_id(),
             expires_at: Some(created_at + expiry_sec as u64),
             invoice_type: Some(invoice_type),
-            description_hash: crate::routes::description_hash_from_invoice(&invoice),
+            description_hash: description_hash_from_invoice(&invoice),
             payment_idx: None,
             async_hash_index: None,
             async_host_node_id: None,

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -99,7 +99,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 const SDK_VIRTUAL_OPEN_MODE_TRUSTED_NO_BROADCAST: &str = "trusted_no_broadcast";
-const ASSET_LINK_NAMESPACE: &str = "asset_link";
 
 struct OpenChannelVirtualIntentGuard {
     unlocked_state: Arc<crate::utils::UnlockedAppState>,
@@ -233,6 +232,8 @@ pub(crate) struct AssetMetadataData {
     pub(crate) ticker: Option<String>,
     pub(crate) details: Option<String>,
     pub(crate) token: Option<Token>,
+    pub(crate) linked_from_asset_id: Option<String>,
+    pub(crate) linked_to_asset_id: Option<String>,
 }
 
 pub(crate) struct BtcBalance {
@@ -1000,15 +1001,8 @@ pub(crate) struct AssetIFA {
     pub(crate) media: Option<Media>,
     pub(crate) reject_list_url: Option<String>,
     pub(crate) link_right_outpoint: Option<RgbLibOutpoint>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-struct AssetLink {
-    asset_id: String,
-    linked_asset_id: Option<String>,
-    created_at: Option<u64>,
-    link_right_outpoint: Option<RgbLibOutpoint>,
-    txid: Option<String>,
+    pub(crate) linked_from_asset_id: Option<String>,
+    pub(crate) linked_to_asset_id: Option<String>,
 }
 
 impl From<RgbLibAssetIFA> for AssetIFA {
@@ -1034,23 +1028,10 @@ impl From<RgbLibAssetIFA> for AssetIFA {
             media: value.media.map(Into::into),
             reject_list_url: value.reject_list_url,
             link_right_outpoint: value.link_right_outpoint,
+            linked_from_asset_id: value.linked_from_asset_id,
+            linked_to_asset_id: value.linked_to_asset_id,
         }
     }
-}
-
-fn asset_link_write_record(
-    kv_store: &dyn KVStoreSync,
-    asset_link: &AssetLink,
-) -> Result<(), APIError> {
-    let encoded = serde_json::to_vec(asset_link)
-        .map_err(|e| APIError::Unexpected(format!("failed to serialize asset link: {e}")))?;
-    kv_store
-        .write(ASSET_LINK_NAMESPACE, "", &asset_link.asset_id, encoded)
-        .map_err(|e| {
-            APIError::IO(std::io::Error::other(format!(
-                "asset link write failed: {e}"
-            )))
-        })
 }
 
 /*
@@ -1619,6 +1600,8 @@ pub(crate) async fn asset_metadata(
         ticker: metadata.ticker,
         details: metadata.details,
         token: metadata.token.map(Into::into),
+        linked_from_asset_id: metadata.linked_from_asset_id,
+        linked_to_asset_id: metadata.linked_to_asset_id,
     })
 }
 
@@ -2508,15 +2491,6 @@ pub(crate) async fn issue_asset_ifa(
         request.reject_list_url,
         request.issuance_type,
     )?;
-
-    let no_asset_link = AssetLink {
-        asset_id: asset.asset_id.clone(),
-        linked_asset_id: None,
-        created_at: None,
-        link_right_outpoint: asset.link_right_outpoint.clone(),
-        txid: None,
-    };
-    asset_link_write_record(unlocked_state.kv_store.as_ref(), &no_asset_link)?;
 
     Ok(asset.into())
 }

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -9,6 +9,7 @@ use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
     AsyncOrderOutboundInvoiceResponse,
 };
+use crate::core_types::PENDING_SWAP_TIMEOUT_SECS;
 use crate::error::APIError;
 use crate::ldk::{
     clear_rgb_payment_pending, peer_has_live_channel, start_ldk, write_rgb_payment_info_file,
@@ -4162,7 +4163,7 @@ fn map_swap(
     if status == SwapStatus::Waiting && get_current_timestamp() > swap_data.swap_info.expiry {
         status = SwapStatus::Expired;
     } else if status == SwapStatus::Pending
-        && get_current_timestamp() > swap_data.initiated_at.unwrap() + 86400
+        && get_current_timestamp() > swap_data.initiated_at.unwrap() + PENDING_SWAP_TIMEOUT_SECS
     {
         status = SwapStatus::Failed;
     }

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -236,6 +236,7 @@ pub(crate) struct AssetMetadataData {
     pub(crate) ticker: Option<String>,
     pub(crate) details: Option<String>,
     pub(crate) token: Option<Token>,
+    pub(crate) unspent_link_right_outpoint: Option<RgbLibOutpoint>,
     pub(crate) linked_from_asset_id: Option<String>,
     pub(crate) linked_to_asset_id: Option<String>,
 }
@@ -266,6 +267,7 @@ pub(crate) struct DecodeLnInvoiceData {
 
 pub(crate) struct DecodeRgbInvoiceData {
     pub(crate) recipient_id: String,
+    pub(crate) proxy_recipient_id: String,
     pub(crate) recipient_type: RgbLibRecipientType,
     pub(crate) asset_schema: Option<RgbLibAssetSchema>,
     pub(crate) asset_id: Option<String>,
@@ -654,6 +656,7 @@ pub(crate) struct TransferData {
     pub(crate) kind: TransferKind,
     pub(crate) txid: Option<String>,
     pub(crate) recipient_id: Option<String>,
+    pub(crate) proxy_recipient_id: Option<String>,
     pub(crate) receive_utxo: Option<String>,
     pub(crate) change_utxo: Option<String>,
     pub(crate) expiration: Option<i64>,
@@ -1004,7 +1007,7 @@ pub(crate) struct AssetIFA {
     pub(crate) balance: AssetBalance,
     pub(crate) media: Option<Media>,
     pub(crate) reject_list_url: Option<String>,
-    pub(crate) link_right_outpoint: Option<RgbLibOutpoint>,
+    pub(crate) issuance_link_right_outpoint: Option<RgbLibOutpoint>,
     pub(crate) linked_from_asset_id: Option<String>,
     pub(crate) linked_to_asset_id: Option<String>,
 }
@@ -1031,7 +1034,7 @@ impl From<RgbLibAssetIFA> for AssetIFA {
             },
             media: value.media.map(Into::into),
             reject_list_url: value.reject_list_url,
-            link_right_outpoint: value.link_right_outpoint,
+            issuance_link_right_outpoint: value.issuance_link_right_outpoint,
             linked_from_asset_id: value.linked_from_asset_id,
             linked_to_asset_id: value.linked_to_asset_id,
         }
@@ -1613,6 +1616,7 @@ pub(crate) async fn asset_metadata(
         ticker: metadata.ticker,
         details: metadata.details,
         token: metadata.token.map(Into::into),
+        unspent_link_right_outpoint: metadata.unspent_link_right_outpoint,
         linked_from_asset_id: metadata.linked_from_asset_id,
         linked_to_asset_id: metadata.linked_to_asset_id,
     })
@@ -3733,6 +3737,7 @@ pub(crate) async fn decode_rgb_invoice(
 
     Ok(DecodeRgbInvoiceData {
         recipient_id: invoice_data.recipient_id,
+        proxy_recipient_id: invoice_data.proxy_recipient_id,
         recipient_type: recipient_info.recipient_type,
         asset_schema: invoice_data.asset_schema,
         asset_id: invoice_data.asset_id,
@@ -4295,6 +4300,7 @@ fn to_transfer_data(transfer: rgb_lib::wallet::Transfer) -> TransferData {
         },
         txid: transfer.txid,
         recipient_id: transfer.recipient_id,
+        proxy_recipient_id: transfer.proxy_recipient_id,
         receive_utxo: transfer.receive_utxo.map(|u| u.to_string()),
         change_utxo: transfer.change_utxo.map(|u| u.to_string()),
         expiration: transfer.expiration_timestamp.map(|t| t as i64),

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1,10 +1,12 @@
 // NOTE: This module mirrors core behavior from `src/routes.rs` for SDK consumers.
 // If route-level business logic changes, keep SDK equivalents in sync.
 
+use crate::asset_link::create_asset_link;
 use crate::async_order::{
     write_async_payments_next_hash_index, AsyncOrderNewResultWire,
     AsyncOrderOutboundInvoiceResultWire,
 };
+use crate::core_types::asset_link::{AssetLinkRequest, AssetLinkResponse};
 use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
     AsyncOrderOutboundInvoiceResponse,
@@ -1577,6 +1579,15 @@ pub(crate) async fn asset_balance(
         offchain_outbound,
         offchain_inbound,
     })
+}
+
+pub(crate) async fn asset_link(
+    state: Arc<AppState>,
+    params: AssetLinkRequest,
+) -> Result<AssetLinkResponse, APIError> {
+    let guard = check_unlocked(&state).await?;
+    let unlocked_state = guard.as_ref().unwrap();
+    create_asset_link(unlocked_state, params)
 }
 
 pub(crate) async fn asset_metadata(

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -1,4 +1,7 @@
-use lightning::{impl_writeable_tlv_based, types::payment::PaymentHash};
+use bitcoin::secp256k1::PublicKey;
+use lightning::{
+    impl_writeable_tlv_based, ln::channelmanager::InterceptId, types::payment::PaymentHash,
+};
 use rgb_lib::ContractId;
 use std::convert::TryInto;
 use std::fmt;
@@ -16,6 +19,8 @@ pub(crate) struct SwapData {
     pub(crate) requested_at: u64,
     pub(crate) initiated_at: Option<u64>,
     pub(crate) completed_at: Option<u64>,
+    pub(crate) pending_intercept_id: Option<InterceptId>,
+    pub(crate) authorized_peer: Option<PublicKey>,
 }
 
 impl_writeable_tlv_based!(SwapData, {
@@ -24,6 +29,8 @@ impl_writeable_tlv_based!(SwapData, {
     (2, requested_at, required),
     (3, initiated_at, option),
     (4, completed_at, option),
+    (5, pending_intercept_id, option),
+    (6, authorized_peer, option),
 });
 
 impl SwapData {
@@ -34,6 +41,8 @@ impl SwapData {
             requested_at: get_current_timestamp(),
             initiated_at: None,
             completed_at: None,
+            pending_intercept_id: None,
+            authorized_peer: None,
         }
     }
 }

--- a/src/test/asset_link.rs
+++ b/src/test/asset_link.rs
@@ -2,6 +2,23 @@ use super::*;
 
 const TEST_DIR_BASE: &str = "tmp/asset_link/";
 
+async fn wait_for_link_transfer_settled(node_addr: SocketAddr, asset_id: &str) {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        refresh_transfers(node_addr).await;
+        let transfers = list_transfers(node_addr, asset_id).await;
+        if transfers.iter().any(|transfer| {
+            transfer.kind == TransferKind::Link && transfer.status == TransferStatus::Settled
+        }) {
+            break;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 70.0 {
+            panic!("link transfer for asset {asset_id} did not settle");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
 #[serial_test::serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[traced_test]
@@ -13,14 +30,14 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     fund_and_create_utxos(node_addr, Some(12)).await;
 
     let legacy_asset = issue_asset_ifa(node_addr).await;
-    assert_eq!(legacy_asset.link_right_outpoint, None);
+    assert_eq!(legacy_asset.issuance_link_right_outpoint, None);
     let legacy_asset_id = legacy_asset.asset_id;
 
     let parent_asset =
         issue_asset_ifa_with_type(node_addr, Some(IfaIssuanceType::LinkRightOnly)).await;
     let parent_asset_id = parent_asset.asset_id;
-    let _link_right_outpoint = parent_asset
-        .link_right_outpoint
+    let issuance_link_right_outpoint = parent_asset
+        .issuance_link_right_outpoint
         .expect("link-right outpoint");
     let child_asset = issue_asset_ifa_with_type(
         node_addr,
@@ -30,10 +47,14 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
         }),
     )
     .await;
-    assert_eq!(child_asset.link_right_outpoint, None);
+    assert_eq!(child_asset.issuance_link_right_outpoint, None);
     let child_asset_id = child_asset.asset_id;
 
     let parent_metadata = asset_metadata(node_addr, &parent_asset_id).await;
+    assert_eq!(
+        parent_metadata.unspent_link_right_outpoint,
+        Some(issuance_link_right_outpoint)
+    );
     assert_eq!(parent_metadata.linked_from_asset_id, None);
     assert_eq!(parent_metadata.linked_to_asset_id, None);
     let child_metadata = asset_metadata(node_addr, &child_asset_id).await;
@@ -42,11 +63,11 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
         Some(parent_asset_id.clone())
     );
     assert_eq!(child_metadata.linked_to_asset_id, None);
+    assert_eq!(child_metadata.unspent_link_right_outpoint, None);
 
     let invalid_link_payload = AssetLinkRequest {
         parent_asset_id: parent_asset_id.clone(),
         child_asset_id: legacy_asset_id.clone(),
-        fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
     let invalid_link_res = reqwest::Client::new()
@@ -74,7 +95,6 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     let missing_link_right_payload = AssetLinkRequest {
         parent_asset_id: legacy_asset_id.clone(),
         child_asset_id: missing_link_right_child.asset_id.clone(),
-        fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
     let missing_link_right_res = reqwest::Client::new()
@@ -86,7 +106,7 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     check_response_is_nok(
         missing_link_right_res,
         StatusCode::BAD_REQUEST,
-        "missing link_right_outpoint",
+        "missing unspent_link_right_outpoint",
         "InvalidRequest",
     )
     .await;
@@ -100,6 +120,25 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
         .is_some_and(|txid| !txid.is_empty()));
     assert!(asset_link.created_at.is_some());
 
+    // the link transaction consumes the link right allocation in the UTXO,
+    // so it must be non-existent after the RGB transition
+    mine(false);
+    wait_for_link_transfer_settled(node_addr, &parent_asset_id).await;
+    let unspents = list_settled_unspents(node_addr).await;
+    assert!(!unspents.iter().any(|unspent| {
+        unspent.rgb_allocations.iter().any(|allocation| {
+            allocation.asset_id.as_deref() == Some(parent_asset_id.as_str())
+                && allocation.assignment == Assignment::LinkRight
+        })
+    }));
+    assert_eq!(
+        asset_metadata(node_addr, &parent_asset_id)
+            .await
+            .unspent_link_right_outpoint,
+        None
+    );
+
+    // the link transition should be idempotent
     let duplicate = asset_link_create(
         node_addr,
         &asset_link.parent_asset_id,
@@ -129,7 +168,6 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     let conflict_payload = AssetLinkRequest {
         parent_asset_id: asset_link.parent_asset_id.clone(),
         child_asset_id: conflicting_linked_asset_id,
-        fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
     let conflict_res = reqwest::Client::new()
@@ -237,7 +275,7 @@ async fn asset_link_send_payment_uses_linked_asset_when_invoice_asset_liquidity_
         issue_asset_ifa_with_type(host_addr, Some(IfaIssuanceType::LinkRightOnly)).await;
     let asset_r = asset_r_data.asset_id;
     let _link_right_outpoint = asset_r_data
-        .link_right_outpoint
+        .issuance_link_right_outpoint
         .expect("link-right outpoint");
     let asset_v = issue_asset_ifa_with_type(
         host_addr,
@@ -249,6 +287,8 @@ async fn asset_link_send_payment_uses_linked_asset_when_invoice_asset_liquidity_
     .await
     .asset_id;
     asset_link_create(host_addr, &asset_r, &asset_v).await;
+    mine(false);
+    wait_for_link_transfer_settled(host_addr, &asset_r).await;
 
     let payer_info = node_info(payer_addr).await;
     open_virtual_channel(

--- a/src/test/asset_link.rs
+++ b/src/test/asset_link.rs
@@ -16,30 +16,36 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     assert_eq!(legacy_asset.link_right_outpoint, None);
     let legacy_asset_id = legacy_asset.asset_id;
 
-    let asset = issue_asset_ifa_with_type(node_addr, Some(IfaIssuanceType::LinkRightOnly)).await;
-    let asset_id = asset.asset_id;
-    let _link_right_outpoint = asset.link_right_outpoint.expect("link-right outpoint");
-    let linked_asset = issue_asset_ifa_with_type(
+    let parent_asset =
+        issue_asset_ifa_with_type(node_addr, Some(IfaIssuanceType::LinkRightOnly)).await;
+    let parent_asset_id = parent_asset.asset_id;
+    let _link_right_outpoint = parent_asset
+        .link_right_outpoint
+        .expect("link-right outpoint");
+    let child_asset = issue_asset_ifa_with_type(
         node_addr,
         Some(IfaIssuanceType::LinkedFromParent {
-            contract_id: asset_id.clone(),
+            contract_id: parent_asset_id.clone(),
             request_link_right: false,
         }),
     )
     .await;
-    assert_eq!(linked_asset.link_right_outpoint, None);
-    let linked_asset_id = linked_asset.asset_id;
+    assert_eq!(child_asset.link_right_outpoint, None);
+    let child_asset_id = child_asset.asset_id;
 
-    let parent_metadata = asset_metadata(node_addr, &asset_id).await;
+    let parent_metadata = asset_metadata(node_addr, &parent_asset_id).await;
     assert_eq!(parent_metadata.linked_from_asset_id, None);
     assert_eq!(parent_metadata.linked_to_asset_id, None);
-    let child_metadata = asset_metadata(node_addr, &linked_asset_id).await;
-    assert_eq!(child_metadata.linked_from_asset_id, Some(asset_id.clone()));
+    let child_metadata = asset_metadata(node_addr, &child_asset_id).await;
+    assert_eq!(
+        child_metadata.linked_from_asset_id,
+        Some(parent_asset_id.clone())
+    );
     assert_eq!(child_metadata.linked_to_asset_id, None);
 
     let invalid_link_payload = AssetLinkCreateRequest {
-        asset_id: asset_id.clone(),
-        linked_asset_id: legacy_asset_id.clone(),
+        parent_asset_id: parent_asset_id.clone(),
+        child_asset_id: legacy_asset_id.clone(),
         fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
@@ -66,8 +72,8 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     )
     .await;
     let missing_link_right_payload = AssetLinkCreateRequest {
-        asset_id: legacy_asset_id.clone(),
-        linked_asset_id: missing_link_right_child.asset_id.clone(),
+        parent_asset_id: legacy_asset_id.clone(),
+        child_asset_id: missing_link_right_child.asset_id.clone(),
         fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
@@ -85,9 +91,9 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     )
     .await;
 
-    let asset_link = asset_link_create(node_addr, &asset_id, &linked_asset_id).await;
-    assert_eq!(asset_link.asset_id, asset_id);
-    assert_eq!(asset_link.linked_asset_id, Some(linked_asset_id.clone()));
+    let asset_link = asset_link_create(node_addr, &parent_asset_id, &child_asset_id).await;
+    assert_eq!(asset_link.parent_asset_id, parent_asset_id);
+    assert_eq!(asset_link.child_asset_id, Some(child_asset_id.clone()));
     assert!(asset_link
         .txid
         .as_deref()
@@ -98,15 +104,15 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
 
     let duplicate = asset_link_create(
         node_addr,
-        &asset_link.asset_id,
+        &asset_link.parent_asset_id,
         asset_link
-            .linked_asset_id
+            .child_asset_id
             .as_deref()
-            .expect("linked asset id"),
+            .expect("child asset id"),
     )
     .await;
-    assert_eq!(duplicate.asset_id, asset_link.asset_id);
-    assert_eq!(duplicate.linked_asset_id, asset_link.linked_asset_id);
+    assert_eq!(duplicate.parent_asset_id, asset_link.parent_asset_id);
+    assert_eq!(duplicate.child_asset_id, asset_link.child_asset_id);
     assert!(duplicate
         .txid
         .as_deref()
@@ -116,15 +122,15 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     let conflicting_linked_asset_id = issue_asset_ifa_with_type(
         node_addr,
         Some(IfaIssuanceType::LinkedFromParent {
-            contract_id: asset_id.clone(),
+            contract_id: parent_asset_id.clone(),
             request_link_right: false,
         }),
     )
     .await
     .asset_id;
     let conflict_payload = AssetLinkCreateRequest {
-        asset_id: asset_link.asset_id.clone(),
-        linked_asset_id: conflicting_linked_asset_id,
+        parent_asset_id: asset_link.parent_asset_id.clone(),
+        child_asset_id: conflicting_linked_asset_id,
         fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
@@ -147,30 +153,30 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
 
     let after_restart = asset_link_create(
         node_addr,
-        &asset_link.asset_id,
+        &asset_link.parent_asset_id,
         asset_link
-            .linked_asset_id
+            .child_asset_id
             .as_deref()
-            .expect("linked asset id"),
+            .expect("child asset id"),
     )
     .await;
-    assert_eq!(after_restart.asset_id, asset_link.asset_id);
-    assert_eq!(after_restart.linked_asset_id, asset_link.linked_asset_id);
+    assert_eq!(after_restart.parent_asset_id, asset_link.parent_asset_id);
+    assert_eq!(after_restart.child_asset_id, asset_link.child_asset_id);
     assert!(after_restart
         .txid
         .as_deref()
         .is_some_and(|txid| !txid.is_empty()));
     assert!(after_restart.created_at.is_some());
 
-    let restarted_parent_metadata = asset_metadata(node_addr, &asset_id).await;
+    let restarted_parent_metadata = asset_metadata(node_addr, &parent_asset_id).await;
     assert_eq!(
         restarted_parent_metadata.linked_to_asset_id,
-        Some(linked_asset_id.clone())
+        Some(child_asset_id.clone())
     );
-    let restarted_child_metadata = asset_metadata(node_addr, &linked_asset_id).await;
+    let restarted_child_metadata = asset_metadata(node_addr, &child_asset_id).await;
     assert_eq!(
         restarted_child_metadata.linked_from_asset_id,
-        Some(asset_id.clone())
+        Some(parent_asset_id.clone())
     );
     assert_eq!(restarted_child_metadata.linked_to_asset_id, None);
 
@@ -178,18 +184,21 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     let listed_parent = assets
         .ifa
         .as_ref()
-        .and_then(|ifa| ifa.iter().find(|asset| asset.asset_id == asset_id))
+        .and_then(|ifa| ifa.iter().find(|asset| asset.asset_id == parent_asset_id))
         .expect("listed parent");
     assert_eq!(
         listed_parent.linked_to_asset_id,
-        Some(linked_asset_id.clone())
+        Some(child_asset_id.clone())
     );
     let listed_child = assets
         .ifa
         .as_ref()
-        .and_then(|ifa| ifa.iter().find(|asset| asset.asset_id == linked_asset_id))
+        .and_then(|ifa| ifa.iter().find(|asset| asset.asset_id == child_asset_id))
         .expect("listed child");
-    assert_eq!(listed_child.linked_from_asset_id, Some(asset_id.clone()));
+    assert_eq!(
+        listed_child.linked_from_asset_id,
+        Some(parent_asset_id.clone())
+    );
     assert_eq!(listed_child.linked_to_asset_id, None);
 }
 

--- a/src/test/asset_link.rs
+++ b/src/test/asset_link.rs
@@ -1,0 +1,94 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/asset_link/";
+
+fn read_asset_link_record(test_dir: &str, asset_id: &str) -> AssetLink {
+    let db_path = get_db_path(&std::path::PathBuf::from(test_dir));
+    let connection_string = format!("sqlite:{}?mode=rwc", db_path.display());
+    let mut opt = ConnectOptions::new(connection_string);
+    opt.max_connections(1);
+    let db = crate::runtime::block_on(Database::connect(opt)).expect("connect to test db");
+    let kv_store = SeaOrmKvStore::from_connection(Arc::new(db));
+    let bytes = kv_store
+        .read("asset_link", "", asset_id)
+        .expect("asset link record");
+    serde_json::from_slice(&bytes).expect("parse asset link")
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn asset_link_create_is_persisted_and_idempotent() {
+    initialize();
+
+    let test_dir_node = format!("{TEST_DIR_BASE}node");
+    let (node_addr, _) = start_node(&test_dir_node, NODE1_PEER_PORT, false).await;
+    fund_and_create_utxos(node_addr, None).await;
+
+    let linked_asset_id = issue_asset_nia(node_addr).await.asset_id;
+    let asset_id = issue_asset_nia(node_addr).await.asset_id;
+    let issuer_pubkey = node_info(node_addr).await.pubkey;
+
+    let asset_record = read_asset_link_record(&test_dir_node, &asset_id);
+    assert_eq!(asset_record.asset_id, asset_id);
+    assert_eq!(asset_record.linked_asset_id, None);
+    assert_eq!(asset_record.issuer_pubkey, issuer_pubkey);
+    assert_eq!(asset_record.signature, None);
+    assert_eq!(asset_record.created_at, None);
+
+    let linked_asset_record = read_asset_link_record(&test_dir_node, &linked_asset_id);
+    assert_eq!(linked_asset_record.asset_id, linked_asset_id);
+    assert_eq!(linked_asset_record.linked_asset_id, None);
+    assert_eq!(linked_asset_record.issuer_pubkey, issuer_pubkey);
+    assert_eq!(linked_asset_record.signature, None);
+    assert_eq!(linked_asset_record.created_at, None);
+
+    let asset_link = asset_link_create(node_addr, &asset_id, &linked_asset_id).await;
+    assert_eq!(asset_link.asset_id, asset_id);
+    assert_eq!(asset_link.linked_asset_id, Some(linked_asset_id.clone()));
+    assert_eq!(asset_link.issuer_pubkey, issuer_pubkey);
+    assert!(asset_link.signature.is_some());
+    assert!(!asset_link.signature.as_deref().unwrap().is_empty());
+    assert!(asset_link.created_at.is_some());
+
+    let persisted_asset_link = read_asset_link_record(&test_dir_node, &asset_id);
+    assert_eq!(persisted_asset_link, asset_link);
+
+    let duplicate = asset_link_create(
+        node_addr,
+        &asset_link.asset_id,
+        asset_link.linked_asset_id.as_deref().unwrap(),
+    )
+    .await;
+    assert_eq!(duplicate, asset_link);
+
+    let conflicting_linked_asset_id = issue_asset_nia(node_addr).await.asset_id;
+    let conflict_payload = AssetLinkCreateRequest {
+        asset_id: asset_link.asset_id.clone(),
+        linked_asset_id: conflicting_linked_asset_id,
+    };
+    let conflict_res = reqwest::Client::new()
+        .post(format!("http://{node_addr}/assetlink/create"))
+        .json(&conflict_payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_nok(
+        conflict_res,
+        StatusCode::BAD_REQUEST,
+        "asset link already exists",
+        "InvalidRequest",
+    )
+    .await;
+
+    shutdown(&[node_addr]).await;
+    let (node_addr, _) = start_node(&test_dir_node, NODE1_PEER_PORT, true).await;
+
+    let after_restart = asset_link_create(
+        node_addr,
+        &asset_link.asset_id,
+        asset_link.linked_asset_id.as_deref().unwrap(),
+    )
+    .await;
+    assert_eq!(after_restart, asset_link);
+}

--- a/src/test/asset_link.rs
+++ b/src/test/asset_link.rs
@@ -2,23 +2,10 @@ use super::*;
 
 const TEST_DIR_BASE: &str = "tmp/asset_link/";
 
-fn read_asset_link_record(test_dir: &str, asset_id: &str) -> AssetLink {
-    let db_path = get_db_path(&std::path::PathBuf::from(test_dir));
-    let connection_string = format!("sqlite:{}?mode=rwc", db_path.display());
-    let mut opt = ConnectOptions::new(connection_string);
-    opt.max_connections(1);
-    let db = crate::runtime::block_on(Database::connect(opt)).expect("connect to test db");
-    let kv_store = SeaOrmKvStore::from_connection(Arc::new(db));
-    let bytes = kv_store
-        .read("asset_link", "", asset_id)
-        .expect("asset link record");
-    serde_json::from_slice(&bytes).expect("parse asset link")
-}
-
 #[serial_test::serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[traced_test]
-async fn asset_link_create_is_persisted_and_idempotent() {
+async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     initialize();
 
     let test_dir_node = format!("{TEST_DIR_BASE}node");
@@ -42,6 +29,13 @@ async fn asset_link_create_is_persisted_and_idempotent() {
     .await;
     assert_eq!(linked_asset.link_right_outpoint, None);
     let linked_asset_id = linked_asset.asset_id;
+
+    let parent_metadata = asset_metadata(node_addr, &asset_id).await;
+    assert_eq!(parent_metadata.linked_from_asset_id, None);
+    assert_eq!(parent_metadata.linked_to_asset_id, None);
+    let child_metadata = asset_metadata(node_addr, &linked_asset_id).await;
+    assert_eq!(child_metadata.linked_from_asset_id, Some(asset_id.clone()));
+    assert_eq!(child_metadata.linked_to_asset_id, None);
 
     let invalid_link_payload = AssetLinkCreateRequest {
         asset_id: asset_id.clone(),
@@ -93,15 +87,14 @@ async fn asset_link_create_is_persisted_and_idempotent() {
 
     let asset_link = asset_link_create(node_addr, &asset_id, &linked_asset_id).await;
     assert_eq!(asset_link.asset_id, asset_id);
-    assert_eq!(asset_link.linked_asset_id, Some(linked_asset_id));
+    assert_eq!(asset_link.linked_asset_id, Some(linked_asset_id.clone()));
     assert!(asset_link
         .txid
         .as_deref()
         .is_some_and(|txid| !txid.is_empty()));
     assert!(asset_link.created_at.is_some());
 
-    let persisted_asset_link = read_asset_link_record(&test_dir_node, &asset_id);
-    assert_eq!(persisted_asset_link, asset_link);
+    assert!(asset_link.link_right_outpoint.is_none());
 
     let duplicate = asset_link_create(
         node_addr,
@@ -112,7 +105,13 @@ async fn asset_link_create_is_persisted_and_idempotent() {
             .expect("linked asset id"),
     )
     .await;
-    assert_eq!(duplicate, asset_link);
+    assert_eq!(duplicate.asset_id, asset_link.asset_id);
+    assert_eq!(duplicate.linked_asset_id, asset_link.linked_asset_id);
+    assert!(duplicate
+        .txid
+        .as_deref()
+        .is_some_and(|txid| !txid.is_empty()));
+    assert!(duplicate.created_at.is_some());
 
     let conflicting_linked_asset_id = issue_asset_ifa_with_type(
         node_addr,
@@ -138,8 +137,8 @@ async fn asset_link_create_is_persisted_and_idempotent() {
     check_response_is_nok(
         conflict_res,
         StatusCode::BAD_REQUEST,
-        "asset link already exists",
-        "InvalidRequest",
+        "already linked to",
+        "InvalidContractLink",
     )
     .await;
 
@@ -155,7 +154,43 @@ async fn asset_link_create_is_persisted_and_idempotent() {
             .expect("linked asset id"),
     )
     .await;
-    assert_eq!(after_restart, asset_link);
+    assert_eq!(after_restart.asset_id, asset_link.asset_id);
+    assert_eq!(after_restart.linked_asset_id, asset_link.linked_asset_id);
+    assert!(after_restart
+        .txid
+        .as_deref()
+        .is_some_and(|txid| !txid.is_empty()));
+    assert!(after_restart.created_at.is_some());
+
+    let restarted_parent_metadata = asset_metadata(node_addr, &asset_id).await;
+    assert_eq!(
+        restarted_parent_metadata.linked_to_asset_id,
+        Some(linked_asset_id.clone())
+    );
+    let restarted_child_metadata = asset_metadata(node_addr, &linked_asset_id).await;
+    assert_eq!(
+        restarted_child_metadata.linked_from_asset_id,
+        Some(asset_id.clone())
+    );
+    assert_eq!(restarted_child_metadata.linked_to_asset_id, None);
+
+    let assets = list_assets(node_addr).await;
+    let listed_parent = assets
+        .ifa
+        .as_ref()
+        .and_then(|ifa| ifa.iter().find(|asset| asset.asset_id == asset_id))
+        .expect("listed parent");
+    assert_eq!(
+        listed_parent.linked_to_asset_id,
+        Some(linked_asset_id.clone())
+    );
+    let listed_child = assets
+        .ifa
+        .as_ref()
+        .and_then(|ifa| ifa.iter().find(|asset| asset.asset_id == linked_asset_id))
+        .expect("listed child");
+    assert_eq!(listed_child.linked_from_asset_id, Some(asset_id.clone()));
+    assert_eq!(listed_child.linked_to_asset_id, None);
 }
 
 #[serial_test::serial]

--- a/src/test/asset_link.rs
+++ b/src/test/asset_link.rs
@@ -43,14 +43,14 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     );
     assert_eq!(child_metadata.linked_to_asset_id, None);
 
-    let invalid_link_payload = AssetLinkCreateRequest {
+    let invalid_link_payload = AssetLinkRequest {
         parent_asset_id: parent_asset_id.clone(),
         child_asset_id: legacy_asset_id.clone(),
         fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
     let invalid_link_res = reqwest::Client::new()
-        .post(format!("http://{node_addr}/assetlink/create"))
+        .post(format!("http://{node_addr}/assetlink"))
         .json(&invalid_link_payload)
         .send()
         .await
@@ -71,14 +71,14 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
         }),
     )
     .await;
-    let missing_link_right_payload = AssetLinkCreateRequest {
+    let missing_link_right_payload = AssetLinkRequest {
         parent_asset_id: legacy_asset_id.clone(),
         child_asset_id: missing_link_right_child.asset_id.clone(),
         fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
     let missing_link_right_res = reqwest::Client::new()
-        .post(format!("http://{node_addr}/assetlink/create"))
+        .post(format!("http://{node_addr}/assetlink"))
         .json(&missing_link_right_payload)
         .send()
         .await
@@ -99,8 +99,6 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
         .as_deref()
         .is_some_and(|txid| !txid.is_empty()));
     assert!(asset_link.created_at.is_some());
-
-    assert!(asset_link.link_right_outpoint.is_none());
 
     let duplicate = asset_link_create(
         node_addr,
@@ -128,14 +126,14 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
     )
     .await
     .asset_id;
-    let conflict_payload = AssetLinkCreateRequest {
+    let conflict_payload = AssetLinkRequest {
         parent_asset_id: asset_link.parent_asset_id.clone(),
         child_asset_id: conflicting_linked_asset_id,
         fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
     let conflict_res = reqwest::Client::new()
-        .post(format!("http://{node_addr}/assetlink/create"))
+        .post(format!("http://{node_addr}/assetlink"))
         .json(&conflict_payload)
         .send()
         .await

--- a/src/test/asset_link.rs
+++ b/src/test/asset_link.rs
@@ -205,7 +205,7 @@ async fn asset_link_create_uses_rgb_link_state_and_is_idempotent() {
 #[serial_test::serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[traced_test]
-async fn asset_link_send_payment_swaps_virtual_to_reserve_asset() {
+async fn asset_link_send_payment_uses_linked_asset_when_invoice_asset_liquidity_is_insufficient() {
     initialize();
 
     const LINK_AMT: u64 = 100;
@@ -295,7 +295,7 @@ async fn asset_link_send_payment_swaps_virtual_to_reserve_asset() {
     .await
     .invoice;
 
-    let payment = asset_link_send_payment(payer_addr, &invoice, &asset_v, &host_info.pubkey).await;
+    let payment = send_payment(payer_addr, invoice).await;
     let payment_hash = payment.payment_hash.clone();
     check_preimage_matches_hash(&payment, &payment_hash);
     assert_eq!(payment.asset_id.as_deref(), Some(asset_v.as_str()));
@@ -327,24 +327,6 @@ async fn asset_link_send_payment_swaps_virtual_to_reserve_asset() {
     assert_eq!(linked_swap.qty_from, LINK_AMT);
     assert_eq!(linked_swap.qty_to, LINK_AMT);
 
-    let asset_unlinked = issue_asset_ifa(host_addr).await.asset_id;
-    let r_invoice_unlinked = ln_invoice(
-        receiver_addr,
-        Some(3_000_000),
-        Some(&asset_r),
-        Some(1),
-        3600,
-    )
-    .await
-    .invoice;
-    let res = asset_link_send_payment_raw(
-        payer_addr,
-        &r_invoice_unlinked,
-        &asset_unlinked,
-        &host_info.pubkey,
-    )
-    .await;
-    check_response_is_nok(res, StatusCode::FORBIDDEN, "No route found", "NoRoute").await;
     wait_for_ln_balance(receiver_addr, &asset_r, CHANNEL_AMT).await;
     wait_for_ln_balance(host_addr, &asset_r, 0).await;
 

--- a/src/test/asset_link.rs
+++ b/src/test/asset_link.rs
@@ -23,32 +23,81 @@ async fn asset_link_create_is_persisted_and_idempotent() {
 
     let test_dir_node = format!("{TEST_DIR_BASE}node");
     let (node_addr, _) = start_node(&test_dir_node, NODE1_PEER_PORT, false).await;
-    fund_and_create_utxos(node_addr, None).await;
+    fund_and_create_utxos(node_addr, Some(12)).await;
 
-    let linked_asset_id = issue_asset_nia(node_addr).await.asset_id;
-    let asset_id = issue_asset_nia(node_addr).await.asset_id;
-    let issuer_pubkey = node_info(node_addr).await.pubkey;
+    let legacy_asset = issue_asset_ifa(node_addr).await;
+    assert_eq!(legacy_asset.link_right_outpoint, None);
+    let legacy_asset_id = legacy_asset.asset_id;
 
-    let asset_record = read_asset_link_record(&test_dir_node, &asset_id);
-    assert_eq!(asset_record.asset_id, asset_id);
-    assert_eq!(asset_record.linked_asset_id, None);
-    assert_eq!(asset_record.issuer_pubkey, issuer_pubkey);
-    assert_eq!(asset_record.signature, None);
-    assert_eq!(asset_record.created_at, None);
+    let asset = issue_asset_ifa_with_type(node_addr, Some(IfaIssuanceType::LinkRightOnly)).await;
+    let asset_id = asset.asset_id;
+    let _link_right_outpoint = asset.link_right_outpoint.expect("link-right outpoint");
+    let linked_asset = issue_asset_ifa_with_type(
+        node_addr,
+        Some(IfaIssuanceType::LinkedFromParent {
+            contract_id: asset_id.clone(),
+            request_link_right: false,
+        }),
+    )
+    .await;
+    assert_eq!(linked_asset.link_right_outpoint, None);
+    let linked_asset_id = linked_asset.asset_id;
 
-    let linked_asset_record = read_asset_link_record(&test_dir_node, &linked_asset_id);
-    assert_eq!(linked_asset_record.asset_id, linked_asset_id);
-    assert_eq!(linked_asset_record.linked_asset_id, None);
-    assert_eq!(linked_asset_record.issuer_pubkey, issuer_pubkey);
-    assert_eq!(linked_asset_record.signature, None);
-    assert_eq!(linked_asset_record.created_at, None);
+    let invalid_link_payload = AssetLinkCreateRequest {
+        asset_id: asset_id.clone(),
+        linked_asset_id: legacy_asset_id.clone(),
+        fee_rate: FEE_RATE,
+        min_confirmations: 1,
+    };
+    let invalid_link_res = reqwest::Client::new()
+        .post(format!("http://{node_addr}/assetlink/create"))
+        .json(&invalid_link_payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_nok(
+        invalid_link_res,
+        StatusCode::BAD_REQUEST,
+        "Invalid contract link",
+        "InvalidContractLink",
+    )
+    .await;
+
+    let missing_link_right_child = issue_asset_ifa_with_type(
+        node_addr,
+        Some(IfaIssuanceType::LinkedFromParent {
+            contract_id: legacy_asset_id.clone(),
+            request_link_right: false,
+        }),
+    )
+    .await;
+    let missing_link_right_payload = AssetLinkCreateRequest {
+        asset_id: legacy_asset_id.clone(),
+        linked_asset_id: missing_link_right_child.asset_id.clone(),
+        fee_rate: FEE_RATE,
+        min_confirmations: 1,
+    };
+    let missing_link_right_res = reqwest::Client::new()
+        .post(format!("http://{node_addr}/assetlink/create"))
+        .json(&missing_link_right_payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_nok(
+        missing_link_right_res,
+        StatusCode::BAD_REQUEST,
+        "missing link_right_outpoint",
+        "InvalidRequest",
+    )
+    .await;
 
     let asset_link = asset_link_create(node_addr, &asset_id, &linked_asset_id).await;
     assert_eq!(asset_link.asset_id, asset_id);
-    assert_eq!(asset_link.linked_asset_id, Some(linked_asset_id.clone()));
-    assert_eq!(asset_link.issuer_pubkey, issuer_pubkey);
-    assert!(asset_link.signature.is_some());
-    assert!(!asset_link.signature.as_deref().unwrap().is_empty());
+    assert_eq!(asset_link.linked_asset_id, Some(linked_asset_id));
+    assert!(asset_link
+        .txid
+        .as_deref()
+        .is_some_and(|txid| !txid.is_empty()));
     assert!(asset_link.created_at.is_some());
 
     let persisted_asset_link = read_asset_link_record(&test_dir_node, &asset_id);
@@ -57,15 +106,28 @@ async fn asset_link_create_is_persisted_and_idempotent() {
     let duplicate = asset_link_create(
         node_addr,
         &asset_link.asset_id,
-        asset_link.linked_asset_id.as_deref().unwrap(),
+        asset_link
+            .linked_asset_id
+            .as_deref()
+            .expect("linked asset id"),
     )
     .await;
     assert_eq!(duplicate, asset_link);
 
-    let conflicting_linked_asset_id = issue_asset_nia(node_addr).await.asset_id;
+    let conflicting_linked_asset_id = issue_asset_ifa_with_type(
+        node_addr,
+        Some(IfaIssuanceType::LinkedFromParent {
+            contract_id: asset_id.clone(),
+            request_link_right: false,
+        }),
+    )
+    .await
+    .asset_id;
     let conflict_payload = AssetLinkCreateRequest {
         asset_id: asset_link.asset_id.clone(),
         linked_asset_id: conflicting_linked_asset_id,
+        fee_rate: FEE_RATE,
+        min_confirmations: 1,
     };
     let conflict_res = reqwest::Client::new()
         .post(format!("http://{node_addr}/assetlink/create"))
@@ -87,7 +149,10 @@ async fn asset_link_create_is_persisted_and_idempotent() {
     let after_restart = asset_link_create(
         node_addr,
         &asset_link.asset_id,
-        asset_link.linked_asset_id.as_deref().unwrap(),
+        asset_link
+            .linked_asset_id
+            .as_deref()
+            .expect("linked asset id"),
     )
     .await;
     assert_eq!(after_restart, asset_link);
@@ -126,9 +191,22 @@ async fn asset_link_send_payment_swaps_virtual_to_reserve_asset() {
     fund_and_create_utxos(host_addr, None).await;
     fund_and_create_utxos(receiver_addr, None).await;
 
-    let asset_v = issue_asset_nia(host_addr).await.asset_id;
-    let asset_r = issue_asset_nia(host_addr).await.asset_id;
-    asset_link_create(host_addr, &asset_v, &asset_r).await;
+    let asset_r_data =
+        issue_asset_ifa_with_type(host_addr, Some(IfaIssuanceType::LinkRightOnly)).await;
+    let asset_r = asset_r_data.asset_id;
+    let _link_right_outpoint = asset_r_data
+        .link_right_outpoint
+        .expect("link-right outpoint");
+    let asset_v = issue_asset_ifa_with_type(
+        host_addr,
+        Some(IfaIssuanceType::LinkedFromParent {
+            contract_id: asset_r.clone(),
+            request_link_right: false,
+        }),
+    )
+    .await
+    .asset_id;
+    asset_link_create(host_addr, &asset_r, &asset_v).await;
 
     let payer_info = node_info(payer_addr).await;
     open_virtual_channel(
@@ -205,7 +283,7 @@ async fn asset_link_send_payment_swaps_virtual_to_reserve_asset() {
     assert_eq!(linked_swap.qty_from, LINK_AMT);
     assert_eq!(linked_swap.qty_to, LINK_AMT);
 
-    let asset_unlinked = issue_asset_nia(host_addr).await.asset_id;
+    let asset_unlinked = issue_asset_ifa(host_addr).await.asset_id;
     let r_invoice_unlinked = ln_invoice(
         receiver_addr,
         Some(3_000_000),

--- a/src/test/asset_link.rs
+++ b/src/test/asset_link.rs
@@ -92,3 +92,145 @@ async fn asset_link_create_is_persisted_and_idempotent() {
     .await;
     assert_eq!(after_restart, asset_link);
 }
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn asset_link_send_payment_swaps_virtual_to_reserve_asset() {
+    initialize();
+
+    const LINK_AMT: u64 = 100;
+    const CHANNEL_AMT: u64 = 300;
+
+    let test_dir_host = format!("{TEST_DIR_BASE}host");
+    let test_dir_payer = format!("{TEST_DIR_BASE}payer");
+    let test_dir_receiver = format!("{TEST_DIR_BASE}receiver");
+
+    let host_peer_port = next_peer_port();
+    let payer_peer_port = next_peer_port();
+    let receiver_peer_port = next_peer_port();
+
+    let (host_addr, _) =
+        start_node_with_virtual_options(&test_dir_host, host_peer_port, false, true, vec![]).await;
+    let host_info = node_info(host_addr).await;
+    let (payer_addr, _) = start_node_with_virtual_options(
+        &test_dir_payer,
+        payer_peer_port,
+        false,
+        true,
+        vec![PublicKey::from_str(&host_info.pubkey).unwrap()],
+    )
+    .await;
+    let (receiver_addr, _) = start_node(&test_dir_receiver, receiver_peer_port, false).await;
+
+    fund_and_create_utxos(host_addr, None).await;
+    fund_and_create_utxos(receiver_addr, None).await;
+
+    let asset_v = issue_asset_nia(host_addr).await.asset_id;
+    let asset_r = issue_asset_nia(host_addr).await.asset_id;
+    asset_link_create(host_addr, &asset_v, &asset_r).await;
+
+    let payer_info = node_info(payer_addr).await;
+    open_virtual_channel(
+        host_addr,
+        &payer_info.pubkey,
+        Some(payer_peer_port),
+        Some(100_000),
+        Some(10_000_000),
+        Some(CHANNEL_AMT),
+        Some(&asset_v),
+        Some(CHANNEL_AMT - LINK_AMT),
+    )
+    .await;
+
+    let receiver_info = node_info(receiver_addr).await;
+    open_channel_raw(
+        host_addr,
+        &receiver_info.pubkey,
+        Some(receiver_peer_port),
+        Some(100_000),
+        Some(10_000_000),
+        Some(CHANNEL_AMT),
+        Some(&asset_r),
+        Some(CHANNEL_AMT - LINK_AMT),
+        None,
+        None,
+        None,
+        true,
+        false,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let invoice = ln_invoice(
+        receiver_addr,
+        Some(3_000_000),
+        Some(&asset_r),
+        Some(LINK_AMT),
+        3600,
+    )
+    .await
+    .invoice;
+
+    let payment = asset_link_send_payment(payer_addr, &invoice, &asset_v, &host_info.pubkey).await;
+    let payment_hash = payment.payment_hash.clone();
+    check_preimage_matches_hash(&payment, &payment_hash);
+    assert_eq!(payment.asset_id.as_deref(), Some(asset_v.as_str()));
+    assert_eq!(payment.asset_amount, Some(LINK_AMT));
+
+    wait_for_ln_balance(receiver_addr, &asset_r, CHANNEL_AMT).await;
+    wait_for_ln_balance(payer_addr, &asset_v, CHANNEL_AMT - LINK_AMT * 2).await;
+    wait_for_ln_balance(host_addr, &asset_v, LINK_AMT * 2).await;
+    wait_for_ln_balance(host_addr, &asset_r, 0).await;
+
+    let receiver_payment = wait_for_ln_payment_by_type(
+        receiver_addr,
+        &payment_hash,
+        PaymentType::InboundAutoClaim,
+        HTLCStatus::Succeeded,
+    )
+    .await;
+    assert_eq!(receiver_payment.asset_id.as_deref(), Some(asset_r.as_str()));
+    assert_eq!(receiver_payment.asset_amount, Some(LINK_AMT));
+
+    let host_swaps = list_swaps(host_addr).await;
+    let linked_swap = host_swaps
+        .taker
+        .iter()
+        .find(|swap| swap.payment_hash == payment_hash)
+        .expect("linked swap whitelist entry on the host");
+    assert_eq!(linked_swap.from_asset.as_deref(), Some(asset_r.as_str()));
+    assert_eq!(linked_swap.to_asset.as_deref(), Some(asset_v.as_str()));
+    assert_eq!(linked_swap.qty_from, LINK_AMT);
+    assert_eq!(linked_swap.qty_to, LINK_AMT);
+
+    let asset_unlinked = issue_asset_nia(host_addr).await.asset_id;
+    let r_invoice_unlinked = ln_invoice(
+        receiver_addr,
+        Some(3_000_000),
+        Some(&asset_r),
+        Some(1),
+        3600,
+    )
+    .await
+    .invoice;
+    let res = asset_link_send_payment_raw(
+        payer_addr,
+        &r_invoice_unlinked,
+        &asset_unlinked,
+        &host_info.pubkey,
+    )
+    .await;
+    check_response_is_nok(
+        res,
+        StatusCode::BAD_REQUEST,
+        "unknown_link",
+        "InvalidRequest",
+    )
+    .await;
+    wait_for_ln_balance(receiver_addr, &asset_r, CHANNEL_AMT).await;
+    wait_for_ln_balance(host_addr, &asset_r, 0).await;
+
+    shutdown(&[payer_addr, host_addr, receiver_addr]).await;
+}

--- a/src/test/asset_link.rs
+++ b/src/test/asset_link.rs
@@ -222,13 +222,7 @@ async fn asset_link_send_payment_swaps_virtual_to_reserve_asset() {
         &host_info.pubkey,
     )
     .await;
-    check_response_is_nok(
-        res,
-        StatusCode::BAD_REQUEST,
-        "unknown_link",
-        "InvalidRequest",
-    )
-    .await;
+    check_response_is_nok(res, StatusCode::FORBIDDEN, "No route found", "NoRoute").await;
     wait_for_ln_balance(receiver_addr, &asset_r, CHANNEL_AMT).await;
     wait_for_ln_balance(host_addr, &asset_r, 0).await;
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -18,7 +18,7 @@ use lightning_invoice::Bolt11Invoice;
 use once_cell::sync::Lazy;
 use rand::RngCore;
 use reqwest::{Response, StatusCode};
-use rgb_lib::{BitcoinNetwork, ContractId};
+use rgb_lib::{wallet::IfaIssuanceType, BitcoinNetwork, ContractId};
 use sea_orm::{ConnectOptions, Database};
 use std::collections::HashMap;
 use std::fs::File;
@@ -584,6 +584,8 @@ async fn asset_link_create(
     let payload = AssetLinkCreateRequest {
         asset_id: asset_id.to_string(),
         linked_asset_id: linked_asset_id.to_string(),
+        fee_rate: FEE_RATE,
+        min_confirmations: 1,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node_address}/assetlink/create"))
@@ -1061,6 +1063,13 @@ async fn issue_asset_cfa(node_address: SocketAddr, file_path: Option<&str>) -> A
 }
 
 async fn issue_asset_ifa(node_address: SocketAddr) -> AssetIFA {
+    issue_asset_ifa_with_type(node_address, None).await
+}
+
+async fn issue_asset_ifa_with_type(
+    node_address: SocketAddr,
+    issuance_type: Option<IfaIssuanceType>,
+) -> AssetIFA {
     println!("issuing IFA asset on node {node_address}");
     let payload = IssueAssetIFARequest {
         amounts: vec![ISSUE_AMT],
@@ -1069,6 +1078,7 @@ async fn issue_asset_ifa(node_address: SocketAddr) -> AssetIFA {
         name: s!("Tether"),
         precision: 0,
         reject_list_url: None,
+        issuance_type,
     };
     let res = reqwest::Client::new()
         .post(format!("http://{node_address}/issueassetifa"))

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -33,7 +33,6 @@ use tokio::io::AsyncReadExt;
 use tokio::net::{TcpListener, TcpStream};
 use tracing_test::traced_test;
 
-use crate::asset_link::AssetLinkSendPaymentRequest;
 use crate::core_types::{HTLCStatus, SwapStatus, FEE_RATE, HTLC_MIN_MSAT, VIRTUAL_HTLC_MIN_MSAT};
 use crate::disk::LDK_LOGS_FILE;
 use crate::error::{APIError, APIErrorResponse};
@@ -617,51 +616,6 @@ async fn asset_link_create(
         .await
         .unwrap()
         .asset_link
-}
-
-async fn asset_link_send_payment_raw(
-    node_address: SocketAddr,
-    invoice: &str,
-    asset_id: &str,
-    host_pubkey: &str,
-) -> reqwest::Response {
-    println!(
-        "sending linked-asset payment with asset {asset_id} for invoice {invoice} \
-         from node {node_address} via host {host_pubkey}"
-    );
-    let payload = AssetLinkSendPaymentRequest {
-        invoice: invoice.to_string(),
-        asset_id: asset_id.to_string(),
-        host_pubkey: host_pubkey.to_string(),
-    };
-    reqwest::Client::new()
-        .post(format!("http://{node_address}/assetlink/sendpayment"))
-        .json(&payload)
-        .send()
-        .await
-        .unwrap()
-}
-
-async fn asset_link_send_payment(
-    node_address: SocketAddr,
-    invoice: &str,
-    asset_id: &str,
-    host_pubkey: &str,
-) -> Payment {
-    let res = check_response_is_ok(
-        asset_link_send_payment_raw(node_address, invoice, asset_id, host_pubkey).await,
-    )
-    .await
-    .json::<SendPaymentResponse>()
-    .await
-    .unwrap();
-    wait_for_ln_payment_by_type(
-        node_address,
-        &res.payment_hash.unwrap(),
-        PaymentType::Outbound,
-        HTLCStatus::Succeeded,
-    )
-    .await
 }
 
 async fn backup(node_address: SocketAddr, backup_path: &str, password: &str) {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -33,6 +33,7 @@ use tokio::io::AsyncReadExt;
 use tokio::net::{TcpListener, TcpStream};
 use tracing_test::traced_test;
 
+use crate::asset_link::AssetLinkSendPaymentRequest;
 use crate::core_types::{HTLCStatus, SwapStatus, FEE_RATE, HTLC_MIN_MSAT, VIRTUAL_HTLC_MIN_MSAT};
 use crate::disk::LDK_LOGS_FILE;
 use crate::error::{APIError, APIErrorResponse};
@@ -596,6 +597,51 @@ async fn asset_link_create(
         .await
         .unwrap()
         .asset_link
+}
+
+async fn asset_link_send_payment_raw(
+    node_address: SocketAddr,
+    invoice: &str,
+    asset_id: &str,
+    host_pubkey: &str,
+) -> reqwest::Response {
+    println!(
+        "sending linked-asset payment with asset {asset_id} for invoice {invoice} \
+         from node {node_address} via host {host_pubkey}"
+    );
+    let payload = AssetLinkSendPaymentRequest {
+        invoice: invoice.to_string(),
+        asset_id: asset_id.to_string(),
+        host_pubkey: host_pubkey.to_string(),
+    };
+    reqwest::Client::new()
+        .post(format!("http://{node_address}/assetlink/sendpayment"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn asset_link_send_payment(
+    node_address: SocketAddr,
+    invoice: &str,
+    asset_id: &str,
+    host_pubkey: &str,
+) -> Payment {
+    let res = check_response_is_ok(
+        asset_link_send_payment_raw(node_address, invoice, asset_id, host_pubkey).await,
+    )
+    .await
+    .json::<SendPaymentResponse>()
+    .await
+    .unwrap();
+    wait_for_ln_payment_by_type(
+        node_address,
+        &res.payment_hash.unwrap(),
+        PaymentType::Outbound,
+        HTLCStatus::Succeeded,
+    )
+    .await
 }
 
 async fn backup(node_address: SocketAddr, backup_path: &str, password: &str) {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -43,28 +43,28 @@ use crate::ldk::{
 #[cfg(feature = "vss")]
 use crate::routes::VssClearFenceRequest;
 use crate::routes::{
-    AddressResponse, AssetBalanceRequest, AssetBalanceResponse, AssetCFA, AssetIFA, AssetNIA,
-    AssetUDA, Assignment, BackupRequest, BtcBalanceRequest, BtcBalanceResponse,
-    CancelHodlInvoiceRequest, ChangePasswordRequest, Channel, ChannelStatus,
-    ClaimHodlInvoiceRequest, ClaimHodlInvoiceResponse, CloseChannelRequest, ConnectPeerRequest,
-    CreateUtxosRequest, DecodeLNInvoiceRequest, DecodeLNInvoiceResponse, DecodeRGBInvoiceRequest,
-    DecodeRGBInvoiceResponse, DecodeSwapstringRequest, DecodeSwapstringResponse,
-    DisconnectPeerRequest, EmptyResponse, FailTransfersRequest, FailTransfersResponse,
-    GetAssetMediaRequest, GetAssetMediaResponse, GetChannelIdRequest, GetChannelIdResponse,
-    GetPaymentRequest, GetPaymentResponse, GetSwapRequest, GetSwapResponse, InflateRequest,
-    InflateResponse, InitRequest, InitResponse, InvoiceStatus, InvoiceStatusRequest,
-    InvoiceStatusResponse, IssueAssetCFARequest, IssueAssetCFAResponse, IssueAssetIFARequest,
-    IssueAssetIFAResponse, IssueAssetNIARequest, IssueAssetNIAResponse, IssueAssetUDARequest,
-    IssueAssetUDAResponse, KeysendRequest, KeysendResponse, LNInvoiceRequest, LNInvoiceResponse,
-    ListAssetsRequest, ListAssetsResponse, ListChannelsResponse, ListPaymentsResponse,
-    ListPeersResponse, ListSwapsResponse, ListTransactionsRequest, ListTransactionsResponse,
-    ListTransfersRequest, ListTransfersResponse, ListUnspentsRequest, ListUnspentsResponse,
-    MakerExecuteRequest, MakerInitRequest, MakerInitResponse, NetworkInfoResponse,
-    NodeInfoResponse, OpenChannelRequest, OpenChannelResponse, Payment, PaymentDirection,
-    PaymentType, Peer, PostAssetMediaResponse, Recipient, RefreshRequest, RestoreRequest,
-    RevokeTokenRequest, RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest, SendBtcResponse,
-    SendPaymentRequest, SendPaymentResponse, SendRgbRequest, SendRgbResponse, Swap, TakerRequest,
-    Transaction, Transfer, TransferStatus, UnlockRequest, Unspent, WitnessData,
+    AddressResponse, AssetBalanceRequest, AssetBalanceResponse, AssetCFA, AssetIFA, AssetLink,
+    AssetLinkCreateRequest, AssetLinkCreateResponse, AssetNIA, AssetUDA, Assignment, BackupRequest,
+    BtcBalanceRequest, BtcBalanceResponse, CancelHodlInvoiceRequest, ChangePasswordRequest,
+    Channel, ChannelStatus, ClaimHodlInvoiceRequest, ClaimHodlInvoiceResponse, CloseChannelRequest,
+    ConnectPeerRequest, CreateUtxosRequest, DecodeLNInvoiceRequest, DecodeLNInvoiceResponse,
+    DecodeRGBInvoiceRequest, DecodeRGBInvoiceResponse, DecodeSwapstringRequest,
+    DecodeSwapstringResponse, DisconnectPeerRequest, EmptyResponse, FailTransfersRequest,
+    FailTransfersResponse, GetAssetMediaRequest, GetAssetMediaResponse, GetChannelIdRequest,
+    GetChannelIdResponse, GetPaymentRequest, GetPaymentResponse, GetSwapRequest, GetSwapResponse,
+    InflateRequest, InflateResponse, InitRequest, InitResponse, InvoiceStatus,
+    InvoiceStatusRequest, InvoiceStatusResponse, IssueAssetCFARequest, IssueAssetCFAResponse,
+    IssueAssetIFARequest, IssueAssetIFAResponse, IssueAssetNIARequest, IssueAssetNIAResponse,
+    IssueAssetUDARequest, IssueAssetUDAResponse, KeysendRequest, KeysendResponse, LNInvoiceRequest,
+    LNInvoiceResponse, ListAssetsRequest, ListAssetsResponse, ListChannelsResponse,
+    ListPaymentsResponse, ListPeersResponse, ListSwapsResponse, ListTransactionsRequest,
+    ListTransactionsResponse, ListTransfersRequest, ListTransfersResponse, ListUnspentsRequest,
+    ListUnspentsResponse, MakerExecuteRequest, MakerInitRequest, MakerInitResponse,
+    NetworkInfoResponse, NodeInfoResponse, OpenChannelRequest, OpenChannelResponse, Payment,
+    PaymentDirection, PaymentType, Peer, PostAssetMediaResponse, Recipient, RefreshRequest,
+    RestoreRequest, RevokeTokenRequest, RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest,
+    SendBtcResponse, SendPaymentRequest, SendPaymentResponse, SendRgbRequest, SendRgbResponse,
+    Swap, TakerRequest, Transaction, Transfer, TransferStatus, UnlockRequest, Unspent, WitnessData,
 };
 use crate::utils::{
     get_db_path, hex_str, hex_str_to_vec, validate_and_parse_payment_hash, AppState,
@@ -572,6 +572,30 @@ async fn asset_balance_offchain_outbound(node_address: SocketAddr, asset_id: &st
 
 async fn asset_balance_spendable(node_address: SocketAddr, asset_id: &str) -> u64 {
     asset_balance(node_address, asset_id).await.spendable
+}
+
+async fn asset_link_create(
+    node_address: SocketAddr,
+    asset_id: &str,
+    linked_asset_id: &str,
+) -> AssetLink {
+    println!("creating asset link for asset {asset_id} on node {node_address}");
+    let payload = AssetLinkCreateRequest {
+        asset_id: asset_id.to_string(),
+        linked_asset_id: linked_asset_id.to_string(),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/assetlink/create"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<AssetLinkCreateResponse>()
+        .await
+        .unwrap()
+        .asset_link
 }
 
 async fn backup(node_address: SocketAddr, backup_path: &str, password: &str) {
@@ -2915,6 +2939,7 @@ pub fn set_mock_fee(fee: u32) {
 }
 
 mod address_reuse;
+mod asset_link;
 mod auth_db_persistence;
 mod authentication;
 mod backup_and_restore;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -595,13 +595,13 @@ async fn asset_balance_spendable(node_address: SocketAddr, asset_id: &str) -> u6
 
 async fn asset_link_create(
     node_address: SocketAddr,
-    asset_id: &str,
-    linked_asset_id: &str,
+    parent_asset_id: &str,
+    child_asset_id: &str,
 ) -> AssetLink {
-    println!("creating asset link for asset {asset_id} on node {node_address}");
+    println!("creating asset link for asset {parent_asset_id} on node {node_address}");
     let payload = AssetLinkCreateRequest {
-        asset_id: asset_id.to_string(),
-        linked_asset_id: linked_asset_id.to_string(),
+        parent_asset_id: parent_asset_id.to_string(),
+        child_asset_id: child_asset_id.to_string(),
         fee_rate: FEE_RATE,
         min_confirmations: 1,
     };

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -33,6 +33,7 @@ use tokio::io::AsyncReadExt;
 use tokio::net::{TcpListener, TcpStream};
 use tracing_test::traced_test;
 
+use crate::core_types::asset_link::{AssetLinkRequest, AssetLinkResponse};
 use crate::core_types::{HTLCStatus, SwapStatus, FEE_RATE, HTLC_MIN_MSAT, VIRTUAL_HTLC_MIN_MSAT};
 use crate::disk::LDK_LOGS_FILE;
 use crate::error::{APIError, APIErrorResponse};
@@ -43,29 +44,28 @@ use crate::ldk::{
 #[cfg(feature = "vss")]
 use crate::routes::VssClearFenceRequest;
 use crate::routes::{
-    AddressResponse, AssetBalanceRequest, AssetBalanceResponse, AssetCFA, AssetIFA, AssetLink,
-    AssetLinkCreateRequest, AssetLinkCreateResponse, AssetMetadataRequest, AssetMetadataResponse,
-    AssetNIA, AssetUDA, Assignment, BackupRequest, BtcBalanceRequest, BtcBalanceResponse,
-    CancelHodlInvoiceRequest, ChangePasswordRequest, Channel, ChannelStatus,
-    ClaimHodlInvoiceRequest, ClaimHodlInvoiceResponse, CloseChannelRequest, ConnectPeerRequest,
-    CreateUtxosRequest, DecodeLNInvoiceRequest, DecodeLNInvoiceResponse, DecodeRGBInvoiceRequest,
-    DecodeRGBInvoiceResponse, DecodeSwapstringRequest, DecodeSwapstringResponse,
-    DisconnectPeerRequest, EmptyResponse, FailTransfersRequest, FailTransfersResponse,
-    GetAssetMediaRequest, GetAssetMediaResponse, GetChannelIdRequest, GetChannelIdResponse,
-    GetPaymentRequest, GetPaymentResponse, GetSwapRequest, GetSwapResponse, InflateRequest,
-    InflateResponse, InitRequest, InitResponse, InvoiceStatus, InvoiceStatusRequest,
-    InvoiceStatusResponse, IssueAssetCFARequest, IssueAssetCFAResponse, IssueAssetIFARequest,
-    IssueAssetIFAResponse, IssueAssetNIARequest, IssueAssetNIAResponse, IssueAssetUDARequest,
-    IssueAssetUDAResponse, KeysendRequest, KeysendResponse, LNInvoiceRequest, LNInvoiceResponse,
-    ListAssetsRequest, ListAssetsResponse, ListChannelsResponse, ListPaymentsResponse,
-    ListPeersResponse, ListSwapsResponse, ListTransactionsRequest, ListTransactionsResponse,
-    ListTransfersRequest, ListTransfersResponse, ListUnspentsRequest, ListUnspentsResponse,
-    MakerExecuteRequest, MakerInitRequest, MakerInitResponse, NetworkInfoResponse,
-    NodeInfoResponse, OpenChannelRequest, OpenChannelResponse, Payment, PaymentDirection,
-    PaymentType, Peer, PostAssetMediaResponse, Recipient, RefreshRequest, RestoreRequest,
-    RevokeTokenRequest, RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest, SendBtcResponse,
-    SendPaymentRequest, SendPaymentResponse, SendRgbRequest, SendRgbResponse, Swap, TakerRequest,
-    Transaction, Transfer, TransferStatus, UnlockRequest, Unspent, WitnessData,
+    AddressResponse, AssetBalanceRequest, AssetBalanceResponse, AssetCFA, AssetIFA,
+    AssetMetadataRequest, AssetMetadataResponse, AssetNIA, AssetUDA, Assignment, BackupRequest,
+    BtcBalanceRequest, BtcBalanceResponse, CancelHodlInvoiceRequest, ChangePasswordRequest,
+    Channel, ChannelStatus, ClaimHodlInvoiceRequest, ClaimHodlInvoiceResponse, CloseChannelRequest,
+    ConnectPeerRequest, CreateUtxosRequest, DecodeLNInvoiceRequest, DecodeLNInvoiceResponse,
+    DecodeRGBInvoiceRequest, DecodeRGBInvoiceResponse, DecodeSwapstringRequest,
+    DecodeSwapstringResponse, DisconnectPeerRequest, EmptyResponse, FailTransfersRequest,
+    FailTransfersResponse, GetAssetMediaRequest, GetAssetMediaResponse, GetChannelIdRequest,
+    GetChannelIdResponse, GetPaymentRequest, GetPaymentResponse, GetSwapRequest, GetSwapResponse,
+    InflateRequest, InflateResponse, InitRequest, InitResponse, InvoiceStatus,
+    InvoiceStatusRequest, InvoiceStatusResponse, IssueAssetCFARequest, IssueAssetCFAResponse,
+    IssueAssetIFARequest, IssueAssetIFAResponse, IssueAssetNIARequest, IssueAssetNIAResponse,
+    IssueAssetUDARequest, IssueAssetUDAResponse, KeysendRequest, KeysendResponse, LNInvoiceRequest,
+    LNInvoiceResponse, ListAssetsRequest, ListAssetsResponse, ListChannelsResponse,
+    ListPaymentsResponse, ListPeersResponse, ListSwapsResponse, ListTransactionsRequest,
+    ListTransactionsResponse, ListTransfersRequest, ListTransfersResponse, ListUnspentsRequest,
+    ListUnspentsResponse, MakerExecuteRequest, MakerInitRequest, MakerInitResponse,
+    NetworkInfoResponse, NodeInfoResponse, OpenChannelRequest, OpenChannelResponse, Payment,
+    PaymentDirection, PaymentType, Peer, PostAssetMediaResponse, Recipient, RefreshRequest,
+    RestoreRequest, RevokeTokenRequest, RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest,
+    SendBtcResponse, SendPaymentRequest, SendPaymentResponse, SendRgbRequest, SendRgbResponse,
+    Swap, TakerRequest, Transaction, Transfer, TransferStatus, UnlockRequest, Unspent, WitnessData,
 };
 use crate::utils::{
     get_db_path, hex_str, hex_str_to_vec, validate_and_parse_payment_hash, AppState,
@@ -596,26 +596,25 @@ async fn asset_link_create(
     node_address: SocketAddr,
     parent_asset_id: &str,
     child_asset_id: &str,
-) -> AssetLink {
+) -> AssetLinkResponse {
     println!("creating asset link for asset {parent_asset_id} on node {node_address}");
-    let payload = AssetLinkCreateRequest {
+    let payload = AssetLinkRequest {
         parent_asset_id: parent_asset_id.to_string(),
         child_asset_id: child_asset_id.to_string(),
         fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
     let res = reqwest::Client::new()
-        .post(format!("http://{node_address}/assetlink/create"))
+        .post(format!("http://{node_address}/assetlink"))
         .json(&payload)
         .send()
         .await
         .unwrap();
     check_response_is_ok(res)
         .await
-        .json::<AssetLinkCreateResponse>()
+        .json::<AssetLinkResponse>()
         .await
         .unwrap()
-        .asset_link
 }
 
 async fn backup(node_address: SocketAddr, backup_path: &str, password: &str) {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -45,27 +45,28 @@ use crate::ldk::{
 use crate::routes::VssClearFenceRequest;
 use crate::routes::{
     AddressResponse, AssetBalanceRequest, AssetBalanceResponse, AssetCFA, AssetIFA, AssetLink,
-    AssetLinkCreateRequest, AssetLinkCreateResponse, AssetNIA, AssetUDA, Assignment, BackupRequest,
-    BtcBalanceRequest, BtcBalanceResponse, CancelHodlInvoiceRequest, ChangePasswordRequest,
-    Channel, ChannelStatus, ClaimHodlInvoiceRequest, ClaimHodlInvoiceResponse, CloseChannelRequest,
-    ConnectPeerRequest, CreateUtxosRequest, DecodeLNInvoiceRequest, DecodeLNInvoiceResponse,
-    DecodeRGBInvoiceRequest, DecodeRGBInvoiceResponse, DecodeSwapstringRequest,
-    DecodeSwapstringResponse, DisconnectPeerRequest, EmptyResponse, FailTransfersRequest,
-    FailTransfersResponse, GetAssetMediaRequest, GetAssetMediaResponse, GetChannelIdRequest,
-    GetChannelIdResponse, GetPaymentRequest, GetPaymentResponse, GetSwapRequest, GetSwapResponse,
-    InflateRequest, InflateResponse, InitRequest, InitResponse, InvoiceStatus,
-    InvoiceStatusRequest, InvoiceStatusResponse, IssueAssetCFARequest, IssueAssetCFAResponse,
-    IssueAssetIFARequest, IssueAssetIFAResponse, IssueAssetNIARequest, IssueAssetNIAResponse,
-    IssueAssetUDARequest, IssueAssetUDAResponse, KeysendRequest, KeysendResponse, LNInvoiceRequest,
-    LNInvoiceResponse, ListAssetsRequest, ListAssetsResponse, ListChannelsResponse,
-    ListPaymentsResponse, ListPeersResponse, ListSwapsResponse, ListTransactionsRequest,
-    ListTransactionsResponse, ListTransfersRequest, ListTransfersResponse, ListUnspentsRequest,
-    ListUnspentsResponse, MakerExecuteRequest, MakerInitRequest, MakerInitResponse,
-    NetworkInfoResponse, NodeInfoResponse, OpenChannelRequest, OpenChannelResponse, Payment,
-    PaymentDirection, PaymentType, Peer, PostAssetMediaResponse, Recipient, RefreshRequest,
-    RestoreRequest, RevokeTokenRequest, RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest,
-    SendBtcResponse, SendPaymentRequest, SendPaymentResponse, SendRgbRequest, SendRgbResponse,
-    Swap, TakerRequest, Transaction, Transfer, TransferStatus, UnlockRequest, Unspent, WitnessData,
+    AssetLinkCreateRequest, AssetLinkCreateResponse, AssetMetadataRequest, AssetMetadataResponse,
+    AssetNIA, AssetUDA, Assignment, BackupRequest, BtcBalanceRequest, BtcBalanceResponse,
+    CancelHodlInvoiceRequest, ChangePasswordRequest, Channel, ChannelStatus,
+    ClaimHodlInvoiceRequest, ClaimHodlInvoiceResponse, CloseChannelRequest, ConnectPeerRequest,
+    CreateUtxosRequest, DecodeLNInvoiceRequest, DecodeLNInvoiceResponse, DecodeRGBInvoiceRequest,
+    DecodeRGBInvoiceResponse, DecodeSwapstringRequest, DecodeSwapstringResponse,
+    DisconnectPeerRequest, EmptyResponse, FailTransfersRequest, FailTransfersResponse,
+    GetAssetMediaRequest, GetAssetMediaResponse, GetChannelIdRequest, GetChannelIdResponse,
+    GetPaymentRequest, GetPaymentResponse, GetSwapRequest, GetSwapResponse, InflateRequest,
+    InflateResponse, InitRequest, InitResponse, InvoiceStatus, InvoiceStatusRequest,
+    InvoiceStatusResponse, IssueAssetCFARequest, IssueAssetCFAResponse, IssueAssetIFARequest,
+    IssueAssetIFAResponse, IssueAssetNIARequest, IssueAssetNIAResponse, IssueAssetUDARequest,
+    IssueAssetUDAResponse, KeysendRequest, KeysendResponse, LNInvoiceRequest, LNInvoiceResponse,
+    ListAssetsRequest, ListAssetsResponse, ListChannelsResponse, ListPaymentsResponse,
+    ListPeersResponse, ListSwapsResponse, ListTransactionsRequest, ListTransactionsResponse,
+    ListTransfersRequest, ListTransfersResponse, ListUnspentsRequest, ListUnspentsResponse,
+    MakerExecuteRequest, MakerInitRequest, MakerInitResponse, NetworkInfoResponse,
+    NodeInfoResponse, OpenChannelRequest, OpenChannelResponse, Payment, PaymentDirection,
+    PaymentType, Peer, PostAssetMediaResponse, Recipient, RefreshRequest, RestoreRequest,
+    RevokeTokenRequest, RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest, SendBtcResponse,
+    SendPaymentRequest, SendPaymentResponse, SendRgbRequest, SendRgbResponse, Swap, TakerRequest,
+    Transaction, Transfer, TransferStatus, UnlockRequest, Unspent, WitnessData,
 };
 use crate::utils::{
     get_db_path, hex_str, hex_str_to_vec, validate_and_parse_payment_hash, AppState,
@@ -569,6 +570,23 @@ async fn asset_balance_offchain_outbound(node_address: SocketAddr, asset_id: &st
     asset_balance(node_address, asset_id)
         .await
         .offchain_outbound
+}
+
+async fn asset_metadata(node_address: SocketAddr, asset_id: &str) -> AssetMetadataResponse {
+    let payload = AssetMetadataRequest {
+        asset_id: asset_id.to_string(),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/assetmetadata"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<AssetMetadataResponse>()
+        .await
+        .unwrap()
 }
 
 async fn asset_balance_spendable(node_address: SocketAddr, asset_id: &str) -> u64 {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -65,7 +65,8 @@ use crate::routes::{
     PaymentDirection, PaymentType, Peer, PostAssetMediaResponse, Recipient, RefreshRequest,
     RestoreRequest, RevokeTokenRequest, RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest,
     SendBtcResponse, SendPaymentRequest, SendPaymentResponse, SendRgbRequest, SendRgbResponse,
-    Swap, TakerRequest, Transaction, Transfer, TransferStatus, UnlockRequest, Unspent, WitnessData,
+    Swap, TakerRequest, Transaction, Transfer, TransferKind, TransferStatus, UnlockRequest,
+    Unspent, WitnessData,
 };
 use crate::utils::{
     get_db_path, hex_str, hex_str_to_vec, validate_and_parse_payment_hash, AppState,
@@ -601,7 +602,6 @@ async fn asset_link_create(
     let payload = AssetLinkRequest {
         parent_asset_id: parent_asset_id.to_string(),
         child_asset_id: child_asset_id.to_string(),
-        fee_rate: FEE_RATE,
         min_confirmations: 1,
     };
     let res = reqwest::Client::new()
@@ -1533,6 +1533,27 @@ async fn list_transactions_by_txid(node_address: SocketAddr, txid: &str) -> Vec<
 
 async fn list_unspents(node_address: SocketAddr) -> Vec<Unspent> {
     list_unspents_full(node_address, None, None).await.unspents
+}
+
+async fn list_settled_unspents(node_address: SocketAddr) -> Vec<Unspent> {
+    let payload = ListUnspentsRequest {
+        settled_only: true,
+        skip_sync: false,
+        index_offset: None,
+        max_unspents: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/listunspents"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<ListUnspentsResponse>()
+        .await
+        .unwrap()
+        .unspents
 }
 
 async fn list_unspents_full(

--- a/src/test/payment.rs
+++ b/src/test/payment.rs
@@ -352,6 +352,26 @@ async fn same_invoice_twice_and_expired_inbound_payments() {
     // wait for the invoices to expire
     tokio::time::sleep(std::time::Duration::from_secs(SHORT_EXPIRY_SEC as u64 + 1)).await;
 
+    let payload = SendPaymentRequest {
+        invoice: invoice1,
+        amt_msat: None,
+        asset_id: None,
+        asset_amount: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/sendpayment"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::BAD_REQUEST,
+        "invoice has expired",
+        "InvalidInvoice",
+    )
+    .await;
+
     // getting a payment should trigger expiration-based status transition
     let payment = get_payment(
         node2_addr,

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -370,6 +370,7 @@ fn map_transfer(t: crate::sdk::TransferData) -> Result<Transfer, RlnError> {
         kind: format!("{:?}", t.kind),
         txid,
         recipient_id: t.recipient_id,
+        proxy_recipient_id: t.proxy_recipient_id,
         receive_utxo: t.receive_utxo,
         change_utxo: t.change_utxo,
         expiration: t.expiration,
@@ -584,7 +585,7 @@ impl SdkNode {
             balance: map_asset_balance(asset.balance),
             media: asset.media.map(map_media),
             reject_list_url: asset.reject_list_url,
-            link_right_outpoint: asset.link_right_outpoint.map(map_rgb_outpoint),
+            issuance_link_right_outpoint: asset.issuance_link_right_outpoint.map(map_rgb_outpoint),
             linked_from_asset_id: asset.linked_from_asset_id,
             linked_to_asset_id: asset.linked_to_asset_id,
         })
@@ -640,7 +641,6 @@ impl SdkNode {
             AssetLinkRequest {
                 parent_asset_id: request.parent_asset_id.to_string(),
                 child_asset_id: request.child_asset_id.to_string(),
-                fee_rate: request.fee_rate,
                 min_confirmations: request.min_confirmations,
             },
         ))?;
@@ -1187,6 +1187,7 @@ impl SdkNode {
             ticker: resp.ticker,
             details: resp.details,
             token: resp.token.map(map_token),
+            unspent_link_right_outpoint: resp.unspent_link_right_outpoint.map(map_rgb_outpoint),
             linked_from_asset_id: resp.linked_from_asset_id,
             linked_to_asset_id: resp.linked_to_asset_id,
         })
@@ -1318,7 +1319,9 @@ impl SdkNode {
                             balance: map_asset_balance(a.balance),
                             media: a.media.map(map_media),
                             reject_list_url: a.reject_list_url,
-                            link_right_outpoint: a.link_right_outpoint.map(map_rgb_outpoint),
+                            issuance_link_right_outpoint: a
+                                .issuance_link_right_outpoint
+                                .map(map_rgb_outpoint),
                             linked_from_asset_id: a.linked_from_asset_id,
                             linked_to_asset_id: a.linked_to_asset_id,
                         })
@@ -1372,6 +1375,7 @@ impl SdkNode {
             .transpose()?;
         Ok(DecodeRgbInvoiceResponse {
             recipient_id: resp.recipient_id,
+            proxy_recipient_id: resp.proxy_recipient_id,
             recipient_type: format!("{:?}", resp.recipient_type),
             asset_schema: resp.asset_schema.map(|s| format!("{:?}", s)),
             asset_id,

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -569,6 +569,8 @@ impl SdkNode {
             media: asset.media.map(map_media),
             reject_list_url: asset.reject_list_url,
             link_right_outpoint: asset.link_right_outpoint.map(map_rgb_outpoint),
+            linked_from_asset_id: asset.linked_from_asset_id,
+            linked_to_asset_id: asset.linked_to_asset_id,
         })
     }
 
@@ -1155,6 +1157,8 @@ impl SdkNode {
             ticker: resp.ticker,
             details: resp.details,
             token: resp.token.map(map_token),
+            linked_from_asset_id: resp.linked_from_asset_id,
+            linked_to_asset_id: resp.linked_to_asset_id,
         })
     }
 
@@ -1285,6 +1289,8 @@ impl SdkNode {
                             media: a.media.map(map_media),
                             reject_list_url: a.reject_list_url,
                             link_right_outpoint: a.link_right_outpoint.map(map_rgb_outpoint),
+                            linked_from_asset_id: a.linked_from_asset_id,
+                            linked_to_asset_id: a.linked_to_asset_id,
                         })
                     })
                     .collect::<Result<Vec<_>, RlnError>>()

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod state;
 mod types;
 
 use crate::async_order::AsyncOrderNewHashWire;
+use crate::core_types::asset_link::{AssetLinkRequest, AssetLinkResponse};
 use crate::core_types::async_order::{AsyncOrderNewRequest, AsyncOrderNewResponse};
 use crate::sdk;
 use crate::{NodeConfig, NodeHandle};
@@ -254,6 +255,21 @@ fn map_asset_balance(data: crate::sdk::AssetBalance) -> AssetBalanceInfo {
         offchain_outbound: data.offchain_outbound,
         offchain_inbound: data.offchain_inbound,
     }
+}
+
+fn map_asset_link(data: AssetLinkResponse) -> Result<AssetLinkRecord, RlnError> {
+    Ok(AssetLinkRecord {
+        parent_asset_id: ContractId::from_str(&data.parent_asset_id).map_err(RlnError::internal)?,
+        child_asset_id: data
+            .child_asset_id
+            .map(|asset_id| ContractId::from_str(&asset_id).map_err(RlnError::internal))
+            .transpose()?,
+        created_at: data.created_at,
+        txid: data
+            .txid
+            .map(|txid| Txid::from_str(&txid).map_err(RlnError::internal))
+            .transpose()?,
+    })
 }
 
 fn map_media(data: crate::sdk::Media) -> Media {
@@ -615,6 +631,20 @@ impl SdkNode {
                 reserves: t.reserves,
             }),
         })
+    }
+
+    pub fn asset_link(&self, request: SdkAssetLinkRequest) -> Result<AssetLinkRecord, RlnError> {
+        let state = self.handle.app_state();
+        let asset_link = block_on_sdk(sdk::asset_link(
+            state,
+            AssetLinkRequest {
+                parent_asset_id: request.parent_asset_id.to_string(),
+                child_asset_id: request.child_asset_id.to_string(),
+                fee_rate: request.fee_rate,
+                min_confirmations: request.min_confirmations,
+            },
+        ))?;
+        map_asset_link(asset_link)
     }
 
     pub fn postassetmedia(

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -264,6 +264,29 @@ fn map_media(data: crate::sdk::Media) -> Media {
     }
 }
 
+fn map_ifa_issuance_type(
+    issuance_type: IfaIssuanceType,
+) -> Result<rgb_lib::wallet::IfaIssuanceType, RlnError> {
+    Ok(match issuance_type {
+        IfaIssuanceType::Legacy => rgb_lib::wallet::IfaIssuanceType::Legacy,
+        IfaIssuanceType::LinkRightOnly => rgb_lib::wallet::IfaIssuanceType::LinkRightOnly,
+        IfaIssuanceType::LinkedFromParent {
+            contract_id,
+            request_link_right,
+        } => rgb_lib::wallet::IfaIssuanceType::LinkedFromParent {
+            contract_id: contract_id.to_string(),
+            request_link_right,
+        },
+    })
+}
+
+fn map_rgb_outpoint(outpoint: rgb_lib::wallet::Outpoint) -> RgbOutpoint {
+    RgbOutpoint {
+        txid: outpoint.txid,
+        vout: outpoint.vout,
+    }
+}
+
 fn map_token(data: crate::sdk::Token) -> Token {
     Token {
         index: data.index,
@@ -514,6 +537,10 @@ impl SdkNode {
 
     pub fn issueassetifa(&self, request: SdkIssueAssetIfaRequest) -> Result<AssetIfa, RlnError> {
         let state = self.handle.app_state();
+        let issuance_type = request
+            .issuance_type
+            .map(map_ifa_issuance_type)
+            .transpose()?;
         let asset = block_on_sdk(sdk::issue_asset_ifa(
             state,
             sdk::IssueAssetIFARequestData {
@@ -523,6 +550,7 @@ impl SdkNode {
                 name: request.name,
                 precision: request.precision,
                 reject_list_url: request.reject_list_url,
+                issuance_type,
             },
         ))?;
 
@@ -540,6 +568,7 @@ impl SdkNode {
             balance: map_asset_balance(asset.balance),
             media: asset.media.map(map_media),
             reject_list_url: asset.reject_list_url,
+            link_right_outpoint: asset.link_right_outpoint.map(map_rgb_outpoint),
         })
     }
 
@@ -1255,6 +1284,7 @@ impl SdkNode {
                             balance: map_asset_balance(a.balance),
                             media: a.media.map(map_media),
                             reject_list_url: a.reject_list_url,
+                            link_right_outpoint: a.link_right_outpoint.map(map_rgb_outpoint),
                         })
                     })
                     .collect::<Result<Vec<_>, RlnError>>()

--- a/src/uniffi_api/state.rs
+++ b/src/uniffi_api/state.rs
@@ -185,6 +185,7 @@ pub(crate) fn map_api_error(err: APIError) -> RlnError {
         | APIError::InvalidBiscuitToken
         | APIError::InvalidChannelID
         | APIError::InvalidContractLink(_)
+        | APIError::InvalidRightOutpoint(_)
         | APIError::InvalidDescriptionHash(_)
         | APIError::InvalidDetails(_)
         | APIError::InvalidEstimationBlocks
@@ -217,6 +218,7 @@ pub(crate) fn map_api_error(err: APIError) -> RlnError {
         | APIError::OutputBelowDustLimit
         | APIError::WrongPassword
         | APIError::UnsupportedBackupVersion { .. } => RlnError::InvalidRequest(msg),
+        APIError::RestoredBackupInconsistent(_) => RlnError::Internal(msg),
         APIError::Network(_) | APIError::NoValidTransportEndpoint => RlnError::Conflict(msg),
         APIError::ExternalSignerUnavailable(_) => RlnError::ExternalSignerUnavailable(msg),
         APIError::ExternalSignerProtocolError(_) => RlnError::ExternalSignerProtocolError(msg),

--- a/src/uniffi_api/state.rs
+++ b/src/uniffi_api/state.rs
@@ -184,6 +184,7 @@ pub(crate) fn map_api_error(err: APIError) -> RlnError {
         | APIError::InvalidBackupPath
         | APIError::InvalidBiscuitToken
         | APIError::InvalidChannelID
+        | APIError::InvalidContractLink(_)
         | APIError::InvalidDescriptionHash(_)
         | APIError::InvalidDetails(_)
         | APIError::InvalidEstimationBlocks

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -381,6 +381,18 @@ mod uniffi_smoke_tests {
         let err = super::super::state::map_api_error(crate::error::APIError::LockedNode);
         assert!(matches!(err, RlnError::NotInitialized(_)));
         assert!(err.to_string().contains("unlock"));
+
+        let err = super::super::state::map_api_error(crate::error::APIError::InvalidRightOutpoint(
+            "stale outpoint".to_string(),
+        ));
+        assert!(matches!(err, RlnError::InvalidRequest(_)));
+        assert!(err.to_string().contains("stale outpoint"));
+
+        let err = super::super::state::map_api_error(
+            crate::error::APIError::RestoredBackupInconsistent("backup gap".to_string()),
+        );
+        assert!(matches!(err, RlnError::Internal(_)));
+        assert!(err.to_string().contains("backup gap"));
     }
 
     #[cfg(feature = "vss")]

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -356,6 +356,12 @@ pub struct AssetIfa {
     pub balance: AssetBalanceInfo,
     pub media: Option<Media>,
     pub reject_list_url: Option<String>,
+    pub link_right_outpoint: Option<RgbOutpoint>,
+}
+
+pub struct RgbOutpoint {
+    pub txid: String,
+    pub vout: u32,
 }
 
 pub struct ListAssetsResponse {
@@ -587,6 +593,16 @@ pub struct SdkIssueAssetIfaRequest {
     pub name: String,
     pub precision: u8,
     pub reject_list_url: Option<String>,
+    pub issuance_type: Option<IfaIssuanceType>,
+}
+
+pub enum IfaIssuanceType {
+    Legacy,
+    LinkRightOnly,
+    LinkedFromParent {
+        contract_id: ContractId,
+        request_link_right: bool,
+    },
 }
 
 pub struct SdkIssueAssetUdaRequest {

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -245,6 +245,13 @@ pub struct AssetBalanceInfo {
     pub offchain_inbound: u64,
 }
 
+pub struct AssetLinkRecord {
+    pub parent_asset_id: ContractId,
+    pub child_asset_id: Option<ContractId>,
+    pub created_at: Option<u64>,
+    pub txid: Option<Txid>,
+}
+
 pub struct AssetMetadataInfo {
     pub asset_schema: String,
     pub initial_supply: u64,
@@ -607,6 +614,13 @@ pub enum IfaIssuanceType {
         contract_id: ContractId,
         request_link_right: bool,
     },
+}
+
+pub struct SdkAssetLinkRequest {
+    pub parent_asset_id: ContractId,
+    pub child_asset_id: ContractId,
+    pub fee_rate: u64,
+    pub min_confirmations: u8,
 }
 
 pub struct SdkIssueAssetUdaRequest {

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -263,6 +263,7 @@ pub struct AssetMetadataInfo {
     pub ticker: Option<String>,
     pub details: Option<String>,
     pub token: Option<Token>,
+    pub unspent_link_right_outpoint: Option<RgbOutpoint>,
     pub linked_from_asset_id: Option<String>,
     pub linked_to_asset_id: Option<String>,
 }
@@ -365,7 +366,7 @@ pub struct AssetIfa {
     pub balance: AssetBalanceInfo,
     pub media: Option<Media>,
     pub reject_list_url: Option<String>,
-    pub link_right_outpoint: Option<RgbOutpoint>,
+    pub issuance_link_right_outpoint: Option<RgbOutpoint>,
     pub linked_from_asset_id: Option<String>,
     pub linked_to_asset_id: Option<String>,
 }
@@ -397,6 +398,7 @@ pub struct DecodeLnInvoiceResponse {
 
 pub struct DecodeRgbInvoiceResponse {
     pub recipient_id: String,
+    pub proxy_recipient_id: String,
     pub recipient_type: String,
     pub asset_schema: Option<String>,
     pub asset_id: Option<ContractId>,
@@ -432,6 +434,7 @@ pub struct Transfer {
     pub kind: String,
     pub txid: Option<Txid>,
     pub recipient_id: Option<String>,
+    pub proxy_recipient_id: Option<String>,
     pub receive_utxo: Option<String>,
     pub change_utxo: Option<String>,
     pub expiration: Option<i64>,
@@ -619,7 +622,6 @@ pub enum IfaIssuanceType {
 pub struct SdkAssetLinkRequest {
     pub parent_asset_id: ContractId,
     pub child_asset_id: ContractId,
-    pub fee_rate: u64,
     pub min_confirmations: u8,
 }
 

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -256,6 +256,8 @@ pub struct AssetMetadataInfo {
     pub ticker: Option<String>,
     pub details: Option<String>,
     pub token: Option<Token>,
+    pub linked_from_asset_id: Option<String>,
+    pub linked_to_asset_id: Option<String>,
 }
 
 pub struct AssetMediaResponse {
@@ -357,6 +359,8 @@ pub struct AssetIfa {
     pub media: Option<Media>,
     pub reject_list_url: Option<String>,
     pub link_right_outpoint: Option<RgbOutpoint>,
+    pub linked_from_asset_id: Option<String>,
+    pub linked_to_asset_id: Option<String>,
 }
 
 pub struct RgbOutpoint {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,6 +36,7 @@ use std::{
 use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
 use tokio_util::sync::CancellationToken;
 
+use crate::asset_link::AssetLinkMessageHandler;
 use crate::async_order::{AsyncOrderMessageHandler, AsyncPaymentsPreimageRoot};
 use crate::ldk::{ChannelIdsMap, Router, VirtualChannelDraftStore, VirtualChannelSessionStore};
 use crate::rgb::{get_rgb_channel_info_optional, RgbLibWalletWrapper};
@@ -174,6 +175,7 @@ pub(crate) struct UnlockedAppState {
     pub(crate) onion_messenger: Arc<OnionMessenger>,
     pub(crate) outbound_payments: Arc<Mutex<OutboundPaymentInfoStorage>>,
     pub(crate) peer_manager: Arc<PeerManager>,
+    pub(crate) asset_link_handler: Arc<AssetLinkMessageHandler>,
     pub(crate) async_order_handler: Arc<AsyncOrderMessageHandler>,
     pub(crate) async_payments_preimage_root: Arc<AsyncPaymentsPreimageRoot>,
     pub(crate) kv_store: Arc<SyncedKvStore>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,6 +19,7 @@ use lightning::{
     util::persist::KVStoreSync,
     util::ser::{Writeable, Writer},
 };
+use lightning_invoice::Bolt11Invoice;
 use magic_crypt::{new_magic_crypt, MagicCryptTrait};
 use rgb_lib::{bdk_wallet::keys::bip39::Mnemonic, BitcoinNetwork, ContractId};
 use rln_migration::{Migrator, MigratorTrait};
@@ -548,6 +549,13 @@ pub(crate) async fn connect_peer_if_necessary(
     do_connect_peer(pubkey, address, peer_manager).await?;
     tracing::info!("connected to peer (pubkey: {pubkey}, addr: {address})");
     Ok(())
+}
+
+pub(crate) fn description_hash_from_invoice(invoice: &Bolt11Invoice) -> Option<[u8; 32]> {
+    match invoice.description() {
+        lightning_invoice::Bolt11InvoiceDescriptionRef::Hash(hash) => Some(hash.0.to_byte_array()),
+        _ => None,
+    }
 }
 
 pub(crate) async fn do_connect_peer(


### PR DESCRIPTION
First iteration:

- Adds `POST /assetlink/create`.
- Persists a local `AssetLink` record per issued asset in KV storage (`issue_asset_nia` now writes an issuer record with `linked_asset_id = None`, `signature = None`, `created_at = None`).
- `asset_link_create` then upgrades the `asset_id` record to point at `linked_asset_id`, adds the host signature, and sets `created_at`.

Validation rules:
- Both assets must exist locally and be issued by the same node pubkey.
- `asset_id` and `linked_asset_id` must differ.
- Repeating the same link is idempotent.
- Linking the same asset to a different target is rejected.