### PR TITLE
Recover cleanly from failed unlocks and release the VSS fence on graceful teardown

### DIFF
--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -3732,6 +3732,8 @@ pub(crate) async fn start_ldk(
     // before ack); ChannelManager and aux state keep the local-first `kv_store`
     // sync facade. Both share the same local DB and (when configured) VSS store.
     #[cfg(feature = "vss")]
+    let mut fence_guard: Option<crate::vss_kv_store::FenceReleaseGuard> = None;
+    #[cfg(feature = "vss")]
     let (kv_store, monitor_kv_store) = if let (Some(ref vss_url), Some(ref identity)) =
         (&static_state.vss_url, &vss_identity)
     {
@@ -3751,6 +3753,16 @@ pub(crate) async fn start_ldk(
         vss_kv_store
             .acquire_fence()
             .map_err(|e| APIError::FailedVssInit(e.to_string()))?;
+
+        // Release the just-acquired fence if the rest of startup fails.
+        fence_guard = Some(crate::vss_kv_store::FenceReleaseGuard::new({
+            let store = Arc::clone(&vss_kv_store);
+            move || {
+                if let Err(e) = store.release_fence_if_owned() {
+                    tracing::warn!(error = %e, "failed to release VSS fence after aborted unlock");
+                }
+            }
+        }));
 
         let monitor_kv_store = Arc::new(RemoteFirstKvStore::new(
             Arc::clone(&local_kv_store),
@@ -4263,8 +4275,20 @@ pub(crate) async fn start_ldk(
         witness_version: WitnessVersion::Taproot,
     };
     let reuse_addresses = static_state.reuse_addresses;
-    let mut rgb_wallet = tokio::task::spawn_blocking(move || {
-        RgbLibWallet::new(
+    let indexer_url_owned = indexer_url.to_string();
+    #[cfg(feature = "vss")]
+    let rgb_vss_backup = match (&static_state.vss_url, &vss_identity) {
+        (Some(vss_url), Some(identity)) => Some((
+            vss_url.clone(),
+            format!("{}_rgb", identity.pubkey_hex),
+            identity.signing_key,
+        )),
+        _ => None,
+    };
+    // go_online and configure_vss_backup drive blocking rgb-lib HTTP clients;
+    // run them off the async runtime so they don't fail on a single-vCPU host.
+    let (rgb_wallet, rgb_online) = tokio::task::spawn_blocking(move || {
+        let mut rgb_wallet = RgbLibWallet::new(
             WalletData {
                 data_dir,
                 bitcoin_network,
@@ -4275,40 +4299,31 @@ pub(crate) async fn start_ldk(
             },
             keys,
         )
-        .expect("valid rgb-lib wallet")
+        .expect("valid rgb-lib wallet");
+        let rgb_online = rgb_wallet.go_online(OnlineOptions {
+            indexer_url: indexer_url_owned,
+            skip_consistency_check: false,
+            vanilla_sync_lookback: 20,
+        })?;
+        #[cfg(feature = "vss")]
+        if let Some((vss_url, rgb_store_id, signing_key)) = rgb_vss_backup {
+            let vss_config =
+                rgb_lib::wallet::vss::VssBackupConfig::new(vss_url, rgb_store_id, signing_key)
+                    .with_encryption(true)
+                    .with_auto_backup(true)
+                    .with_backup_mode(rgb_lib::wallet::vss::VssBackupMode::Blocking);
+            // Fail closed: a misconfigured backup must not silently run local-only.
+            rgb_wallet.configure_vss_backup(vss_config).map_err(|e| {
+                APIError::FailedVssInit(format!(
+                    "Failed to configure VSS backup for RGB wallet: {e}"
+                ))
+            })?;
+            tracing::info!("VSS auto-backup (blocking) enabled for RGB wallet");
+        }
+        Ok::<_, APIError>((rgb_wallet, rgb_online))
     })
     .await
-    .unwrap();
-    let rgb_online = rgb_wallet.go_online(OnlineOptions {
-        indexer_url: indexer_url.to_string(),
-        skip_consistency_check: false,
-        vanilla_sync_lookback: 20,
-    })?;
-
-    // Configure VSS backup for the RGB wallet if VSS is enabled. Reuses the
-    // identity derived once at the top of this function — see N3.1 / the
-    // `derive_vss_identity` helper.
-    #[cfg(feature = "vss")]
-    if let (Some(ref vss_url), Some(ref identity)) = (&static_state.vss_url, &vss_identity) {
-        let rgb_store_id = format!("{}_rgb", identity.pubkey_hex);
-        let vss_config = rgb_lib::wallet::vss::VssBackupConfig::new(
-            vss_url.clone(),
-            rgb_store_id,
-            identity.signing_key,
-        )
-        .with_encryption(true)
-        .with_auto_backup(true)
-        // Blocking: each RGB op waits until its VSS backup is durable.
-        .with_backup_mode(rgb_lib::wallet::vss::VssBackupMode::Blocking);
-
-        // Fail closed: a misconfigured backup must not silently run local-only.
-        rgb_wallet.configure_vss_backup(vss_config).map_err(|e| {
-            APIError::FailedVssInit(format!(
-                "Failed to configure VSS backup for RGB wallet: {e}"
-            ))
-        })?;
-        tracing::info!("VSS auto-backup (blocking) enabled for RGB wallet");
-    }
+    .map_err(|e| APIError::Unexpected(format!("rgb-lib wallet setup task failed: {e}")))??;
     save_config(
         &static_state.db(),
         kv_store.as_ref(),
@@ -5086,6 +5101,11 @@ pub(crate) async fn start_ldk(
     tracing::info!("LDK logs are available at <your-supplied-ldk-data-dir-path>/.ldk/logs");
     tracing::info!("Local Node ID is {}", channel_manager.get_our_node_id());
 
+    #[cfg(feature = "vss")]
+    if let Some(guard) = fence_guard.as_mut() {
+        guard.disarm();
+    }
+
     Ok((
         LdkBackgroundServices {
             stop_processing,
@@ -5173,6 +5193,27 @@ pub(crate) async fn stop_ldk(app_state: Arc<AppState>) {
 
     if let Some(join_handle) = app_state.stop_ldk() {
         join_handle.await.unwrap().unwrap();
+    }
+
+    // Graceful teardown (lock, shutdown, signal): release the VSS fence so
+    // the next unlock — a fresh instance id — takes over without an explicit
+    // /vssclearfence. Hard kills still leave the fence behind by design.
+    #[cfg(feature = "vss")]
+    {
+        let kv_store = app_state
+            .get_unlocked_app_state()
+            .await
+            .as_ref()
+            .map(|unlocked| Arc::clone(&unlocked.kv_store));
+        if let Some(kv_store) = kv_store {
+            match tokio::task::spawn_blocking(move || kv_store.release_vss_fence_if_owned()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!(error = %e, "failed to release VSS fence during shutdown")
+                }
+                Err(e) => tracing::warn!(error = %e, "VSS fence release task failed"),
+            }
+        }
     }
 
     // connect to the peer port so it can be released

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -5028,28 +5028,22 @@ pub(crate) async fn unlock(
             }
         }
 
-        let mnemonic = match check_password_validity(&payload.password, &state.db()) {
-            Ok(mnemonic) => mnemonic,
-            Err(e) => {
-                state.update_changing_state(false);
-                return Err(e);
-            }
-        };
+        // Clear the changing-state flag on any exit — including a panic during
+        // startup — so a failed unlock can't wedge the node in ChangingState.
+        let _changing_state_guard = crate::utils::CallOnDrop::new({
+            let state = state.clone();
+            move || state.update_changing_state(false)
+        });
+
+        let mnemonic = check_password_validity(&payload.password, &state.db())?;
 
         tracing::debug!("Starting LDK...");
-        let (new_ldk_background_services, new_unlocked_app_state) = match start_ldk(
+        let (new_ldk_background_services, new_unlocked_app_state) = start_ldk(
             state.clone(),
             crate::core_types::NodeKeySource::InternalMnemonic(mnemonic),
             payload.into(),
         )
-        .await
-        {
-            Ok((nlbs, nuap)) => (nlbs, nuap),
-            Err(e) => {
-                state.update_changing_state(false);
-                return Err(e);
-            }
-        };
+        .await?;
         tracing::debug!("LDK started");
 
         state
@@ -5057,8 +5051,6 @@ pub(crate) async fn unlock(
             .await;
 
         state.update_ldk_background_services(Some(new_ldk_background_services));
-
-        state.update_changing_state(false);
 
         tracing::info!("Unlock completed");
         Ok(Json(EmptyResponse {}))

--- a/src/synced_kv_store.rs
+++ b/src/synced_kv_store.rs
@@ -64,6 +64,16 @@ impl SyncedKvStore {
         }
     }
 
+    /// Releases the VSS single-writer fence if this instance owns it. No-op
+    /// without a remote store.
+    #[cfg(feature = "vss")]
+    pub(crate) fn release_vss_fence_if_owned(&self) -> Result<(), io::Error> {
+        match &self.remote {
+            Some(remote) => remote.release_fence_if_owned(),
+            None => Ok(()),
+        }
+    }
+
     /// Restores all key-value pairs from VSS into the local store.
     ///
     /// `force = false` is the safe default and returns `Ok(0)` if the local

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -473,9 +473,9 @@ async fn start_node_with_vss(
         String::new()
     } else {
         let resp = init(node_address, &password, mnemonic.map(|m| m.to_string())).await;
-        // Take over our own store_id: a same-seed restart inherits the previous
-        // incarnation's fence (nothing releases it on shutdown). No-op on a first
-        // start.
+        // Take over our own store_id: a same-seed restart may inherit a fence
+        // from a previous incarnation that exited without a graceful teardown.
+        // No-op on a first start.
         clear_vss_fence(node_address, &password).await;
         resp.mnemonic
     };

--- a/src/test/vss.rs
+++ b/src/test/vss.rs
@@ -126,6 +126,43 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn vss_kv_store_remove_is_idempotent() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let (signing_key, store_id) = generate_test_keys();
+        let store = VssKvStore::new(VSS_URL.to_string(), store_id, signing_key).expect("vss store");
+
+        let ns = "monitors";
+        let sub_ns = "funding";
+        let key = "mon";
+
+        // Removing a key that was never written must succeed (no version to
+        // conflict on) — this is the case that used to loop forever.
+        store
+            .remove(ns, sub_ns, key, false)
+            .expect("remove of absent key must be a no-op success");
+
+        // Write then remove: the removal must succeed and the key must be gone.
+        store
+            .write(ns, sub_ns, key, b"data".to_vec())
+            .expect("write");
+        store
+            .remove(ns, sub_ns, key, false)
+            .expect("remove of existing key must succeed");
+        let err = store.read(ns, sub_ns, key).unwrap_err();
+        assert_eq!(err.kind(), bitcoin::io::ErrorKind::NotFound);
+
+        // Removing again (already gone) must still succeed, so a queued retry
+        // can drain instead of re-failing on a version conflict.
+        store
+            .remove(ns, sub_ns, key, false)
+            .expect("second remove of same key must be a no-op success");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn vss_kv_store_multiple_namespaces() {
         if !vss_server_available() {
             eprintln!("SKIP: VSS server not available at {VSS_URL}");

--- a/src/test/vss.rs
+++ b/src/test/vss.rs
@@ -553,6 +553,153 @@ mod tests {
         store.delete_fence().expect("second delete is no-op");
     }
 
+    /// `release_fence_if_owned` frees the fence for the owner and is a no-op
+    /// for everyone else, so an aborted unlock can roll back its own fence
+    /// without clobbering one another instance holds.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn vss_release_fence_if_owned_semantics() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let (signing_key, store_id) = generate_test_keys();
+        let store_a =
+            VssKvStore::new(VSS_URL.to_string(), store_id.clone(), signing_key).expect("store a");
+        store_a.acquire_fence().expect("a acquires fence");
+
+        // A non-owner release is a no-op: the fence stays with A.
+        let store_b =
+            VssKvStore::new(VSS_URL.to_string(), store_id.clone(), signing_key).expect("store b");
+        store_b
+            .release_fence_if_owned()
+            .expect("non-owner release must not error");
+        store_b
+            .acquire_fence()
+            .expect_err("fence must still be owned by a");
+
+        // The owner's release frees the fence for the next instance.
+        store_a.release_fence_if_owned().expect("owner release");
+        store_b
+            .acquire_fence()
+            .expect("b acquires after a released");
+
+        // Releasing with no owned fence stays a no-op and leaves B's fence.
+        store_a
+            .release_fence_if_owned()
+            .expect("stale owner release must not error");
+        let store_c = VssKvStore::new(VSS_URL.to_string(), store_id, signing_key).expect("store c");
+        store_c
+            .acquire_fence()
+            .expect_err("fence must still be owned by b");
+    }
+
+    /// A failed unlock must roll back what it acquired: the VSS fence is
+    /// released and the changing-state flag is cleared, so a retry (failed or
+    /// successful) is never wedged behind a stranded fence.
+    #[serial_test::serial]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn vss_failed_unlock_releases_fence_and_allows_retry() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+        tokio::time::timeout(
+            std::time::Duration::from_secs(120),
+            failed_unlock_releases_fence_inner(),
+        )
+        .await
+        .expect("vss_failed_unlock_releases_fence_and_allows_retry timed out");
+    }
+
+    async fn failed_unlock_releases_fence_inner() {
+        crate::test::initialize();
+
+        let test_dir_node = "tmp/vss_failed_unlock_retry/node1";
+        let node_address = crate::test::start_daemon_with_vss(
+            test_dir_node,
+            crate::test::NODE1_PEER_PORT,
+            false,
+            Some(VSS_URL.to_string()),
+            false,
+        )
+        .await;
+        let password = "vss_failed_unlock_retry";
+        crate::test::init(node_address, password, None).await;
+
+        // Unlock against an unreachable indexer: fails after the fence acquire.
+        let mut payload = crate::test::unlock_req(password);
+        payload.indexer_url = Some("127.0.0.1:1".to_string());
+        let client = reqwest::Client::new();
+        for attempt in 1..=2 {
+            let res = client
+                .post(format!("http://{node_address}/unlock"))
+                .json(&payload)
+                .send()
+                .await
+                .unwrap();
+            assert!(
+                !res.status().is_success(),
+                "unlock with unreachable indexer must fail"
+            );
+            let body = res.text().await.unwrap();
+            // Every attempt must fail on the indexer itself, not on a fence
+            // stranded by the previous attempt or a stuck changing-state flag.
+            assert!(
+                !body.contains("owned by another"),
+                "attempt {attempt} hit a stranded fence: {body}"
+            );
+            assert!(
+                !body.contains("changing state"),
+                "attempt {attempt} hit a stuck changing-state flag: {body}"
+            );
+        }
+
+        // With the fence rolled back a retry with good parameters succeeds.
+        crate::test::unlock(node_address, password).await;
+
+        crate::test::shutdown(&[node_address]).await;
+    }
+
+    /// A graceful lock must release the VSS fence: the next unlock runs under
+    /// a fresh instance id and must take over without `/vssclearfence`.
+    #[serial_test::serial]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn vss_lock_releases_fence_for_next_unlock() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+        tokio::time::timeout(
+            std::time::Duration::from_secs(180),
+            lock_releases_fence_inner(),
+        )
+        .await
+        .expect("vss_lock_releases_fence_for_next_unlock timed out");
+    }
+
+    async fn lock_releases_fence_inner() {
+        crate::test::initialize();
+
+        let test_dir_node = "tmp/vss_lock_release_fence/node1";
+        let node_address = crate::test::start_daemon_with_vss(
+            test_dir_node,
+            crate::test::NODE1_PEER_PORT,
+            false,
+            Some(VSS_URL.to_string()),
+            false,
+        )
+        .await;
+        let password = "vss_lock_release_fence";
+        crate::test::init(node_address, password, None).await;
+
+        crate::test::unlock(node_address, password).await;
+        crate::test::lock(node_address).await;
+        crate::test::unlock(node_address, password).await;
+
+        crate::test::shutdown(&[node_address]).await;
+    }
+
     /// End-to-end happy-path that mirrors what the SDK does for a legitimate
     /// "wipe device and restore" flow:
     ///
@@ -616,8 +763,8 @@ mod tests {
                 .expect("original write");
         }
 
-        // Graceful shutdown: drop the instance. The fence is intentionally not
-        // released — this is the source of the bug the SDK escape hatch fixes.
+        // Abrupt exit (crash/kill): drop the instance without releasing the
+        // fence — the case the SDK escape hatch exists for.
         drop(original);
 
         // --- Fresh device, same mnemonic ---

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -567,6 +567,25 @@ pub(crate) fn hex_str_to_vec(hex: &str) -> Option<Vec<u8>> {
     Some(out)
 }
 
+/// Runs a closure on drop, including during panic unwinding, so cleanup (e.g.
+/// clearing the changing-state flag) still happens if the guarded work returns
+/// early or panics.
+pub(crate) struct CallOnDrop<F: FnMut()> {
+    action: F,
+}
+
+impl<F: FnMut()> CallOnDrop<F> {
+    pub(crate) fn new(action: F) -> Self {
+        Self { action }
+    }
+}
+
+impl<F: FnMut()> Drop for CallOnDrop<F> {
+    fn drop(&mut self) {
+        (self.action)();
+    }
+}
+
 pub(crate) async fn no_cancel<Fut>(fut: Fut) -> Fut::Output
 where
     Fut: 'static + Future + Send,
@@ -843,5 +862,37 @@ mod utils_tests {
     fn vss_url_other_schemes_rejected() {
         assert!(validate_vss_url("ftp://example.com/vss", true).is_err());
         assert!(validate_vss_url("example.com/vss", true).is_err());
+    }
+}
+
+#[cfg(test)]
+mod call_on_drop_tests {
+    use super::CallOnDrop;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn runs_action_on_scope_exit() {
+        let ran = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&ran);
+        {
+            let _g = CallOnDrop::new(move || flag.store(true, Ordering::SeqCst));
+        }
+        assert!(ran.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn runs_action_during_panic_unwind() {
+        let ran = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&ran);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _g = CallOnDrop::new(move || flag.store(true, Ordering::SeqCst));
+            panic!("boom");
+        }));
+        assert!(result.is_err(), "closure should have panicked");
+        assert!(
+            ran.load(Ordering::SeqCst),
+            "action must run while unwinding a panic"
+        );
     }
 }

--- a/src/vss_kv_store.rs
+++ b/src/vss_kv_store.rs
@@ -713,23 +713,51 @@ impl KVStoreSync for VssKvStore {
 
         self.check_fence_periodic();
 
+        // VSS honors `version = -1` only for puts; `delete_items` require the
+        // object's current version, so a blind delete is rejected with a
+        // version conflict and, once queued, retries forever without ever
+        // converging. Read the current version and issue a conditional delete;
+        // an absent key means the removal goal is already met.
+        let get_req = GetObjectRequest {
+            store_id: self.store_id.clone(),
+            key: vss_key.clone(),
+        };
+        let existing_version = match self.block_on(self.client.get_object(&get_req)) {
+            Ok(resp) => match resp.value {
+                Some(kv) => kv.version,
+                None => return Ok(()),
+            },
+            Err(VssError::NoSuchKeyError(_)) => return Ok(()),
+            Err(e) => {
+                tracing::error!(vss_key, error = %e, "VssKvStore remove read failed");
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("VSS remove read failed: {e}"),
+                ));
+            }
+        };
+
         let request = PutObjectRequest {
             store_id: self.store_id.clone(),
             global_version: None,
             transaction_items: vec![],
             delete_items: vec![KeyValue {
                 key: vss_key.clone(),
-                version: -1,
+                version: existing_version,
                 value: vec![],
             }],
         };
 
-        self.block_on(self.client.put_object(&request))
-            .map_err(|e| {
+        match self.block_on(self.client.put_object(&request)) {
+            Ok(_) | Err(VssError::NoSuchKeyError(_)) => Ok(()),
+            Err(e) => {
                 tracing::error!(vss_key, error = %e, "VssKvStore remove failed");
-                io::Error::new(io::ErrorKind::Other, format!("VSS remove failed: {e}"))
-            })?;
-        Ok(())
+                Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("VSS remove failed: {e}"),
+                ))
+            }
+        }
     }
 
     fn list(

--- a/src/vss_kv_store.rs
+++ b/src/vss_kv_store.rs
@@ -308,6 +308,52 @@ impl VssKvStore {
         }
     }
 
+    /// Deletes the fence only if VSS still records this instance as the owner,
+    /// so a failed unlock can roll back its own fence without clobbering one
+    /// another instance may have taken over.
+    pub fn release_fence_if_owned(&self) -> Result<(), io::Error> {
+        let get_req = GetObjectRequest {
+            store_id: self.store_id.clone(),
+            key: FENCE_KEY.to_string(),
+        };
+        let existing = match self.block_on(self.client.get_object(&get_req)) {
+            Ok(resp) => match resp.value {
+                Some(kv) => kv,
+                None => return Ok(()),
+            },
+            Err(VssError::NoSuchKeyError(_)) => return Ok(()),
+            Err(e) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("VSS fence read failed: {e}"),
+                ));
+            }
+        };
+        if String::from_utf8_lossy(&existing.value) != self.instance_id.to_string() {
+            return Ok(());
+        }
+        let request = PutObjectRequest {
+            store_id: self.store_id.clone(),
+            global_version: None,
+            transaction_items: vec![],
+            delete_items: vec![KeyValue {
+                key: FENCE_KEY.to_string(),
+                version: existing.version,
+                value: vec![],
+            }],
+        };
+        match self.block_on(self.client.put_object(&request)) {
+            Ok(_) | Err(VssError::NoSuchKeyError(_)) => {
+                tracing::info!(instance_id = %self.instance_id, "VSS fence released");
+                Ok(())
+            }
+            Err(e) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("VSS fence release failed: {e}"),
+            )),
+        }
+    }
+
     /// Periodic re-check of the fence; panics if the fence has been taken over
     /// by another instance, since at that point our writes would corrupt the
     /// other instance's state.
@@ -730,5 +776,66 @@ impl KVStoreSync for VssKvStore {
         }
 
         Ok(keys)
+    }
+}
+
+/// Releases the VSS single-writer fence on drop unless disarmed. Armed after
+/// `acquire_fence`, disarmed once the node starts; a failed unlock in between
+/// releases the fence so it doesn't wedge the next attempt.
+pub(crate) struct FenceReleaseGuard {
+    release: Option<Box<dyn FnMut() + Send>>,
+}
+
+impl FenceReleaseGuard {
+    pub(crate) fn new(release: impl FnMut() + Send + 'static) -> Self {
+        Self {
+            release: Some(Box::new(release)),
+        }
+    }
+
+    pub(crate) fn disarm(&mut self) {
+        self.release = None;
+    }
+}
+
+impl Drop for FenceReleaseGuard {
+    fn drop(&mut self) {
+        if let Some(mut release) = self.release.take() {
+            release();
+        }
+    }
+}
+
+#[cfg(test)]
+mod fence_release_guard_tests {
+    use super::FenceReleaseGuard;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn armed_guard_runs_release_on_drop() {
+        let released = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&released);
+        {
+            let _guard = FenceReleaseGuard::new(move || flag.store(true, Ordering::SeqCst));
+        }
+        assert!(
+            released.load(Ordering::SeqCst),
+            "an armed guard must run its release action when dropped"
+        );
+    }
+
+    #[test]
+    fn disarmed_guard_skips_release_on_drop() {
+        let released = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&released);
+        {
+            let mut guard = FenceReleaseGuard::new(move || flag.store(true, Ordering::SeqCst));
+            guard.disarm();
+        }
+        assert!(
+            !released.load(Ordering::SeqCst),
+            "a disarmed guard must not run its release action"
+        );
     }
 }


### PR DESCRIPTION
A failed /unlock used to leave the node wedged: the VSS single-writer fence acquired during startup was never rolled back (forcing a manual /vssclearfence before any retry), and a panic mid-unlock left the node stuck in ChangingState. This PR makes unlock failures fully recoverable — the fence is released on any aborted unlock and on every graceful teardown (/lock, /shutdown, SIGTERM), and the changing-state flag is cleared on any exit path, including panics. It also moves go_online and configure_vss_backup off the async runtime onto the blocking pool, since they drive blocking rgb-lib HTTP clients.

It also fixes a VSS replication bug that wedged channel-monitor persistence under load: VssKvStore::remove issued blind deletes with version = -1, but the VSS server honors -1 only for puts, so every delete_items was rejected as a version conflict and the queued retry re-failed forever — leaving pending_kv_writes climbing without ever draining (writes, using -1, succeeded, so only removes piled up). remove now reads the object's current version and issues a conditional delete, treating an absent key as success (mirroring the working release_fence_if_owned), so removes converge instead of looping.

Includes e2e tests against a real VSS server: a failed unlock (unreachable indexer) no longer strands the fence and a retry succeeds, a graceful lock → unlock cycle takes over its own fence without operator intervention, owner/non-owner semantics for release_fence_if_owned, and idempotent/versioned remove semantics. All were verified to fail on dev before the fix; the remove fix was additionally verified in a live enclave, channel activity that previously stuck pending_kv_writes at 124 now drains to 0.