### PR TITLE
add TOML config file support with layered CLI overrides and validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4361,6 +4361,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "toml 0.8.23",
  "tower-http",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ sea-orm = { version = "1.1.19", default-features = false, features = [
 scrypt = "0.11.0"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.8"
 prost = "0.13"
 tempfile = "3.14.0"
 thiserror = "2.0"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ body must include exactly one of:
 `bitcoind + esplora` returns `400 AmbiguousChainBackend`. No credentials at
 all returns `400 MissingChainBackend`.
 
+### Configuration file
+
+The node can be configured via a TOML file, loaded from
+`<storage_directory_path>/config.toml` if it exists, or from the path given
+with `--config <path>`. All settings are optional and documented, along with
+their defaults, in [sample-config.toml](sample-config.toml). Values are
+resolved in order: built-in defaults, then the config file, then explicit CLI
+options; `/unlock` body params override the corresponding config values at
+runtime. Invalid values and unknown keys abort startup with an error.
+
 ### Regtest
 
 To easily start the required services on a regtest network, run:

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/MultiOpenCloseTest.kt
@@ -153,7 +153,8 @@ class MultiOpenCloseTest {
             SdkCreateUtxosRequest(
                 upTo = false,
                 num = utxosNum,
-                size = null,
+                // explicit size keeps fixture balances independent of the default
+                size = 32_000u,
                 feeRate = utxosFeeRate,
                 skipSync = false,
             )

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/PaymentTest.kt
@@ -162,7 +162,8 @@ class PaymentTest {
             SdkCreateUtxosRequest(
                 upTo = false,
                 num = utxosNum,
-                size = null,
+                // explicit size keeps fixture balances independent of the default
+                size = 32_000u,
                 feeRate = utxosFeeRate,
                 skipSync = false,
             )

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/RestartTest.kt
@@ -154,7 +154,8 @@ class RestartTest {
             SdkCreateUtxosRequest(
                 upTo = false,
                 num = utxosNum,
-                size = null,
+                // explicit size keeps fixture balances independent of the default
+                size = 32_000u,
                 feeRate = utxosFeeRate,
                 skipSync = false,
             )

--- a/android-e2e/app/src/androidTest/java/org/rgblightningnode/SwapRoundtripBuyTest.kt
+++ b/android-e2e/app/src/androidTest/java/org/rgblightningnode/SwapRoundtripBuyTest.kt
@@ -181,7 +181,8 @@ class SwapRoundtripBuyTest {
             SdkCreateUtxosRequest(
                 upTo = false,
                 num = utxosNum,
-                size = null,
+                // explicit size keeps fixture balances independent of the default
+                size = 32_000u,
                 feeRate = utxosFeeRate,
                 skipSync = false,
             )

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -1,0 +1,142 @@
+# Sample configuration file for rgb-lightning-node.
+#
+# The node loads <storage_directory_path>/config.toml if it exists, or the
+# file given via --config. Values here override the built-in defaults and are
+# overridden by explicit CLI options. All keys are optional; unknown keys are
+# rejected. The values below document the defaults.
+
+[node]
+# Bitcoin network (Mainnet, Testnet, Testnet4, Signet, Regtest)
+#network = "Testnet"
+# Listening port of the daemon
+#daemon_listening_port = 3001
+# Listening port for LN peers
+#ldk_peer_listening_port = 9735
+# Default node alias announced via gossip (max 32 bytes, /unlock overrides)
+#announce_alias = ""
+# Default addresses announced via gossip (/unlock overrides)
+#announce_addresses = []
+# Reuse a pinned wallet address instead of generating a fresh one per call
+#reuse_addresses = false
+# Interval between channel peer reconnection attempts (seconds)
+#peer_reconnect_interval_secs = 1
+# Delay before the first node announcement broadcast (seconds)
+#announce_initial_delay_secs = 60
+# Interval between node announcement refreshes (seconds)
+#announce_refresh_interval_secs = 3600
+
+[auth]
+# Disable biscuit token authentication
+#disable_authentication = false
+# Root public key for biscuit token authentication (hex-encoded)
+#root_public_key = ""
+# Minimum accepted wallet password length
+#password_min_length = 8
+
+[chain]
+# Default indexer URL used when /unlock does not provide one
+# (defaults to a per-network public electrum server)
+#indexer_url = ""
+# Default RGB proxy endpoint used when /unlock does not provide one
+# (defaults to a per-network public proxy)
+#proxy_endpoint = ""
+# Socket timeout for the indexer client (seconds)
+#indexer_timeout_secs = 10
+# Interval between fee estimate refreshes (seconds)
+#fee_refresh_interval_secs = 60
+
+[rgb]
+# Default fee rate in sat/vB for coloring, witness and channel funding txs
+#fee_rate_sat_vb = 7
+# Default size in sats for colorable UTXOs created by /createutxos
+#utxo_size_sat = 32000
+# Default number of UTXOs created by /createutxos
+#utxo_num = 4
+# Confirmations required for channel funding transactions
+#min_channel_confirmations = 6
+
+[channels]
+# Minimum HTLC amount on RGB channels (msat)
+#htlc_min_msat = 3000000
+# Minimum HTLC amount on virtual channels (msat)
+#virtual_htlc_min_msat = 1000
+# Minimum inbound payment amount (msat)
+#dust_limit_msat = 546000
+# Minimum capacity for a vanilla channel (sat)
+#open_min_sat = 5506
+# Maximum channel capacity (sat, protocol limit 16777215)
+#open_max_sat = 16777215
+# Minimum RGB asset amount in a channel
+#open_min_rgb_amount = 1
+# Maximum to_self_delay accepted from the counterparty (max 2016)
+#their_to_self_delay = 2016
+# to_self_delay we require from the counterparty (144-2016)
+#our_to_self_delay = 144
+# CLTV expiry delta advertised for forwarded HTLCs (min 48)
+#cltv_expiry_delta = 72
+# Default forwarding base fee for new channels (msat)
+#forwarding_fee_base_msat = 1000
+# Default forwarding proportional fee for new channels (parts per million)
+#forwarding_fee_proportional_millionths = 0
+# Max dust HTLC exposure as a multiplier on the max fee estimate (mutually exclusive with the fixed variant)
+#max_dust_htlc_exposure_multiplier = 10000
+# Max dust HTLC exposure as a fixed msat limit (mutually exclusive with the multiplier variant)
+#max_dust_htlc_exposure_fixed_msat = 5000000
+# Max inbound HTLC value in flight, percent of channel capacity (1-100)
+#max_inbound_htlc_value_in_flight_percent = 10
+# Max concurrent HTLCs we accept per channel (1-483)
+#our_max_accepted_htlcs = 50
+# Max confirmations a peer may require before a channel is usable
+#max_minimum_depth = 144
+# Enable virtual channels (v0)
+#enable_virtual_channels_v0 = false
+# Allowed virtual channel peer pubkeys (hex-encoded)
+#virtual_peer_pubkeys = []
+
+[payments]
+# Final CLTV expiry delta used for payments
+#final_cltv_expiry_delta = 14
+# Payment retry timeout in seconds
+#retry_timeout_secs = 10
+# Maximum acceptable total swap fee (msat)
+#max_swap_fee_msat = 3000000
+
+[gossip]
+# Interval between rapid gossip sync updates (seconds)
+#rgs_sync_interval_secs = 3600
+# Maximum accepted RGS snapshot size (MB)
+#rgs_snapshot_max_size_mb = 15
+# RGS server connect timeout (seconds)
+#rgs_connect_timeout_secs = 5
+# RGS snapshot download timeout (seconds)
+#rgs_sync_timeout_secs = 60
+
+[lsp]
+# LSP base URL
+#base_url = ""
+# LSP bearer token
+#bearer_token = ""
+# Timeout waiting for an async order response from the LSP (seconds)
+#order_response_timeout_secs = 30
+# HTTP request timeout towards the LSP (seconds, keep above the LSP's own timeout)
+#request_timeout_secs = 25
+
+[vss]
+# VSS server URL for cloud backup (empty = VSS disabled)
+#url = ""
+# Allow http:// VSS URLs for non-loopback hosts
+#allow_http = false
+# Start with empty local state if VSS restore fails on a fresh device
+#allow_empty_restore = false
+# Initial backoff between VSS request retries (milliseconds)
+#retry_backoff_ms = 100
+# Maximum VSS request attempts
+#retry_max_attempts = 3
+# Maximum total delay across VSS request retries (seconds)
+#retry_max_total_delay_secs = 5
+
+[api]
+# Max allowed media size for upload (MB)
+#max_media_upload_size_mb = 5
+# Default page size for list endpoints
+#default_page_size = 100

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -49,14 +49,14 @@
 # Default fee rate in sat/vB for coloring, witness and channel funding txs
 #fee_rate_sat_vb = 7
 # Default size in sats for colorable UTXOs created by /createutxos
-#utxo_size_sat = 32000
+#utxo_size_sat = 20000
 # Default number of UTXOs created by /createutxos
 #utxo_num = 4
 # Confirmations required for channel funding transactions
-#min_channel_confirmations = 6
+#min_channel_confirmations = 3
 
 [channels]
-# Minimum HTLC amount on RGB channels (msat)
+# Minimum HTLC amount on RGB channels (msat, must clear HTLC dust so asset payments can settle)
 #htlc_min_msat = 3000000
 # Minimum HTLC amount on virtual channels (msat)
 #virtual_htlc_min_msat = 1000

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,9 +1,11 @@
 use bitcoin::secp256k1::PublicKey;
-use clap::{value_parser, Parser};
+use clap::parser::ValueSource;
+use clap::{value_parser, ArgMatches, CommandFactory, FromArgMatches, Parser};
 use rgb_lib::BitcoinNetwork;
 use std::path::PathBuf;
 
 use crate::auth::check_auth_args;
+use crate::config::{load_config_file, Config, TomlConfig, DEFAULT_CONFIG_FILENAME};
 use crate::error::AppError;
 use crate::utils::{check_port_is_available, hex_str_to_compressed_pubkey};
 
@@ -12,6 +14,12 @@ use crate::utils::{check_port_is_available, hex_str_to_compressed_pubkey};
 struct Args {
     /// Path for the node storage directory
     storage_directory_path: PathBuf,
+
+    /// Path to a TOML configuration file. When not set,
+    /// <STORAGE_DIRECTORY_PATH>/config.toml is loaded if it exists. Explicit
+    /// CLI options override values from the file.
+    #[arg(long)]
+    config: Option<PathBuf>,
 
     /// Listening port of the daemon
     #[arg(long, default_value_t = 3001)]
@@ -114,32 +122,116 @@ pub(crate) struct UserArgs {
     /// it's load-bearing: the `--remote-signer-addr` clap arg above, and the code that actually
     /// connects to the daemon in `routes::unlock`.
     pub(crate) remote_signer_listen_addr: Option<std::net::SocketAddr>,
+    pub(crate) config: Config,
 }
 
 pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
-    let args = Args::parse();
+    let matches = Args::command().get_matches();
+    let args =
+        Args::from_arg_matches(&matches).map_err(|e| AppError::InvalidConfig(e.to_string()))?;
+    let toml = load_startup_toml(&args)?;
+    let user_args = resolve_user_args(args, &matches, toml)?;
 
-    let network = args.network;
+    check_port_is_available(user_args.daemon_listening_port)?;
+    check_port_is_available(user_args.ldk_peer_listening_port)?;
 
-    let daemon_listening_port = args.daemon_listening_port;
-    check_port_is_available(daemon_listening_port)?;
-    let ldk_peer_listening_port = args.ldk_peer_listening_port;
-    check_port_is_available(ldk_peer_listening_port)?;
+    Ok(user_args)
+}
 
-    let root_public_key = check_auth_args(args.disable_authentication, args.root_public_key)?;
+fn load_startup_toml(args: &Args) -> Result<TomlConfig, AppError> {
+    if let Some(path) = &args.config {
+        return load_config_file(path);
+    }
+    let default_path = args.storage_directory_path.join(DEFAULT_CONFIG_FILENAME);
+    if default_path.exists() {
+        load_config_file(&default_path)
+    } else {
+        Ok(TomlConfig::default())
+    }
+}
 
+/// Merge the three configuration layers: built-in defaults, then the config
+/// file, then explicit CLI options.
+fn resolve_user_args(
+    args: Args,
+    matches: &ArgMatches,
+    toml: TomlConfig,
+) -> Result<UserArgs, AppError> {
+    let config = Config::from_toml(&toml)?;
+    let from_cli = |name: &str| matches.value_source(name) == Some(ValueSource::CommandLine);
+
+    let node = toml.node.unwrap_or_default();
+    let auth = toml.auth.unwrap_or_default();
+    let channels = toml.channels.unwrap_or_default();
+    let lsp = toml.lsp.unwrap_or_default();
+    let vss = toml.vss.unwrap_or_default();
+    let api = toml.api.unwrap_or_default();
+
+    let network = match node.network {
+        Some(ref s) if !from_cli("network") => s
+            .parse::<BitcoinNetwork>()
+            .map_err(|_| AppError::InvalidConfig(format!("invalid node.network: {s}")))?,
+        _ => args.network,
+    };
+
+    let daemon_listening_port = if from_cli("daemon_listening_port") {
+        args.daemon_listening_port
+    } else {
+        node.daemon_listening_port
+            .unwrap_or(args.daemon_listening_port)
+    };
+    let ldk_peer_listening_port = if from_cli("ldk_peer_listening_port") {
+        args.ldk_peer_listening_port
+    } else {
+        node.ldk_peer_listening_port
+            .unwrap_or(args.ldk_peer_listening_port)
+    };
+    if daemon_listening_port == ldk_peer_listening_port {
+        return Err(AppError::InvalidConfig(format!(
+            "daemon_listening_port and ldk_peer_listening_port cannot both be {daemon_listening_port}"
+        )));
+    }
+
+    let max_media_upload_size_mb = if from_cli("max_media_upload_size_mb") {
+        args.max_media_upload_size_mb
+    } else {
+        api.max_media_upload_size_mb
+            .unwrap_or(args.max_media_upload_size_mb)
+    };
+
+    let disable_authentication =
+        args.disable_authentication || auth.disable_authentication.unwrap_or(false);
+    let root_public_key_hex = args.root_public_key.or(auth.root_public_key);
+    let root_public_key = check_auth_args(disable_authentication, root_public_key_hex)?;
+
+    let enable_virtual_channels_v0 =
+        args.enable_virtual_channels_v0 || channels.enable_virtual_channels_v0.unwrap_or(false);
+    let raw_virtual_peer_pubkeys = if !args.virtual_peer_pubkeys.is_empty() {
+        args.virtual_peer_pubkeys
+    } else {
+        channels.virtual_peer_pubkeys.unwrap_or_default()
+    };
     let mut virtual_peer_pubkeys = Vec::new();
-    for pubkey in args.virtual_peer_pubkeys {
+    for pubkey in raw_virtual_peer_pubkeys {
         let Some(parsed_pubkey) = hex_str_to_compressed_pubkey(&pubkey) else {
             return Err(AppError::InvalidVirtualPeerPubkey(pubkey));
         };
         virtual_peer_pubkeys.push(parsed_pubkey);
     }
 
-    // Reject http:// URLs unless the host is loopback or --vss-allow-http is set.
-    if let Some(url) = &args.vss_url {
-        crate::utils::validate_vss_url(url, args.vss_allow_http)?;
+    let lsp_base_url = args.lsp_base_url.or(lsp.base_url);
+    let lsp_bearer_token = args.lsp_bearer_token.or(lsp.bearer_token);
+
+    let vss_url = args.vss_url.or(vss.url);
+    let vss_allow_http = args.vss_allow_http || vss.allow_http.unwrap_or(false);
+    let vss_allow_empty_restore =
+        args.vss_allow_empty_restore || vss.allow_empty_restore.unwrap_or(false);
+    // Reject http:// URLs unless the host is loopback or allow_http is set.
+    if let Some(url) = &vss_url {
+        crate::utils::validate_vss_url(url, vss_allow_http)?;
     }
+
+    let reuse_addresses = args.reuse_addresses || node.reuse_addresses.unwrap_or(false);
 
     // The clap arg only exists under `remote-signer` (see `Args`); bridge to the always-present
     // `UserArgs` field here so nothing downstream needs to cfg-gate it.
@@ -153,15 +245,183 @@ pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
         daemon_listening_port,
         ldk_peer_listening_port,
         network,
-        max_media_upload_size_mb: args.max_media_upload_size_mb,
+        max_media_upload_size_mb,
         root_public_key,
-        enable_virtual_channels_v0: args.enable_virtual_channels_v0,
+        enable_virtual_channels_v0,
         virtual_peer_pubkeys,
-        lsp_base_url: args.lsp_base_url,
-        lsp_bearer_token: args.lsp_bearer_token,
-        vss_url: args.vss_url,
-        vss_allow_empty_restore: args.vss_allow_empty_restore,
-        reuse_addresses: args.reuse_addresses,
+        lsp_base_url,
+        lsp_bearer_token,
+        vss_url,
+        vss_allow_empty_restore,
+        reuse_addresses,
         remote_signer_listen_addr,
+        config,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::TomlConfig;
+
+    const PUBKEY: &str = "02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619";
+
+    fn resolve(argv: &[&str], toml: &str) -> Result<UserArgs, AppError> {
+        let matches = <Args as clap::CommandFactory>::command()
+            .try_get_matches_from(argv)
+            .unwrap();
+        let args = <Args as clap::FromArgMatches>::from_arg_matches(&matches).unwrap();
+        resolve_user_args(args, &matches, TomlConfig::parse(toml).unwrap())
+    }
+
+    fn base(extra: &[&str]) -> Vec<&'static str> {
+        let mut argv = vec!["rln", "/tmp/storage", "--disable-authentication"];
+        argv.extend(
+            extra
+                .iter()
+                .map(|s| -> &'static str { Box::leak(s.to_string().into_boxed_str()) }),
+        );
+        argv
+    }
+
+    #[test]
+    fn defaults_without_file_or_flags() {
+        let ua = resolve(&base(&[]), "").unwrap();
+        assert_eq!(ua.daemon_listening_port, 3001);
+        assert_eq!(ua.ldk_peer_listening_port, 9735);
+        assert_eq!(ua.network, BitcoinNetwork::Testnet);
+        assert_eq!(ua.max_media_upload_size_mb, 5);
+        assert!(!ua.enable_virtual_channels_v0);
+        assert!(ua.virtual_peer_pubkeys.is_empty());
+        assert!(ua.lsp_base_url.is_none());
+        assert!(ua.vss_url.is_none());
+        assert!(!ua.vss_allow_empty_restore);
+        assert!(!ua.reuse_addresses);
+        assert_eq!(ua.config, crate::config::Config::default());
+    }
+
+    #[test]
+    fn file_overrides_defaults() {
+        let ua = resolve(
+            &base(&[]),
+            "[node]\nnetwork = \"regtest\"\ndaemon_listening_port = 8888\nldk_peer_listening_port = 9999\nreuse_addresses = true\n\n[api]\nmax_media_upload_size_mb = 10\n",
+        )
+        .unwrap();
+        assert_eq!(ua.network, BitcoinNetwork::Regtest);
+        assert_eq!(ua.daemon_listening_port, 8888);
+        assert_eq!(ua.ldk_peer_listening_port, 9999);
+        assert!(ua.reuse_addresses);
+        assert_eq!(ua.max_media_upload_size_mb, 10);
+    }
+
+    #[test]
+    fn cli_overrides_file() {
+        let ua = resolve(
+            &base(&["--daemon-listening-port", "9999", "--network", "signet"]),
+            "[node]\nnetwork = \"regtest\"\ndaemon_listening_port = 8888\n",
+        )
+        .unwrap();
+        assert_eq!(ua.daemon_listening_port, 9999);
+        assert_eq!(ua.network, BitcoinNetwork::Signet);
+    }
+
+    #[test]
+    fn invalid_network_in_file_rejected() {
+        let res = resolve(&base(&[]), "[node]\nnetwork = \"bogus\"\n");
+        assert!(matches!(res, Err(AppError::InvalidConfig(ref m)) if m.contains("bogus")));
+    }
+
+    #[test]
+    fn same_ports_rejected() {
+        let res = resolve(
+            &base(&[]),
+            "[node]\ndaemon_listening_port = 4000\nldk_peer_listening_port = 4000\n",
+        );
+        assert!(matches!(res, Err(AppError::InvalidConfig(_))));
+    }
+
+    #[test]
+    fn auth_from_file() {
+        let argv = vec!["rln", "/tmp/storage"];
+        let ua = resolve(&argv, "[auth]\ndisable_authentication = true\n").unwrap();
+        assert!(ua.root_public_key.is_none());
+    }
+
+    #[test]
+    fn auth_conflict_rejected() {
+        let res = resolve(
+            &base(&[]),
+            &format!("[auth]\nroot_public_key = \"{PUBKEY}\"\n"),
+        );
+        assert!(matches!(res, Err(AppError::InvalidAuthenticationArgs)));
+    }
+
+    #[test]
+    fn missing_auth_rejected() {
+        let argv = vec!["rln", "/tmp/storage"];
+        let res = resolve(&argv, "");
+        assert!(matches!(res, Err(AppError::InvalidAuthenticationArgs)));
+    }
+
+    #[test]
+    fn vss_http_from_file_rejected_without_allow_http() {
+        let res = resolve(&base(&[]), "[vss]\nurl = \"http://example.com/vss\"\n");
+        assert!(matches!(res, Err(AppError::InvalidVssConfig(_))));
+    }
+
+    #[test]
+    fn vss_http_from_file_allowed_with_allow_http() {
+        let ua = resolve(
+            &base(&[]),
+            "[vss]\nurl = \"http://example.com/vss\"\nallow_http = true\nallow_empty_restore = true\n",
+        )
+        .unwrap();
+        assert_eq!(ua.vss_url.as_deref(), Some("http://example.com/vss"));
+        assert!(ua.vss_allow_empty_restore);
+    }
+
+    #[test]
+    fn virtual_peers_from_file() {
+        let ua = resolve(
+            &base(&[]),
+            &format!(
+                "[channels]\nenable_virtual_channels_v0 = true\nvirtual_peer_pubkeys = [\"{PUBKEY}\"]\n"
+            ),
+        )
+        .unwrap();
+        assert!(ua.enable_virtual_channels_v0);
+        assert_eq!(ua.virtual_peer_pubkeys.len(), 1);
+    }
+
+    #[test]
+    fn invalid_virtual_peer_in_file_rejected() {
+        let res = resolve(
+            &base(&[]),
+            "[channels]\nvirtual_peer_pubkeys = [\"nothex\"]\n",
+        );
+        assert!(matches!(res, Err(AppError::InvalidVirtualPeerPubkey(_))));
+    }
+
+    #[test]
+    fn lsp_from_file_cli_wins() {
+        let ua = resolve(
+            &base(&["--lsp-base-url", "https://cli.example.com"]),
+            "[lsp]\nbase_url = \"https://file.example.com\"\nbearer_token = \"tok\"\n",
+        )
+        .unwrap();
+        assert_eq!(ua.lsp_base_url.as_deref(), Some("https://cli.example.com"));
+        assert_eq!(ua.lsp_bearer_token.as_deref(), Some("tok"));
+    }
+
+    #[test]
+    fn policy_sections_attached_to_user_args() {
+        let ua = resolve(&base(&[]), "[rgb]\nfee_rate_sat_vb = 12\n").unwrap();
+        assert_eq!(ua.config.rgb.fee_rate_sat_vb, 12);
+    }
+
+    #[test]
+    fn invalid_policy_in_file_rejected() {
+        let res = resolve(&base(&[]), "[rgb]\nfee_rate_sat_vb = 0\n");
+        assert!(matches!(res, Err(AppError::InvalidConfig(_))));
+    }
 }

--- a/src/async_order.rs
+++ b/src/async_order.rs
@@ -29,7 +29,6 @@ use crate::utils::{hex_str, validate_and_parse_description_hash, validate_and_pa
 
 pub(crate) const ASYNC_ORDER_MESSAGE_TYPE_ID: u16 = 37915;
 pub(crate) const ASYNC_ORDER_MAX_HASH_BATCH_SIZE: usize = 200;
-pub(crate) const ASYNC_ORDER_RESPONSE_TIMEOUT_SECS: u64 = 30;
 const ASYNC_ERROR_DUPLICATE_INDEX_CONFLICT: i64 = 1004;
 const ASYNC_ERROR_DUPLICATE_HASH_CONFLICT: i64 = 1005;
 const ASYNC_ERROR_INVALID_HASH_BATCH: i64 = 1003;
@@ -46,7 +45,6 @@ const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
 const JSONRPC_PARSE_ERROR: i64 = -32700;
 const JSONRPC_VERSION: &str = "2.0";
 const PROTOCOL_VERSION: u64 = 1;
-const ASYNC_ORDER_LSP_REQUEST_TIMEOUT_SECS: u64 = 25; // Must be above utexo-lsp's default 15s HTTP timeout with a buffer.
 const ASYNC_ORDER_FIRST_HASH_INDEX: u64 = 1;
 const ASYNC_PAYMENTS_ACCOUNT_INDEX: u32 = 0;
 const ASYNC_PAYMENTS_BIP32_MAX_CHILD_INDEX: u32 = 0x7fff_ffff;
@@ -872,6 +870,7 @@ impl AsyncOrderMessageHandler {
         lsp_base_url: String,
         lsp_bearer_token: Option<String>,
         runtime_handle: Handle,
+        request_timeout_secs: u64,
     ) -> Self {
         Self {
             access_control,
@@ -879,7 +878,7 @@ impl AsyncOrderMessageHandler {
             lsp_client: Some(AsyncOrderLspClient::new(
                 lsp_base_url,
                 lsp_bearer_token,
-                Duration::from_secs(ASYNC_ORDER_LSP_REQUEST_TIMEOUT_SECS),
+                Duration::from_secs(request_timeout_secs),
             )),
             runtime_handle: Some(runtime_handle),
             state: Arc::new(Mutex::new(AsyncOrderState::default())),

--- a/src/bitcoind.rs
+++ b/src/bitcoind.rs
@@ -120,6 +120,7 @@ impl BitcoindClient {
         rpc_password: String,
         handle: tokio::runtime::Handle,
         logger: Arc<FilesystemLogger>,
+        fee_refresh_interval_secs: u64,
     ) -> std::io::Result<Self> {
         let http_endpoint = HttpEndpoint::for_host(host.clone()).with_port(port);
         let rpc_credentials = general_purpose::STANDARD.encode(format!(
@@ -177,6 +178,7 @@ impl BitcoindClient {
             client.bitcoind_rpc_client.clone(),
             client.logger.clone(),
             handle,
+            fee_refresh_interval_secs,
         );
         Ok(client)
     }
@@ -186,6 +188,7 @@ impl BitcoindClient {
         rpc_client: Arc<RpcClient>,
         logger: Arc<FilesystemLogger>,
         handle: tokio::runtime::Handle,
+        refresh_interval_secs: u64,
     ) {
         handle.spawn(async move {
             async fn get_estimate(
@@ -290,7 +293,7 @@ impl BitcoindClient {
                     .unwrap()
                     .store(background_estimate, Ordering::Release);
 
-                tokio::time::sleep(Duration::from_secs(60)).await;
+                tokio::time::sleep(Duration::from_secs(refresh_interval_secs)).await;
             }
         });
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,0 +1,146 @@
+use std::fs;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::AppError;
+
+/// Mirror of the TOML config file. Every field is optional: absent keys keep
+/// the built-in defaults, unknown keys are hard errors.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlConfig {
+    pub(crate) node: Option<TomlNode>,
+    pub(crate) auth: Option<TomlAuth>,
+    pub(crate) chain: Option<TomlChain>,
+    pub(crate) rgb: Option<TomlRgb>,
+    pub(crate) channels: Option<TomlChannels>,
+    pub(crate) payments: Option<TomlPayments>,
+    pub(crate) gossip: Option<TomlGossip>,
+    pub(crate) lsp: Option<TomlLsp>,
+    pub(crate) vss: Option<TomlVss>,
+    pub(crate) api: Option<TomlApi>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlNode {
+    pub(crate) network: Option<String>,
+    pub(crate) daemon_listening_port: Option<u16>,
+    pub(crate) ldk_peer_listening_port: Option<u16>,
+    pub(crate) announce_alias: Option<String>,
+    pub(crate) announce_addresses: Option<Vec<String>>,
+    pub(crate) reuse_addresses: Option<bool>,
+    pub(crate) peer_reconnect_interval_secs: Option<u64>,
+    pub(crate) announce_initial_delay_secs: Option<u64>,
+    pub(crate) announce_refresh_interval_secs: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlAuth {
+    pub(crate) disable_authentication: Option<bool>,
+    pub(crate) root_public_key: Option<String>,
+    pub(crate) password_min_length: Option<u8>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlChain {
+    pub(crate) indexer_url: Option<String>,
+    pub(crate) proxy_endpoint: Option<String>,
+    pub(crate) indexer_timeout_secs: Option<u64>,
+    pub(crate) fee_refresh_interval_secs: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlRgb {
+    pub(crate) fee_rate_sat_vb: Option<u64>,
+    pub(crate) utxo_size_sat: Option<u32>,
+    pub(crate) utxo_num: Option<u8>,
+    pub(crate) min_channel_confirmations: Option<u8>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlChannels {
+    pub(crate) htlc_min_msat: Option<u64>,
+    pub(crate) virtual_htlc_min_msat: Option<u64>,
+    pub(crate) dust_limit_msat: Option<u64>,
+    pub(crate) open_min_sat: Option<u64>,
+    pub(crate) open_max_sat: Option<u64>,
+    pub(crate) open_min_rgb_amount: Option<u64>,
+    pub(crate) their_to_self_delay: Option<u16>,
+    pub(crate) cltv_expiry_delta: Option<u16>,
+    pub(crate) our_to_self_delay: Option<u16>,
+    pub(crate) forwarding_fee_base_msat: Option<u32>,
+    pub(crate) forwarding_fee_proportional_millionths: Option<u32>,
+    pub(crate) max_dust_htlc_exposure_multiplier: Option<u64>,
+    pub(crate) max_dust_htlc_exposure_fixed_msat: Option<u64>,
+    pub(crate) max_inbound_htlc_value_in_flight_percent: Option<u8>,
+    pub(crate) our_max_accepted_htlcs: Option<u16>,
+    pub(crate) max_minimum_depth: Option<u32>,
+    pub(crate) enable_virtual_channels_v0: Option<bool>,
+    pub(crate) virtual_peer_pubkeys: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlPayments {
+    pub(crate) final_cltv_expiry_delta: Option<u32>,
+    pub(crate) retry_timeout_secs: Option<u64>,
+    pub(crate) max_swap_fee_msat: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlGossip {
+    pub(crate) rgs_sync_interval_secs: Option<u64>,
+    pub(crate) rgs_snapshot_max_size_mb: Option<u64>,
+    pub(crate) rgs_connect_timeout_secs: Option<u64>,
+    pub(crate) rgs_sync_timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlLsp {
+    pub(crate) base_url: Option<String>,
+    pub(crate) bearer_token: Option<String>,
+    pub(crate) order_response_timeout_secs: Option<u64>,
+    pub(crate) request_timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlVss {
+    pub(crate) url: Option<String>,
+    pub(crate) allow_http: Option<bool>,
+    pub(crate) allow_empty_restore: Option<bool>,
+    pub(crate) retry_backoff_ms: Option<u64>,
+    pub(crate) retry_max_attempts: Option<u32>,
+    pub(crate) retry_max_total_delay_secs: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlApi {
+    pub(crate) max_media_upload_size_mb: Option<u16>,
+    pub(crate) default_page_size: Option<u64>,
+}
+
+impl TomlConfig {
+    pub(crate) fn parse(content: &str) -> Result<Self, AppError> {
+        toml::from_str(content).map_err(|e| AppError::InvalidConfig(e.to_string()))
+    }
+}
+
+pub(crate) fn load_config_file(path: &Path) -> Result<TomlConfig, AppError> {
+    let content = fs::read_to_string(path).map_err(|e| {
+        AppError::InvalidConfig(format!("cannot read config file {}: {e}", path.display()))
+    })?;
+    TomlConfig::parse(&content).map_err(|e| match e {
+        AppError::InvalidConfig(m) => AppError::InvalidConfig(format!("{}: {m}", path.display())),
+        other => other,
+    })
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,660 @@
+mod file;
+#[cfg(test)]
+mod tests;
+
+pub(crate) use file::{load_config_file, TomlConfig};
+
+use crate::core_types::{
+    DEFAULT_FINAL_CLTV_EXPIRY_DELTA, DUST_LIMIT_MSAT, FEE_RATE, HTLC_MIN_MSAT, MAX_SWAP_FEE_MSAT,
+    MIN_CHANNEL_CONFIRMATIONS, UTXO_SIZE_SAT, VIRTUAL_HTLC_MIN_MSAT,
+};
+use lightning::ln::channelmanager::{BREAKDOWN_TIMEOUT, MIN_CLTV_EXPIRY_DELTA};
+use lightning::util::config::{
+    ChannelConfig as LdkChannelConfig, ChannelHandshakeConfig as LdkChannelHandshakeConfig,
+    ChannelHandshakeLimits as LdkChannelHandshakeLimits, MaxDustHTLCExposure,
+};
+
+use crate::error::AppError;
+
+pub(crate) const DEFAULT_CONFIG_FILENAME: &str = "config.toml";
+
+const DEFAULT_UTXO_NUM: u8 = 4;
+const DEFAULT_OPENCHANNEL_MIN_SAT: u64 = 5506;
+const DEFAULT_OPENCHANNEL_MAX_SAT: u64 = 16_777_215;
+const DEFAULT_OPENCHANNEL_MIN_RGB_AMT: u64 = 1;
+// lnd's max to_self_delay is 2016, so we want to be compatible
+const DEFAULT_THEIR_TO_SELF_DELAY: u16 = 2016;
+const DEFAULT_PAYMENT_RETRY_TIMEOUT_SECS: u64 = 10;
+const DEFAULT_PASSWORD_MIN_LENGTH: u8 = 8;
+const DEFAULT_PAGE_SIZE: u64 = 100;
+const DEFAULT_PEER_RECONNECT_INTERVAL_SECS: u64 = 1;
+const DEFAULT_ANNOUNCE_INITIAL_DELAY_SECS: u64 = 60;
+const DEFAULT_ANNOUNCE_REFRESH_INTERVAL_SECS: u64 = 3600;
+const DEFAULT_INDEXER_TIMEOUT_SECS: u64 = 10;
+const DEFAULT_FEE_REFRESH_INTERVAL_SECS: u64 = 60;
+const DEFAULT_RGS_SYNC_INTERVAL_SECS: u64 = 3600;
+const DEFAULT_RGS_SNAPSHOT_MAX_SIZE_MB: u64 = 15;
+const DEFAULT_RGS_CONNECT_TIMEOUT_SECS: u64 = 5;
+const DEFAULT_RGS_SYNC_TIMEOUT_SECS: u64 = 60;
+const DEFAULT_VSS_RETRY_BACKOFF_MS: u64 = 100;
+const DEFAULT_VSS_RETRY_MAX_ATTEMPTS: u32 = 3;
+const DEFAULT_VSS_RETRY_MAX_TOTAL_DELAY_SECS: u64 = 5;
+const DEFAULT_LSP_ORDER_RESPONSE_TIMEOUT_SECS: u64 = 30;
+// must stay above utexo-lsp's default 15s HTTP timeout with a buffer
+const DEFAULT_LSP_REQUEST_TIMEOUT_SECS: u64 = 25;
+
+const MAX_TO_SELF_DELAY: u16 = 2016;
+const MAX_CHANNEL_SAT: u64 = 16_777_215;
+const MAX_ALIAS_BYTES: usize = 32;
+// BOLT-2 maximum for max_accepted_htlcs (LDK silently clamps higher values)
+const MAX_ACCEPTED_HTLCS_CAP: u16 = 483;
+
+/// Node settings resolved from built-in defaults overridden by the optional
+/// TOML config file. With no config file every value matches the historical
+/// hardcoded behavior.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct Config {
+    pub(crate) node: NodeSection,
+    pub(crate) chain: ChainSection,
+    pub(crate) rgb: RgbSection,
+    pub(crate) channels: ChannelsSection,
+    pub(crate) payments: PaymentsSection,
+    pub(crate) gossip: GossipSection,
+    pub(crate) vss: VssSection,
+    pub(crate) lsp: LspSection,
+    pub(crate) auth: AuthSection,
+    pub(crate) api: ApiSection,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct NodeSection {
+    pub(crate) announce_alias: Option<String>,
+    pub(crate) announce_addresses: Vec<String>,
+    pub(crate) peer_reconnect_interval_secs: u64,
+    pub(crate) announce_initial_delay_secs: u64,
+    pub(crate) announce_refresh_interval_secs: u64,
+}
+
+impl Default for NodeSection {
+    fn default() -> Self {
+        Self {
+            announce_alias: None,
+            announce_addresses: Vec::new(),
+            peer_reconnect_interval_secs: DEFAULT_PEER_RECONNECT_INTERVAL_SECS,
+            announce_initial_delay_secs: DEFAULT_ANNOUNCE_INITIAL_DELAY_SECS,
+            announce_refresh_interval_secs: DEFAULT_ANNOUNCE_REFRESH_INTERVAL_SECS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ChainSection {
+    pub(crate) indexer_url: Option<String>,
+    pub(crate) proxy_endpoint: Option<String>,
+    pub(crate) indexer_timeout_secs: u64,
+    pub(crate) fee_refresh_interval_secs: u64,
+}
+
+impl Default for ChainSection {
+    fn default() -> Self {
+        Self {
+            indexer_url: None,
+            proxy_endpoint: None,
+            indexer_timeout_secs: DEFAULT_INDEXER_TIMEOUT_SECS,
+            fee_refresh_interval_secs: DEFAULT_FEE_REFRESH_INTERVAL_SECS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct GossipSection {
+    pub(crate) rgs_sync_interval_secs: u64,
+    pub(crate) rgs_snapshot_max_size_mb: u64,
+    pub(crate) rgs_connect_timeout_secs: u64,
+    pub(crate) rgs_sync_timeout_secs: u64,
+}
+
+impl Default for GossipSection {
+    fn default() -> Self {
+        Self {
+            rgs_sync_interval_secs: DEFAULT_RGS_SYNC_INTERVAL_SECS,
+            rgs_snapshot_max_size_mb: DEFAULT_RGS_SNAPSHOT_MAX_SIZE_MB,
+            rgs_connect_timeout_secs: DEFAULT_RGS_CONNECT_TIMEOUT_SECS,
+            rgs_sync_timeout_secs: DEFAULT_RGS_SYNC_TIMEOUT_SECS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct VssSection {
+    pub(crate) retry_backoff_ms: u64,
+    pub(crate) retry_max_attempts: u32,
+    pub(crate) retry_max_total_delay_secs: u64,
+}
+
+impl Default for VssSection {
+    fn default() -> Self {
+        Self {
+            retry_backoff_ms: DEFAULT_VSS_RETRY_BACKOFF_MS,
+            retry_max_attempts: DEFAULT_VSS_RETRY_MAX_ATTEMPTS,
+            retry_max_total_delay_secs: DEFAULT_VSS_RETRY_MAX_TOTAL_DELAY_SECS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct LspSection {
+    pub(crate) order_response_timeout_secs: u64,
+    pub(crate) request_timeout_secs: u64,
+}
+
+impl Default for LspSection {
+    fn default() -> Self {
+        Self {
+            order_response_timeout_secs: DEFAULT_LSP_ORDER_RESPONSE_TIMEOUT_SECS,
+            request_timeout_secs: DEFAULT_LSP_REQUEST_TIMEOUT_SECS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct RgbSection {
+    pub(crate) fee_rate_sat_vb: u64,
+    pub(crate) utxo_size_sat: u32,
+    pub(crate) utxo_num: u8,
+    pub(crate) min_channel_confirmations: u8,
+}
+
+impl Default for RgbSection {
+    fn default() -> Self {
+        Self {
+            fee_rate_sat_vb: FEE_RATE,
+            utxo_size_sat: UTXO_SIZE_SAT,
+            utxo_num: DEFAULT_UTXO_NUM,
+            min_channel_confirmations: MIN_CHANNEL_CONFIRMATIONS,
+        }
+    }
+}
+
+/// Maximum dust HTLC exposure, mirroring LDK's `MaxDustHTLCExposure`.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum DustExposure {
+    FeeRateMultiplier(u64),
+    FixedLimitMsat(u64),
+}
+
+impl DustExposure {
+    fn from_ldk(value: MaxDustHTLCExposure) -> Self {
+        match value {
+            MaxDustHTLCExposure::FeeRateMultiplier(m) => Self::FeeRateMultiplier(m),
+            MaxDustHTLCExposure::FixedLimitMsat(m) => Self::FixedLimitMsat(m),
+        }
+    }
+
+    fn to_ldk(&self) -> MaxDustHTLCExposure {
+        match self {
+            Self::FeeRateMultiplier(m) => MaxDustHTLCExposure::FeeRateMultiplier(*m),
+            Self::FixedLimitMsat(m) => MaxDustHTLCExposure::FixedLimitMsat(*m),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ChannelsSection {
+    pub(crate) htlc_min_msat: u64,
+    pub(crate) virtual_htlc_min_msat: u64,
+    pub(crate) dust_limit_msat: u64,
+    pub(crate) open_min_sat: u64,
+    pub(crate) open_max_sat: u64,
+    pub(crate) open_min_rgb_amount: u64,
+    pub(crate) their_to_self_delay: u16,
+    pub(crate) cltv_expiry_delta: u16,
+    pub(crate) our_to_self_delay: u16,
+    pub(crate) forwarding_fee_base_msat: u32,
+    pub(crate) forwarding_fee_proportional_millionths: u32,
+    pub(crate) max_dust_htlc_exposure: DustExposure,
+    pub(crate) max_inbound_htlc_value_in_flight_percent: u8,
+    pub(crate) our_max_accepted_htlcs: u16,
+    pub(crate) max_minimum_depth: u32,
+}
+
+impl Default for ChannelsSection {
+    fn default() -> Self {
+        // LDK-inherited values source their defaults from LDK itself so they
+        // keep tracking the fork
+        let ldk_channel = LdkChannelConfig::default();
+        let ldk_handshake = LdkChannelHandshakeConfig::default();
+        let ldk_limits = LdkChannelHandshakeLimits::default();
+        Self {
+            htlc_min_msat: HTLC_MIN_MSAT,
+            virtual_htlc_min_msat: VIRTUAL_HTLC_MIN_MSAT,
+            dust_limit_msat: DUST_LIMIT_MSAT,
+            open_min_sat: DEFAULT_OPENCHANNEL_MIN_SAT,
+            open_max_sat: DEFAULT_OPENCHANNEL_MAX_SAT,
+            open_min_rgb_amount: DEFAULT_OPENCHANNEL_MIN_RGB_AMT,
+            their_to_self_delay: DEFAULT_THEIR_TO_SELF_DELAY,
+            cltv_expiry_delta: ldk_channel.cltv_expiry_delta,
+            our_to_self_delay: ldk_handshake.our_to_self_delay,
+            forwarding_fee_base_msat: ldk_channel.forwarding_fee_base_msat,
+            forwarding_fee_proportional_millionths: ldk_channel
+                .forwarding_fee_proportional_millionths,
+            max_dust_htlc_exposure: DustExposure::from_ldk(ldk_channel.max_dust_htlc_exposure),
+            max_inbound_htlc_value_in_flight_percent: ldk_handshake
+                .max_inbound_htlc_value_in_flight_percent_of_channel,
+            our_max_accepted_htlcs: ldk_handshake.our_max_accepted_htlcs,
+            max_minimum_depth: ldk_limits.max_minimum_depth,
+        }
+    }
+}
+
+impl ChannelsSection {
+    /// Minimum capacity for an RGB channel, derived from the HTLC minimum so
+    /// the channel can always route at least ten minimum HTLCs.
+    pub(crate) fn open_rgb_min_sat(&self) -> u64 {
+        self.htlc_min_msat / 1000 * 10 + 10
+    }
+
+    /// LDK per-channel config with the configured forwarding values applied.
+    pub(crate) fn channel_config(&self) -> LdkChannelConfig {
+        LdkChannelConfig {
+            forwarding_fee_proportional_millionths: self.forwarding_fee_proportional_millionths,
+            forwarding_fee_base_msat: self.forwarding_fee_base_msat,
+            cltv_expiry_delta: self.cltv_expiry_delta,
+            max_dust_htlc_exposure: self.max_dust_htlc_exposure.to_ldk(),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PaymentsSection {
+    pub(crate) final_cltv_expiry_delta: u32,
+    pub(crate) retry_timeout_secs: u64,
+    pub(crate) max_swap_fee_msat: u64,
+}
+
+impl Default for PaymentsSection {
+    fn default() -> Self {
+        Self {
+            final_cltv_expiry_delta: DEFAULT_FINAL_CLTV_EXPIRY_DELTA,
+            retry_timeout_secs: DEFAULT_PAYMENT_RETRY_TIMEOUT_SECS,
+            max_swap_fee_msat: MAX_SWAP_FEE_MSAT,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct AuthSection {
+    pub(crate) password_min_length: u8,
+}
+
+impl Default for AuthSection {
+    fn default() -> Self {
+        Self {
+            password_min_length: DEFAULT_PASSWORD_MIN_LENGTH,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ApiSection {
+    pub(crate) default_page_size: u64,
+}
+
+impl Default for ApiSection {
+    fn default() -> Self {
+        Self {
+            default_page_size: DEFAULT_PAGE_SIZE,
+        }
+    }
+}
+
+fn invalid(msg: String) -> AppError {
+    AppError::InvalidConfig(msg)
+}
+
+impl Config {
+    /// Overlay the file values on the defaults and validate the result.
+    pub(crate) fn from_toml(toml: &TomlConfig) -> Result<Self, AppError> {
+        if let Some(channels) = &toml.channels {
+            if channels.max_dust_htlc_exposure_multiplier.is_some()
+                && channels.max_dust_htlc_exposure_fixed_msat.is_some()
+            {
+                return Err(invalid(
+                    "channels.max_dust_htlc_exposure_multiplier and \
+                     channels.max_dust_htlc_exposure_fixed_msat are mutually exclusive"
+                        .to_string(),
+                ));
+            }
+        }
+        let mut config = Config::default();
+        config.apply_toml(toml);
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn apply_toml(&mut self, toml: &TomlConfig) {
+        if let Some(node) = &toml.node {
+            if node.announce_alias.is_some() {
+                self.node.announce_alias = node.announce_alias.clone();
+            }
+            if let Some(addresses) = &node.announce_addresses {
+                self.node.announce_addresses = addresses.clone();
+            }
+            apply(
+                &mut self.node.peer_reconnect_interval_secs,
+                node.peer_reconnect_interval_secs,
+            );
+            apply(
+                &mut self.node.announce_initial_delay_secs,
+                node.announce_initial_delay_secs,
+            );
+            apply(
+                &mut self.node.announce_refresh_interval_secs,
+                node.announce_refresh_interval_secs,
+            );
+        }
+        if let Some(chain) = &toml.chain {
+            if chain.indexer_url.is_some() {
+                self.chain.indexer_url = chain.indexer_url.clone();
+            }
+            if chain.proxy_endpoint.is_some() {
+                self.chain.proxy_endpoint = chain.proxy_endpoint.clone();
+            }
+            apply(
+                &mut self.chain.indexer_timeout_secs,
+                chain.indexer_timeout_secs,
+            );
+            apply(
+                &mut self.chain.fee_refresh_interval_secs,
+                chain.fee_refresh_interval_secs,
+            );
+        }
+        if let Some(gossip) = &toml.gossip {
+            apply(
+                &mut self.gossip.rgs_sync_interval_secs,
+                gossip.rgs_sync_interval_secs,
+            );
+            apply(
+                &mut self.gossip.rgs_snapshot_max_size_mb,
+                gossip.rgs_snapshot_max_size_mb,
+            );
+            apply(
+                &mut self.gossip.rgs_connect_timeout_secs,
+                gossip.rgs_connect_timeout_secs,
+            );
+            apply(
+                &mut self.gossip.rgs_sync_timeout_secs,
+                gossip.rgs_sync_timeout_secs,
+            );
+        }
+        if let Some(vss) = &toml.vss {
+            apply(&mut self.vss.retry_backoff_ms, vss.retry_backoff_ms);
+            apply(&mut self.vss.retry_max_attempts, vss.retry_max_attempts);
+            apply(
+                &mut self.vss.retry_max_total_delay_secs,
+                vss.retry_max_total_delay_secs,
+            );
+        }
+        if let Some(lsp) = &toml.lsp {
+            apply(
+                &mut self.lsp.order_response_timeout_secs,
+                lsp.order_response_timeout_secs,
+            );
+            apply(&mut self.lsp.request_timeout_secs, lsp.request_timeout_secs);
+        }
+        if let Some(rgb) = &toml.rgb {
+            apply(&mut self.rgb.fee_rate_sat_vb, rgb.fee_rate_sat_vb);
+            apply(&mut self.rgb.utxo_size_sat, rgb.utxo_size_sat);
+            apply(&mut self.rgb.utxo_num, rgb.utxo_num);
+            apply(
+                &mut self.rgb.min_channel_confirmations,
+                rgb.min_channel_confirmations,
+            );
+        }
+        if let Some(channels) = &toml.channels {
+            apply(&mut self.channels.htlc_min_msat, channels.htlc_min_msat);
+            apply(
+                &mut self.channels.virtual_htlc_min_msat,
+                channels.virtual_htlc_min_msat,
+            );
+            apply(&mut self.channels.dust_limit_msat, channels.dust_limit_msat);
+            apply(&mut self.channels.open_min_sat, channels.open_min_sat);
+            apply(&mut self.channels.open_max_sat, channels.open_max_sat);
+            apply(
+                &mut self.channels.open_min_rgb_amount,
+                channels.open_min_rgb_amount,
+            );
+            apply(
+                &mut self.channels.their_to_self_delay,
+                channels.their_to_self_delay,
+            );
+            apply(
+                &mut self.channels.cltv_expiry_delta,
+                channels.cltv_expiry_delta,
+            );
+            apply(
+                &mut self.channels.our_to_self_delay,
+                channels.our_to_self_delay,
+            );
+            apply(
+                &mut self.channels.forwarding_fee_base_msat,
+                channels.forwarding_fee_base_msat,
+            );
+            apply(
+                &mut self.channels.forwarding_fee_proportional_millionths,
+                channels.forwarding_fee_proportional_millionths,
+            );
+            if let Some(multiplier) = channels.max_dust_htlc_exposure_multiplier {
+                self.channels.max_dust_htlc_exposure = DustExposure::FeeRateMultiplier(multiplier);
+            }
+            if let Some(fixed_msat) = channels.max_dust_htlc_exposure_fixed_msat {
+                self.channels.max_dust_htlc_exposure = DustExposure::FixedLimitMsat(fixed_msat);
+            }
+            apply(
+                &mut self.channels.max_inbound_htlc_value_in_flight_percent,
+                channels.max_inbound_htlc_value_in_flight_percent,
+            );
+            apply(
+                &mut self.channels.our_max_accepted_htlcs,
+                channels.our_max_accepted_htlcs,
+            );
+            apply(
+                &mut self.channels.max_minimum_depth,
+                channels.max_minimum_depth,
+            );
+        }
+        if let Some(payments) = &toml.payments {
+            apply(
+                &mut self.payments.final_cltv_expiry_delta,
+                payments.final_cltv_expiry_delta,
+            );
+            apply(
+                &mut self.payments.retry_timeout_secs,
+                payments.retry_timeout_secs,
+            );
+            apply(
+                &mut self.payments.max_swap_fee_msat,
+                payments.max_swap_fee_msat,
+            );
+        }
+        if let Some(auth) = &toml.auth {
+            apply(&mut self.auth.password_min_length, auth.password_min_length);
+        }
+        if let Some(api) = &toml.api {
+            apply(&mut self.api.default_page_size, api.default_page_size);
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), AppError> {
+        if let Some(alias) = &self.node.announce_alias {
+            if alias.len() > MAX_ALIAS_BYTES {
+                return Err(invalid(format!(
+                    "announce_alias cannot be longer than {MAX_ALIAS_BYTES} bytes"
+                )));
+            }
+        }
+        nonzero(self.rgb.fee_rate_sat_vb, "rgb.fee_rate_sat_vb")?;
+        nonzero(self.rgb.utxo_size_sat as u64, "rgb.utxo_size_sat")?;
+        nonzero(self.rgb.utxo_num as u64, "rgb.utxo_num")?;
+        nonzero(
+            self.rgb.min_channel_confirmations as u64,
+            "rgb.min_channel_confirmations",
+        )?;
+        nonzero(self.channels.htlc_min_msat, "channels.htlc_min_msat")?;
+        nonzero(
+            self.channels.virtual_htlc_min_msat,
+            "channels.virtual_htlc_min_msat",
+        )?;
+        nonzero(self.channels.dust_limit_msat, "channels.dust_limit_msat")?;
+        nonzero(self.channels.open_min_sat, "channels.open_min_sat")?;
+        nonzero(
+            self.channels.open_min_rgb_amount,
+            "channels.open_min_rgb_amount",
+        )?;
+        if self.channels.open_max_sat > MAX_CHANNEL_SAT {
+            return Err(invalid(format!(
+                "channels.open_max_sat cannot exceed the protocol limit of {MAX_CHANNEL_SAT} sats"
+            )));
+        }
+        if self.channels.open_min_sat > self.channels.open_max_sat {
+            return Err(invalid(format!(
+                "channels.open_min_sat ({}) cannot exceed channels.open_max_sat ({})",
+                self.channels.open_min_sat, self.channels.open_max_sat
+            )));
+        }
+        if self.channels.open_rgb_min_sat() > self.channels.open_max_sat {
+            return Err(invalid(format!(
+                "the RGB channel minimum derived from channels.htlc_min_msat ({} sats) \
+                 cannot exceed channels.open_max_sat ({})",
+                self.channels.open_rgb_min_sat(),
+                self.channels.open_max_sat
+            )));
+        }
+        if self.channels.their_to_self_delay == 0
+            || self.channels.their_to_self_delay > MAX_TO_SELF_DELAY
+        {
+            return Err(invalid(format!(
+                "channels.their_to_self_delay must be between 1 and {MAX_TO_SELF_DELAY}"
+            )));
+        }
+        if self.channels.cltv_expiry_delta < MIN_CLTV_EXPIRY_DELTA {
+            return Err(invalid(format!(
+                "channels.cltv_expiry_delta must be at least {MIN_CLTV_EXPIRY_DELTA}"
+            )));
+        }
+        if self.channels.our_to_self_delay < BREAKDOWN_TIMEOUT
+            || self.channels.our_to_self_delay > MAX_TO_SELF_DELAY
+        {
+            return Err(invalid(format!(
+                "channels.our_to_self_delay must be between {BREAKDOWN_TIMEOUT} and {MAX_TO_SELF_DELAY}"
+            )));
+        }
+        match self.channels.max_dust_htlc_exposure {
+            DustExposure::FeeRateMultiplier(0) => {
+                return Err(invalid(
+                    "channels.max_dust_htlc_exposure_multiplier must be greater than 0".to_string(),
+                ));
+            }
+            DustExposure::FixedLimitMsat(0) => {
+                return Err(invalid(
+                    "channels.max_dust_htlc_exposure_fixed_msat must be greater than 0".to_string(),
+                ));
+            }
+            _ => {}
+        }
+        if self.channels.max_inbound_htlc_value_in_flight_percent == 0
+            || self.channels.max_inbound_htlc_value_in_flight_percent > 100
+        {
+            return Err(invalid(
+                "channels.max_inbound_htlc_value_in_flight_percent must be between 1 and 100"
+                    .to_string(),
+            ));
+        }
+        if self.channels.our_max_accepted_htlcs == 0
+            || self.channels.our_max_accepted_htlcs > MAX_ACCEPTED_HTLCS_CAP
+        {
+            return Err(invalid(format!(
+                "channels.our_max_accepted_htlcs must be between 1 and {MAX_ACCEPTED_HTLCS_CAP}"
+            )));
+        }
+        nonzero(
+            self.channels.max_minimum_depth as u64,
+            "channels.max_minimum_depth",
+        )?;
+        nonzero(
+            self.payments.final_cltv_expiry_delta as u64,
+            "payments.final_cltv_expiry_delta",
+        )?;
+        nonzero(
+            self.payments.retry_timeout_secs,
+            "payments.retry_timeout_secs",
+        )?;
+        nonzero(
+            self.payments.max_swap_fee_msat,
+            "payments.max_swap_fee_msat",
+        )?;
+        nonzero(
+            self.auth.password_min_length as u64,
+            "auth.password_min_length",
+        )?;
+        nonzero(self.api.default_page_size, "api.default_page_size")?;
+        nonzero(
+            self.node.peer_reconnect_interval_secs,
+            "node.peer_reconnect_interval_secs",
+        )?;
+        nonzero(
+            self.node.announce_refresh_interval_secs,
+            "node.announce_refresh_interval_secs",
+        )?;
+        nonzero(
+            self.chain.indexer_timeout_secs,
+            "chain.indexer_timeout_secs",
+        )?;
+        nonzero(
+            self.chain.fee_refresh_interval_secs,
+            "chain.fee_refresh_interval_secs",
+        )?;
+        nonzero(
+            self.gossip.rgs_sync_interval_secs,
+            "gossip.rgs_sync_interval_secs",
+        )?;
+        nonzero(
+            self.gossip.rgs_snapshot_max_size_mb,
+            "gossip.rgs_snapshot_max_size_mb",
+        )?;
+        nonzero(
+            self.gossip.rgs_connect_timeout_secs,
+            "gossip.rgs_connect_timeout_secs",
+        )?;
+        nonzero(
+            self.gossip.rgs_sync_timeout_secs,
+            "gossip.rgs_sync_timeout_secs",
+        )?;
+        nonzero(self.vss.retry_backoff_ms, "vss.retry_backoff_ms")?;
+        nonzero(self.vss.retry_max_attempts as u64, "vss.retry_max_attempts")?;
+        nonzero(
+            self.vss.retry_max_total_delay_secs,
+            "vss.retry_max_total_delay_secs",
+        )?;
+        nonzero(
+            self.lsp.order_response_timeout_secs,
+            "lsp.order_response_timeout_secs",
+        )?;
+        nonzero(self.lsp.request_timeout_secs, "lsp.request_timeout_secs")?;
+        Ok(())
+    }
+}
+
+fn apply<T: Copy>(target: &mut T, value: Option<T>) {
+    if let Some(value) = value {
+        *target = value;
+    }
+}
+
+fn nonzero(value: u64, key: &str) -> Result<(), AppError> {
+    if value == 0 {
+        return Err(invalid(format!("{key} must be greater than 0")));
+    }
+    Ok(())
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,0 +1,537 @@
+use super::*;
+
+fn cfg(content: &str) -> Result<Config, AppError> {
+    Config::from_toml(&TomlConfig::parse(content)?)
+}
+
+fn err_msg(res: Result<Config, AppError>) -> String {
+    match res {
+        Err(AppError::InvalidConfig(m)) => m,
+        other => panic!("expected InvalidConfig, got {other:?}"),
+    }
+}
+
+#[test]
+fn defaults_match_hardcoded_values() {
+    let c = Config::default();
+    assert_eq!(c.rgb.fee_rate_sat_vb, 7);
+    assert_eq!(c.rgb.utxo_size_sat, 32000);
+    assert_eq!(c.rgb.utxo_num, 4);
+    assert_eq!(c.rgb.min_channel_confirmations, 6);
+    assert_eq!(c.channels.htlc_min_msat, 3_000_000);
+    assert_eq!(c.channels.virtual_htlc_min_msat, 1_000);
+    assert_eq!(c.channels.dust_limit_msat, 546_000);
+    assert_eq!(c.channels.open_min_sat, 5506);
+    assert_eq!(c.channels.open_max_sat, 16_777_215);
+    assert_eq!(c.channels.open_min_rgb_amount, 1);
+    assert_eq!(c.channels.their_to_self_delay, 2016);
+    assert_eq!(c.channels.open_rgb_min_sat(), 30_010);
+    assert_eq!(c.payments.final_cltv_expiry_delta, 14);
+    assert_eq!(c.payments.retry_timeout_secs, 10);
+    assert_eq!(c.payments.max_swap_fee_msat, 3_000_000);
+    assert_eq!(c.auth.password_min_length, 8);
+    assert_eq!(c.api.default_page_size, 100);
+    assert!(c.chain.indexer_url.is_none());
+    assert!(c.chain.proxy_endpoint.is_none());
+    assert!(c.node.announce_alias.is_none());
+    assert!(c.node.announce_addresses.is_empty());
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn empty_toml_keeps_defaults() {
+    assert_eq!(cfg("").unwrap(), Config::default());
+}
+
+#[test]
+fn partial_override_leaves_other_defaults() {
+    let c = cfg("[rgb]\nfee_rate_sat_vb = 12\n").unwrap();
+    assert_eq!(c.rgb.fee_rate_sat_vb, 12);
+    assert_eq!(c.rgb.utxo_size_sat, 32000);
+    assert_eq!(c.channels, Config::default().channels);
+}
+
+#[test]
+fn all_policy_sections_apply() {
+    let c = cfg(r#"
+[node]
+announce_alias = "rln-node"
+announce_addresses = ["1.2.3.4:9735"]
+
+[chain]
+indexer_url = "ssl://electrum.example.com:50002"
+proxy_endpoint = "rpcs://proxy.example.com/0.2/json-rpc"
+
+[rgb]
+fee_rate_sat_vb = 3
+utxo_size_sat = 64000
+utxo_num = 8
+min_channel_confirmations = 3
+
+[channels]
+htlc_min_msat = 2000000
+virtual_htlc_min_msat = 500
+dust_limit_msat = 600000
+open_min_sat = 10000
+open_max_sat = 1000000
+open_min_rgb_amount = 2
+their_to_self_delay = 1440
+
+[payments]
+final_cltv_expiry_delta = 18
+retry_timeout_secs = 30
+max_swap_fee_msat = 5000000
+
+[auth]
+password_min_length = 12
+
+[api]
+default_page_size = 50
+"#)
+    .unwrap();
+    assert_eq!(c.node.announce_alias.as_deref(), Some("rln-node"));
+    assert_eq!(c.node.announce_addresses, vec!["1.2.3.4:9735"]);
+    assert_eq!(
+        c.chain.indexer_url.as_deref(),
+        Some("ssl://electrum.example.com:50002")
+    );
+    assert_eq!(
+        c.chain.proxy_endpoint.as_deref(),
+        Some("rpcs://proxy.example.com/0.2/json-rpc")
+    );
+    assert_eq!(c.rgb.fee_rate_sat_vb, 3);
+    assert_eq!(c.rgb.utxo_size_sat, 64000);
+    assert_eq!(c.rgb.utxo_num, 8);
+    assert_eq!(c.rgb.min_channel_confirmations, 3);
+    assert_eq!(c.channels.htlc_min_msat, 2_000_000);
+    assert_eq!(c.channels.virtual_htlc_min_msat, 500);
+    assert_eq!(c.channels.dust_limit_msat, 600_000);
+    assert_eq!(c.channels.open_min_sat, 10_000);
+    assert_eq!(c.channels.open_max_sat, 1_000_000);
+    assert_eq!(c.channels.open_min_rgb_amount, 2);
+    assert_eq!(c.channels.their_to_self_delay, 1440);
+    assert_eq!(c.channels.open_rgb_min_sat(), 20_010);
+    assert_eq!(c.payments.final_cltv_expiry_delta, 18);
+    assert_eq!(c.payments.retry_timeout_secs, 30);
+    assert_eq!(c.payments.max_swap_fee_msat, 5_000_000);
+    assert_eq!(c.auth.password_min_length, 12);
+    assert_eq!(c.api.default_page_size, 50);
+}
+
+#[test]
+fn startup_sections_parse() {
+    let t = TomlConfig::parse(
+        r#"
+[node]
+network = "regtest"
+daemon_listening_port = 8888
+ldk_peer_listening_port = 9999
+reuse_addresses = true
+
+[auth]
+disable_authentication = true
+
+[channels]
+enable_virtual_channels_v0 = true
+virtual_peer_pubkeys = ["02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"]
+
+[lsp]
+base_url = "https://lsp.example.com"
+bearer_token = "token"
+
+[vss]
+url = "https://vss.example.com/vss"
+allow_http = true
+allow_empty_restore = true
+
+[api]
+max_media_upload_size_mb = 10
+"#,
+    )
+    .unwrap();
+    let node = t.node.unwrap();
+    assert_eq!(node.network.as_deref(), Some("regtest"));
+    assert_eq!(node.daemon_listening_port, Some(8888));
+    assert_eq!(node.ldk_peer_listening_port, Some(9999));
+    assert_eq!(node.reuse_addresses, Some(true));
+    let auth = t.auth.unwrap();
+    assert_eq!(auth.disable_authentication, Some(true));
+    let channels = t.channels.unwrap();
+    assert_eq!(channels.enable_virtual_channels_v0, Some(true));
+    assert_eq!(channels.virtual_peer_pubkeys.unwrap().len(), 1);
+    let lsp = t.lsp.unwrap();
+    assert_eq!(lsp.base_url.as_deref(), Some("https://lsp.example.com"));
+    assert_eq!(lsp.bearer_token.as_deref(), Some("token"));
+    let vss = t.vss.unwrap();
+    assert_eq!(vss.url.as_deref(), Some("https://vss.example.com/vss"));
+    assert_eq!(vss.allow_http, Some(true));
+    assert_eq!(vss.allow_empty_restore, Some(true));
+    let api = t.api.unwrap();
+    assert_eq!(api.max_media_upload_size_mb, Some(10));
+}
+
+#[test]
+fn unknown_section_rejected() {
+    let res = TomlConfig::parse("[bogus]\nkey = 1\n");
+    assert!(matches!(res, Err(AppError::InvalidConfig(ref m)) if m.contains("bogus")));
+}
+
+#[test]
+fn unknown_key_rejected() {
+    let res = TomlConfig::parse("[rgb]\nbogus_key = 1\n");
+    assert!(matches!(res, Err(AppError::InvalidConfig(ref m)) if m.contains("bogus_key")));
+}
+
+#[test]
+fn wrong_type_rejected() {
+    assert!(TomlConfig::parse("[rgb]\nfee_rate_sat_vb = \"high\"\n").is_err());
+}
+
+#[test]
+fn zero_fee_rate_rejected() {
+    let m = err_msg(cfg("[rgb]\nfee_rate_sat_vb = 0\n"));
+    assert!(m.contains("fee_rate_sat_vb"));
+}
+
+#[test]
+fn zero_utxo_size_rejected() {
+    let m = err_msg(cfg("[rgb]\nutxo_size_sat = 0\n"));
+    assert!(m.contains("utxo_size_sat"));
+}
+
+#[test]
+fn zero_utxo_num_rejected() {
+    let m = err_msg(cfg("[rgb]\nutxo_num = 0\n"));
+    assert!(m.contains("utxo_num"));
+}
+
+#[test]
+fn zero_min_channel_confirmations_rejected() {
+    let m = err_msg(cfg("[rgb]\nmin_channel_confirmations = 0\n"));
+    assert!(m.contains("min_channel_confirmations"));
+}
+
+#[test]
+fn zero_htlc_min_rejected() {
+    let m = err_msg(cfg("[channels]\nhtlc_min_msat = 0\n"));
+    assert!(m.contains("htlc_min_msat"));
+}
+
+#[test]
+fn zero_virtual_htlc_min_rejected() {
+    let m = err_msg(cfg("[channels]\nvirtual_htlc_min_msat = 0\n"));
+    assert!(m.contains("virtual_htlc_min_msat"));
+}
+
+#[test]
+fn zero_dust_limit_rejected() {
+    let m = err_msg(cfg("[channels]\ndust_limit_msat = 0\n"));
+    assert!(m.contains("dust_limit_msat"));
+}
+
+#[test]
+fn zero_open_min_rejected() {
+    let m = err_msg(cfg("[channels]\nopen_min_sat = 0\n"));
+    assert!(m.contains("open_min_sat"));
+}
+
+#[test]
+fn open_min_above_max_rejected() {
+    let m = err_msg(cfg(
+        "[channels]\nopen_min_sat = 20000\nopen_max_sat = 10000\n",
+    ));
+    assert!(m.contains("open_min_sat") && m.contains("open_max_sat"));
+}
+
+#[test]
+fn open_max_above_protocol_cap_rejected() {
+    let m = err_msg(cfg("[channels]\nopen_max_sat = 16777216\n"));
+    assert!(m.contains("open_max_sat"));
+}
+
+#[test]
+fn derived_rgb_min_above_max_rejected() {
+    // htlc_min_msat = 20_000_000_000 derives an RGB channel minimum of
+    // 200_000_010 sat, above the default open_max_sat
+    let m = err_msg(cfg("[channels]\nhtlc_min_msat = 20000000000\n"));
+    assert!(m.contains("open_max_sat"));
+}
+
+#[test]
+fn zero_open_min_rgb_amount_rejected() {
+    let m = err_msg(cfg("[channels]\nopen_min_rgb_amount = 0\n"));
+    assert!(m.contains("open_min_rgb_amount"));
+}
+
+#[test]
+fn zero_their_to_self_delay_rejected() {
+    let m = err_msg(cfg("[channels]\ntheir_to_self_delay = 0\n"));
+    assert!(m.contains("their_to_self_delay"));
+}
+
+#[test]
+fn their_to_self_delay_above_2016_rejected() {
+    let m = err_msg(cfg("[channels]\ntheir_to_self_delay = 2017\n"));
+    assert!(m.contains("their_to_self_delay"));
+}
+
+#[test]
+fn zero_final_cltv_rejected() {
+    let m = err_msg(cfg("[payments]\nfinal_cltv_expiry_delta = 0\n"));
+    assert!(m.contains("final_cltv_expiry_delta"));
+}
+
+#[test]
+fn zero_retry_timeout_rejected() {
+    let m = err_msg(cfg("[payments]\nretry_timeout_secs = 0\n"));
+    assert!(m.contains("retry_timeout_secs"));
+}
+
+#[test]
+fn zero_max_swap_fee_rejected() {
+    let m = err_msg(cfg("[payments]\nmax_swap_fee_msat = 0\n"));
+    assert!(m.contains("max_swap_fee_msat"));
+}
+
+#[test]
+fn zero_password_min_length_rejected() {
+    let m = err_msg(cfg("[auth]\npassword_min_length = 0\n"));
+    assert!(m.contains("password_min_length"));
+}
+
+#[test]
+fn zero_page_size_rejected() {
+    let m = err_msg(cfg("[api]\ndefault_page_size = 0\n"));
+    assert!(m.contains("default_page_size"));
+}
+
+#[test]
+fn announce_alias_over_32_bytes_rejected() {
+    let m = err_msg(cfg(
+        "[node]\nannounce_alias = \"123456789012345678901234567890123\"\n",
+    ));
+    assert!(m.contains("announce_alias"));
+}
+
+#[test]
+fn load_missing_file_errors() {
+    assert!(matches!(
+        load_config_file(std::path::Path::new("/nonexistent/config.toml")),
+        Err(AppError::InvalidConfig(_))
+    ));
+}
+
+#[test]
+fn timing_defaults_match_hardcoded_values() {
+    let c = Config::default();
+    assert_eq!(c.chain.indexer_timeout_secs, 10);
+    assert_eq!(c.chain.fee_refresh_interval_secs, 60);
+    assert_eq!(c.gossip.rgs_sync_interval_secs, 3600);
+    assert_eq!(c.gossip.rgs_snapshot_max_size_mb, 15);
+    assert_eq!(c.gossip.rgs_connect_timeout_secs, 5);
+    assert_eq!(c.gossip.rgs_sync_timeout_secs, 60);
+    assert_eq!(c.node.peer_reconnect_interval_secs, 1);
+    assert_eq!(c.node.announce_initial_delay_secs, 60);
+    assert_eq!(c.node.announce_refresh_interval_secs, 3600);
+    assert_eq!(c.vss.retry_backoff_ms, 100);
+    assert_eq!(c.vss.retry_max_attempts, 3);
+    assert_eq!(c.vss.retry_max_total_delay_secs, 5);
+    assert_eq!(c.lsp.order_response_timeout_secs, 30);
+    assert_eq!(c.lsp.request_timeout_secs, 25);
+}
+
+#[test]
+fn timing_sections_apply() {
+    let c = cfg(r#"
+[node]
+peer_reconnect_interval_secs = 2
+announce_initial_delay_secs = 30
+announce_refresh_interval_secs = 1800
+
+[chain]
+indexer_timeout_secs = 20
+fee_refresh_interval_secs = 120
+
+[gossip]
+rgs_sync_interval_secs = 7200
+rgs_snapshot_max_size_mb = 30
+rgs_connect_timeout_secs = 10
+rgs_sync_timeout_secs = 90
+
+[vss]
+retry_backoff_ms = 200
+retry_max_attempts = 5
+retry_max_total_delay_secs = 10
+
+[lsp]
+order_response_timeout_secs = 60
+request_timeout_secs = 50
+"#)
+    .unwrap();
+    assert_eq!(c.node.peer_reconnect_interval_secs, 2);
+    assert_eq!(c.node.announce_initial_delay_secs, 30);
+    assert_eq!(c.node.announce_refresh_interval_secs, 1800);
+    assert_eq!(c.chain.indexer_timeout_secs, 20);
+    assert_eq!(c.chain.fee_refresh_interval_secs, 120);
+    assert_eq!(c.gossip.rgs_sync_interval_secs, 7200);
+    assert_eq!(c.gossip.rgs_snapshot_max_size_mb, 30);
+    assert_eq!(c.gossip.rgs_connect_timeout_secs, 10);
+    assert_eq!(c.gossip.rgs_sync_timeout_secs, 90);
+    assert_eq!(c.vss.retry_backoff_ms, 200);
+    assert_eq!(c.vss.retry_max_attempts, 5);
+    assert_eq!(c.vss.retry_max_total_delay_secs, 10);
+    assert_eq!(c.lsp.order_response_timeout_secs, 60);
+    assert_eq!(c.lsp.request_timeout_secs, 50);
+}
+
+#[test]
+fn zero_timing_values_rejected() {
+    for (section, key) in [
+        ("node", "peer_reconnect_interval_secs"),
+        ("node", "announce_refresh_interval_secs"),
+        ("chain", "indexer_timeout_secs"),
+        ("chain", "fee_refresh_interval_secs"),
+        ("gossip", "rgs_sync_interval_secs"),
+        ("gossip", "rgs_snapshot_max_size_mb"),
+        ("gossip", "rgs_connect_timeout_secs"),
+        ("gossip", "rgs_sync_timeout_secs"),
+        ("vss", "retry_backoff_ms"),
+        ("vss", "retry_max_attempts"),
+        ("vss", "retry_max_total_delay_secs"),
+        ("lsp", "order_response_timeout_secs"),
+        ("lsp", "request_timeout_secs"),
+    ] {
+        let m = err_msg(cfg(&format!("[{section}]\n{key} = 0\n")));
+        assert!(m.contains(key), "expected error naming {key}, got: {m}");
+    }
+}
+
+#[test]
+fn zero_announce_initial_delay_allowed() {
+    let c = cfg("[node]\nannounce_initial_delay_secs = 0\n").unwrap();
+    assert_eq!(c.node.announce_initial_delay_secs, 0);
+}
+
+#[test]
+fn ldk_channel_defaults_match_upstream() {
+    let c = Config::default();
+    assert_eq!(c.channels.cltv_expiry_delta, 72);
+    assert_eq!(c.channels.our_to_self_delay, 144);
+    assert_eq!(c.channels.forwarding_fee_base_msat, 1000);
+    assert_eq!(c.channels.forwarding_fee_proportional_millionths, 0);
+    assert_eq!(
+        c.channels.max_dust_htlc_exposure,
+        DustExposure::FeeRateMultiplier(10000)
+    );
+    assert_eq!(c.channels.max_inbound_htlc_value_in_flight_percent, 10);
+    assert_eq!(c.channels.our_max_accepted_htlcs, 50);
+    assert_eq!(c.channels.max_minimum_depth, 144);
+    // the resolved defaults must be exactly LDK's ChannelConfig defaults
+    assert_eq!(
+        c.channels.channel_config(),
+        lightning::util::config::ChannelConfig::default()
+    );
+}
+
+#[test]
+fn ldk_channel_overrides_apply() {
+    let c = cfg(r#"
+[channels]
+cltv_expiry_delta = 80
+our_to_self_delay = 288
+forwarding_fee_base_msat = 0
+forwarding_fee_proportional_millionths = 100
+max_dust_htlc_exposure_fixed_msat = 5000000
+max_inbound_htlc_value_in_flight_percent = 25
+our_max_accepted_htlcs = 100
+max_minimum_depth = 6
+"#)
+    .unwrap();
+    assert_eq!(c.channels.cltv_expiry_delta, 80);
+    assert_eq!(c.channels.our_to_self_delay, 288);
+    assert_eq!(c.channels.forwarding_fee_base_msat, 0);
+    assert_eq!(c.channels.forwarding_fee_proportional_millionths, 100);
+    assert_eq!(
+        c.channels.max_dust_htlc_exposure,
+        DustExposure::FixedLimitMsat(5_000_000)
+    );
+    assert_eq!(c.channels.max_inbound_htlc_value_in_flight_percent, 25);
+    assert_eq!(c.channels.our_max_accepted_htlcs, 100);
+    assert_eq!(c.channels.max_minimum_depth, 6);
+    let ldk = c.channels.channel_config();
+    assert_eq!(ldk.cltv_expiry_delta, 80);
+    assert_eq!(ldk.forwarding_fee_base_msat, 0);
+    assert_eq!(ldk.forwarding_fee_proportional_millionths, 100);
+}
+
+#[test]
+fn dust_exposure_multiplier_key_applies() {
+    let c = cfg("[channels]\nmax_dust_htlc_exposure_multiplier = 20000\n").unwrap();
+    assert_eq!(
+        c.channels.max_dust_htlc_exposure,
+        DustExposure::FeeRateMultiplier(20000)
+    );
+}
+
+#[test]
+fn dust_exposure_keys_mutually_exclusive() {
+    let m = err_msg(cfg(
+        "[channels]\nmax_dust_htlc_exposure_multiplier = 20000\nmax_dust_htlc_exposure_fixed_msat = 5000000\n",
+    ));
+    assert!(m.contains("max_dust_htlc_exposure"));
+}
+
+#[test]
+fn zero_dust_exposure_rejected() {
+    for key in [
+        "max_dust_htlc_exposure_multiplier",
+        "max_dust_htlc_exposure_fixed_msat",
+    ] {
+        let m = err_msg(cfg(&format!("[channels]\n{key} = 0\n")));
+        assert!(m.contains(key), "expected error naming {key}, got: {m}");
+    }
+}
+
+#[test]
+fn cltv_expiry_delta_below_ldk_minimum_rejected() {
+    let m = err_msg(cfg("[channels]\ncltv_expiry_delta = 47\n"));
+    assert!(m.contains("cltv_expiry_delta"));
+    assert!(cfg("[channels]\ncltv_expiry_delta = 48\n").is_ok());
+}
+
+#[test]
+fn our_to_self_delay_out_of_bounds_rejected() {
+    let m = err_msg(cfg("[channels]\nour_to_self_delay = 143\n"));
+    assert!(m.contains("our_to_self_delay"));
+    let m = err_msg(cfg("[channels]\nour_to_self_delay = 2017\n"));
+    assert!(m.contains("our_to_self_delay"));
+    assert!(cfg("[channels]\nour_to_self_delay = 2016\n").is_ok());
+}
+
+#[test]
+fn max_inbound_htlc_percent_out_of_bounds_rejected() {
+    let m = err_msg(cfg(
+        "[channels]\nmax_inbound_htlc_value_in_flight_percent = 0\n",
+    ));
+    assert!(m.contains("max_inbound_htlc_value_in_flight_percent"));
+    let m = err_msg(cfg(
+        "[channels]\nmax_inbound_htlc_value_in_flight_percent = 101\n",
+    ));
+    assert!(m.contains("max_inbound_htlc_value_in_flight_percent"));
+    assert!(cfg("[channels]\nmax_inbound_htlc_value_in_flight_percent = 100\n").is_ok());
+}
+
+#[test]
+fn our_max_accepted_htlcs_out_of_bounds_rejected() {
+    let m = err_msg(cfg("[channels]\nour_max_accepted_htlcs = 0\n"));
+    assert!(m.contains("our_max_accepted_htlcs"));
+    let m = err_msg(cfg("[channels]\nour_max_accepted_htlcs = 484\n"));
+    assert!(m.contains("our_max_accepted_htlcs"));
+    assert!(cfg("[channels]\nour_max_accepted_htlcs = 483\n").is_ok());
+}
+
+#[test]
+fn zero_max_minimum_depth_rejected() {
+    let m = err_msg(cfg("[channels]\nmax_minimum_depth = 0\n"));
+    assert!(m.contains("max_minimum_depth"));
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -15,9 +15,9 @@ fn err_msg(res: Result<Config, AppError>) -> String {
 fn defaults_match_hardcoded_values() {
     let c = Config::default();
     assert_eq!(c.rgb.fee_rate_sat_vb, 7);
-    assert_eq!(c.rgb.utxo_size_sat, 32000);
+    assert_eq!(c.rgb.utxo_size_sat, 20000);
     assert_eq!(c.rgb.utxo_num, 4);
-    assert_eq!(c.rgb.min_channel_confirmations, 6);
+    assert_eq!(c.rgb.min_channel_confirmations, 3);
     assert_eq!(c.channels.htlc_min_msat, 3_000_000);
     assert_eq!(c.channels.virtual_htlc_min_msat, 1_000);
     assert_eq!(c.channels.dust_limit_msat, 546_000);
@@ -47,7 +47,7 @@ fn empty_toml_keeps_defaults() {
 fn partial_override_leaves_other_defaults() {
     let c = cfg("[rgb]\nfee_rate_sat_vb = 12\n").unwrap();
     assert_eq!(c.rgb.fee_rate_sat_vb, 12);
-    assert_eq!(c.rgb.utxo_size_sat, 32000);
+    assert_eq!(c.rgb.utxo_size_sat, 20000);
     assert_eq!(c.channels, Config::default().channels);
 }
 

--- a/src/core_types.rs
+++ b/src/core_types.rs
@@ -4,12 +4,15 @@ use rgb_lib::bdk_wallet::keys::bip39::Mnemonic;
 use serde::{Deserialize, Serialize};
 
 pub(crate) const FEE_RATE: u64 = 7;
-pub(crate) const UTXO_SIZE_SAT: u32 = 32000;
-pub(crate) const MIN_CHANNEL_CONFIRMATIONS: u8 = 6;
+// matches lnd's MinChanFundingSize
+pub(crate) const UTXO_SIZE_SAT: u32 = 20000;
+pub(crate) const MIN_CHANNEL_CONFIRMATIONS: u8 = 3;
 pub(crate) const DUST_LIMIT_MSAT: u64 = 546000;
+// must clear the commitment dust limit plus HTLC-tx fees: RGB assets ride the
+// HTLC output, so a dust-trimmed HTLC cannot settle an asset payment
 pub(crate) const HTLC_MIN_MSAT: u64 = 3_000_000;
 pub(crate) const VIRTUAL_HTLC_MIN_MSAT: u64 = 1_000;
-pub(crate) const MAX_SWAP_FEE_MSAT: u64 = HTLC_MIN_MSAT;
+pub(crate) const MAX_SWAP_FEE_MSAT: u64 = 3_000_000;
 pub(crate) const DEFAULT_FINAL_CLTV_EXPIRY_DELTA: u32 = 14;
 
 pub mod async_order {

--- a/src/error.rs
+++ b/src/error.rs
@@ -673,6 +673,9 @@ pub enum AppError {
     #[error("Invalid VSS configuration: {0}")]
     InvalidVssConfig(String),
 
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(String),
+
     #[error("IO error: {0}")]
     IO(#[from] std::io::Error),
 

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -9,10 +9,27 @@ use tokio::sync::Notify;
 use crate::disk::FilesystemLogger;
 use crate::ldk::{GossipVerifier, NetworkGraph, P2PGossipSync, RapidGossipSync};
 
-pub(crate) const RGS_SYNC_INTERVAL: Duration = Duration::from_secs(60 * 60);
 pub(crate) const RGS_SNAPSHOT_MAX_SIZE: usize = 15 * 1024 * 1024;
 pub(crate) const RGS_CONNECT_TIMEOUT_SECS: u64 = 5;
 pub(crate) const RGS_SYNC_TIMEOUT_SECS: u64 = 60;
+
+/// RGS network tuning, sourced from the config file.
+#[derive(Clone, Debug)]
+pub(crate) struct RgsTuning {
+    pub(crate) connect_timeout_secs: u64,
+    pub(crate) sync_timeout_secs: u64,
+    pub(crate) snapshot_max_size: usize,
+}
+
+impl Default for RgsTuning {
+    fn default() -> Self {
+        Self {
+            connect_timeout_secs: RGS_CONNECT_TIMEOUT_SECS,
+            sync_timeout_secs: RGS_SYNC_TIMEOUT_SECS,
+            snapshot_max_size: RGS_SNAPSHOT_MAX_SIZE,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -32,6 +49,7 @@ pub(crate) enum GossipSource {
         gossip_sync: Arc<RapidGossipSync>,
         server_url: String,
         latest_sync_timestamp: AtomicU32,
+        tuning: RgsTuning,
     },
 }
 
@@ -50,12 +68,14 @@ impl GossipSource {
         latest_sync_timestamp: u32,
         network_graph: Arc<NetworkGraph>,
         logger: Arc<FilesystemLogger>,
+        tuning: RgsTuning,
     ) -> Self {
         let gossip_sync = Arc::new(RapidGossipSync::new(network_graph, logger));
         Self::RapidGossipSync {
             gossip_sync,
             server_url,
             latest_sync_timestamp: AtomicU32::new(latest_sync_timestamp),
+            tuning,
         }
     }
 
@@ -72,15 +92,17 @@ impl GossipSource {
     }
 
     pub(crate) async fn update_rgs_snapshot(&self) -> Result<u32, crate::error::APIError> {
-        let (gossip_sync, server_url, latest_sync_timestamp) = match self {
+        let (gossip_sync, server_url, latest_sync_timestamp, tuning) = match self {
             Self::P2PNetwork { .. } => return Ok(0),
             Self::RapidGossipSync {
                 gossip_sync,
                 server_url,
                 latest_sync_timestamp,
+                tuning,
                 ..
-            } => (gossip_sync, server_url, latest_sync_timestamp),
+            } => (gossip_sync, server_url, latest_sync_timestamp, tuning),
         };
+        let snapshot_max_size = tuning.snapshot_max_size;
 
         let ts = latest_sync_timestamp.load(Ordering::Acquire);
         let url = snapshot_url(server_url, ts)?;
@@ -88,8 +110,8 @@ impl GossipSource {
         // Fail fast on unreachable servers but allow a 15 MiB body to land
         // on slow links — the two timeouts have different jobs.
         let client = reqwest::Client::builder()
-            .connect_timeout(Duration::from_secs(RGS_CONNECT_TIMEOUT_SECS))
-            .timeout(Duration::from_secs(RGS_SYNC_TIMEOUT_SECS))
+            .connect_timeout(Duration::from_secs(tuning.connect_timeout_secs))
+            .timeout(Duration::from_secs(tuning.sync_timeout_secs))
             .build()
             .map_err(|e| crate::error::APIError::GossipUpdateFailed(e.to_string()))?;
 
@@ -113,7 +135,7 @@ impl GossipSource {
         // then enforce the same cap per-chunk for responses without a
         // Content-Length (or with a truthful one that exceeds the cap).
         if let Some(advertised) = response.content_length() {
-            if advertised > RGS_SNAPSHOT_MAX_SIZE as u64 {
+            if advertised > snapshot_max_size as u64 {
                 return Err(crate::error::APIError::GossipUpdateFailed(format!(
                     "snapshot too large: {advertised} bytes"
                 )));
@@ -122,7 +144,7 @@ impl GossipSource {
 
         let cap_hint = response
             .content_length()
-            .map(|n| (n as usize).min(RGS_SNAPSHOT_MAX_SIZE))
+            .map(|n| (n as usize).min(snapshot_max_size))
             .unwrap_or(0);
         let mut buf: Vec<u8> = Vec::with_capacity(cap_hint);
         let mut response = response;
@@ -133,7 +155,7 @@ impl GossipSource {
                 crate::error::APIError::GossipUpdateFailed(e.to_string())
             }
         })? {
-            if buf.len() + chunk.len() > RGS_SNAPSHOT_MAX_SIZE {
+            if buf.len() + chunk.len() > snapshot_max_size {
                 return Err(crate::error::APIError::GossipUpdateFailed(format!(
                     "snapshot too large: {} bytes",
                     buf.len() + chunk.len()
@@ -302,7 +324,13 @@ mod source_tests {
 
         let logger = test_logger();
         let graph = test_graph(Arc::clone(&logger));
-        let source = GossipSource::new_rgs(format!("http://{addr}/snapshot"), 0, graph, logger);
+        let source = GossipSource::new_rgs(
+            format!("http://{addr}/snapshot"),
+            0,
+            graph,
+            logger,
+            RgsTuning::default(),
+        );
         match source.update_rgs_snapshot().await {
             Err(crate::error::APIError::GossipUpdateFailed(_)) => {}
             other => panic!("expected GossipUpdateFailed, got {other:?}"),
@@ -339,7 +367,13 @@ mod source_tests {
 
         let logger = test_logger();
         let graph = test_graph(Arc::clone(&logger));
-        let source = GossipSource::new_rgs(format!("http://{addr}/snapshot"), 0, graph, logger);
+        let source = GossipSource::new_rgs(
+            format!("http://{addr}/snapshot"),
+            0,
+            graph,
+            logger,
+            RgsTuning::default(),
+        );
 
         let started = Instant::now();
         let result = source.update_rgs_snapshot().await;
@@ -402,7 +436,13 @@ mod source_tests {
 
         let logger = test_logger();
         let graph = test_graph(Arc::clone(&logger));
-        let source = GossipSource::new_rgs(format!("http://{addr}/snapshot"), 0, graph, logger);
+        let source = GossipSource::new_rgs(
+            format!("http://{addr}/snapshot"),
+            0,
+            graph,
+            logger,
+            RgsTuning::default(),
+        );
 
         let result = source.update_rgs_snapshot().await;
         let _ = server.await;
@@ -435,6 +475,7 @@ mod source_tests {
             0,
             graph,
             logger,
+            RgsTuning::default(),
         ));
         let shutdown = Arc::new(Notify::new());
         shutdown.notify_one();
@@ -482,7 +523,13 @@ mod source_tests {
 
         let logger = test_logger();
         let graph = test_graph(Arc::clone(&logger));
-        let source = GossipSource::new_rgs(format!("http://{addr}/snapshot"), 0, graph, logger);
+        let source = GossipSource::new_rgs(
+            format!("http://{addr}/snapshot"),
+            0,
+            graph,
+            logger,
+            RgsTuning::default(),
+        );
 
         let result = source.update_rgs_snapshot().await;
         let _ = server.await;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -154,9 +154,11 @@ fn poll_esplora_fee_estimates(
                         .store(background_estimate, Ordering::Release);
                 }
                 Ok(Err(e)) => {
-                    log_warn!(logger, "Error getting fee estimate from esplora: {}", e)
+                    log_warn!(logger, "Error getting fee estimate from esplora: {}", e);
                 }
-                Err(e) => log_warn!(logger, "Error polling esplora fee estimates: {}", e),
+                Err(e) => {
+                    log_warn!(logger, "Error polling esplora fee estimates: {}", e);
+                }
             }
 
             tokio::time::sleep(Duration::from_secs(refresh_interval_secs)).await;
@@ -226,8 +228,12 @@ impl BroadcasterInterface for EsploraIndexerClient {
             .await;
             match res {
                 Ok(Ok(())) => {}
-                Ok(Err(e)) => log_warn!(logger, "esplora broadcast failed: {}", e),
-                Err(e) => log_warn!(logger, "esplora broadcast task spawn failed: {}", e),
+                Ok(Err(e)) => {
+                    log_warn!(logger, "esplora broadcast failed: {}", e);
+                }
+                Err(e) => {
+                    log_warn!(logger, "esplora broadcast task spawn failed: {}", e);
+                }
             }
         });
     }
@@ -355,8 +361,12 @@ impl BroadcasterInterface for ElectrumIndexerClient {
             .await;
             match res {
                 Ok(Ok(())) => {}
-                Ok(Err(e)) => log_warn!(logger, "electrum broadcast failed: {}", e),
-                Err(e) => log_warn!(logger, "electrum broadcast task spawn failed: {}", e),
+                Ok(Err(e)) => {
+                    log_warn!(logger, "electrum broadcast failed: {}", e);
+                }
+                Err(e) => {
+                    log_warn!(logger, "electrum broadcast task spawn failed: {}", e);
+                }
             }
         });
     }
@@ -443,8 +453,12 @@ fn poll_electrum_fee_estimates(
                         .unwrap()
                         .store(bg_e, Ordering::Release);
                 }
-                Ok(Err(e)) => log_warn!(logger, "Error getting fee estimate from electrum: {}", e),
-                Err(e) => log_warn!(logger, "Error polling electrum fee estimates: {}", e),
+                Ok(Err(e)) => {
+                    log_warn!(logger, "Error getting fee estimate from electrum: {}", e);
+                }
+                Err(e) => {
+                    log_warn!(logger, "Error polling electrum fee estimates: {}", e);
+                }
             }
             tokio::time::sleep(Duration::from_secs(refresh_interval_secs)).await;
         }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -71,11 +71,13 @@ impl EsploraIndexerClient {
         network: Network,
         handle: tokio::runtime::Handle,
         logger: Arc<FilesystemLogger>,
+        timeout_secs: u64,
+        fee_refresh_interval_secs: u64,
     ) -> io::Result<Self> {
         // Bounded socket timeout so a hung endpoint doesn't block runtime shutdown.
         let client = Arc::new(
             EsploraBuilder::new(&server_url)
-                .timeout(10)
+                .timeout(timeout_secs)
                 .build_blocking(),
         );
         client
@@ -85,7 +87,13 @@ impl EsploraIndexerClient {
             .get_height()
             .map_err(|e| io::Error::other(format!("failed to query esplora tip height: {e}")))?;
         let fees = Arc::new(default_fee_buckets());
-        poll_esplora_fee_estimates(fees.clone(), client.clone(), logger.clone(), handle.clone());
+        poll_esplora_fee_estimates(
+            fees.clone(),
+            client.clone(),
+            logger.clone(),
+            handle.clone(),
+            fee_refresh_interval_secs,
+        );
         Ok(Self {
             client,
             fees,
@@ -101,6 +109,7 @@ fn poll_esplora_fee_estimates(
     client: Arc<EsploraBlockingClient>,
     logger: Arc<FilesystemLogger>,
     handle: tokio::runtime::Handle,
+    refresh_interval_secs: u64,
 ) {
     handle.spawn(async move {
         loop {
@@ -150,7 +159,7 @@ fn poll_esplora_fee_estimates(
                 Err(e) => log_warn!(logger, "Error polling esplora fee estimates: {}", e),
             }
 
-            tokio::time::sleep(Duration::from_secs(60)).await;
+            tokio::time::sleep(Duration::from_secs(refresh_interval_secs)).await;
         }
     });
 }
@@ -271,6 +280,7 @@ impl ElectrumIndexerClient {
         network: Network,
         handle: tokio::runtime::Handle,
         logger: Arc<FilesystemLogger>,
+        fee_refresh_interval_secs: u64,
     ) -> io::Result<Self> {
         let client =
             Arc::new(ElectrumClient::new(&server_url).map_err(|e| {
@@ -280,7 +290,13 @@ impl ElectrumIndexerClient {
             io::Error::other(format!("failed to query electrum server features: {e}"))
         })?;
         let fees = Arc::new(default_fee_buckets());
-        poll_electrum_fee_estimates(fees.clone(), client.clone(), logger.clone(), handle.clone());
+        poll_electrum_fee_estimates(
+            fees.clone(),
+            client.clone(),
+            logger.clone(),
+            handle.clone(),
+            fee_refresh_interval_secs,
+        );
         Ok(Self {
             client,
             fees,
@@ -380,6 +396,7 @@ fn poll_electrum_fee_estimates(
     client: Arc<ElectrumClient>,
     logger: Arc<FilesystemLogger>,
     handle: tokio::runtime::Handle,
+    refresh_interval_secs: u64,
 ) {
     handle.spawn(async move {
         loop {
@@ -429,7 +446,7 @@ fn poll_electrum_fee_estimates(
                 Ok(Err(e)) => log_warn!(logger, "Error getting fee estimate from electrum: {}", e),
                 Err(e) => log_warn!(logger, "Error polling electrum fee estimates: {}", e),
             }
-            tokio::time::sleep(Duration::from_secs(60)).await;
+            tokio::time::sleep(Duration::from_secs(refresh_interval_secs)).await;
         }
     });
 }

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -117,10 +117,7 @@ use tokio::task::JoinHandle;
 use crate::async_kv_store::RemoteFirstKvStore;
 use crate::bitcoind::BitcoindClient;
 use crate::chain_backend::ChainBackend;
-use crate::core_types::{
-    HTLCStatus, NodeKeySource, SwapStatus, UnlockRequest, DUST_LIMIT_MSAT, FEE_RATE, HTLC_MIN_MSAT,
-    MIN_CHANNEL_CONFIRMATIONS, VIRTUAL_HTLC_MIN_MSAT,
-};
+use crate::core_types::{HTLCStatus, NodeKeySource, SwapStatus, UnlockRequest};
 use crate::database::RlnDatabase;
 use crate::disk::{self, FilesystemLogger};
 use crate::gossip::{GossipSource, GossipSourceConfig};
@@ -1187,6 +1184,7 @@ impl AsyncOrderAccessControl for LiveChannelAccess {
 }
 
 struct AsyncOrderRecipientInvoiceProvider {
+    config: Arc<crate::config::Config>,
     channel_manager: Arc<ChannelManager>,
     inbound_payments: Arc<Mutex<InboundPaymentInfoStorage>>,
     async_payments_preimage_root: Arc<AsyncPaymentsPreimageRoot>,
@@ -1219,9 +1217,9 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
         let htlc_min_msat = if self.channel_manager.list_channels().iter().any(|channel| {
             channel.counterparty.node_id == sender_node_id && channel.trusted_no_broadcast
         }) {
-            VIRTUAL_HTLC_MIN_MSAT
+            self.config.channels.virtual_htlc_min_msat
         } else {
-            HTLC_MIN_MSAT
+            self.config.channels.htlc_min_msat
         };
         if amount_msat < htlc_min_msat {
             return Err(JsonRpcErrorWire::invalid_params(format!(
@@ -1774,10 +1772,19 @@ async fn handle_ldk_events(
                             assignment,
                             transport_endpoints: vec![unlocked_state.proxy_endpoint.clone()]
                     }]};
+                    let fee_rate_sat_vb = unlocked_state.config.rgb.fee_rate_sat_vb;
                     let unlocked_state_copy = unlocked_state.clone();
                     let res = tokio::task::spawn_blocking(move || -> Result<String, String> {
                         let res = unlocked_state_copy
-                            .rgb_send_begin(recipient_map, true, FEE_RATE, 0, None, false, Some(0))
+                            .rgb_send_begin(
+                                recipient_map,
+                                true,
+                                fee_rate_sat_vb,
+                                0,
+                                None,
+                                false,
+                                Some(0),
+                            )
                             .map_err(|e| e.to_string())?;
                         let fascia_str = fs::read_to_string(&res.details.fascia_path)
                             .map_err(|e| e.to_string())?;
@@ -1981,14 +1988,16 @@ async fn handle_ldk_events(
                         transport_endpoints: vec![unlocked_state.proxy_endpoint.clone()]
                 }]};
 
+                let fee_rate_sat_vb = unlocked_state.config.rgb.fee_rate_sat_vb;
+                let min_channel_confirmations = unlocked_state.config.rgb.min_channel_confirmations;
                 let unlocked_state_copy = unlocked_state.clone();
                 let res = tokio::task::spawn_blocking(
                     move || -> Result<(String, Option<i32>), RgbLibError> {
                         let res = unlocked_state_copy.rgb_send_begin(
                             recipient_map,
                             true,
-                            FEE_RATE,
-                            MIN_CHANNEL_CONFIRMATIONS,
+                            fee_rate_sat_vb,
+                            min_channel_confirmations,
                             None,
                             false,
                             // Final locktime: this colored tx funds an LN channel.
@@ -2043,7 +2052,7 @@ async fn handle_ldk_events(
                 let raw_psbt = match unlocked_state.rgb_send_btc_begin(
                     addr.to_address(),
                     channel_value_satoshis,
-                    FEE_RATE,
+                    unlocked_state.config.rgb.fee_rate_sat_vb,
                 ) {
                     Ok(psbt) => psbt,
                     Err(e) => {
@@ -3274,7 +3283,9 @@ impl OutputSpender for RgbOutputSpender {
                     .unwrap()
                     .unwrap();
                 txouts.push(TxOut {
-                    value: Amount::from_sat(DUST_LIMIT_MSAT / 1000),
+                    value: Amount::from_sat(
+                        self.static_state.config.channels.dust_limit_msat / 1000,
+                    ),
                     script_pubkey,
                 });
                 receive_data.recipient_id
@@ -3305,7 +3316,7 @@ impl OutputSpender for RgbOutputSpender {
             );
         }
 
-        let feerate_sat_per_1000_weight = FEE_RATE as u32 * 250; // 1 sat/vB = 250 sat/kw
+        let feerate_sat_per_1000_weight = self.static_state.config.rgb.fee_rate_sat_vb as u32 * 250; // 1 sat/vB = 250 sat/kw
         let (psbt, _expected_max_weight) =
             SpendableOutputDescriptor::create_spendable_outputs_psbt(
                 secp_ctx,
@@ -3764,10 +3775,25 @@ fn supported_asset_schemas(bitcoin_network: BitcoinNetwork) -> Vec<AssetSchema> 
 pub(crate) async fn start_ldk(
     app_state: Arc<AppState>,
     key_source: NodeKeySource,
-    unlock_request: UnlockRequest,
+    mut unlock_request: UnlockRequest,
 ) -> Result<(LdkBackgroundServices, Arc<UnlockedAppState>), APIError> {
     let gossip_source_config = unlock_request.gossip_source.clone().unwrap_or_default();
     let static_state = &app_state.static_state;
+
+    // Unlock request params take precedence, the config file provides defaults.
+    let file_config = &static_state.config;
+    unlock_request.indexer_url = unlock_request
+        .indexer_url
+        .or_else(|| file_config.chain.indexer_url.clone());
+    unlock_request.proxy_endpoint = unlock_request
+        .proxy_endpoint
+        .or_else(|| file_config.chain.proxy_endpoint.clone());
+    unlock_request.announce_alias = unlock_request
+        .announce_alias
+        .or_else(|| file_config.node.announce_alias.clone());
+    if unlock_request.announce_addresses.is_empty() {
+        unlock_request.announce_addresses = file_config.node.announce_addresses.clone();
+    }
     let (
         internal_mnemonic,
         external_signer_mode,
@@ -3859,10 +3885,11 @@ pub(crate) async fn start_ldk(
     {
         tracing::info!(store_id = %identity.pubkey_hex, "Initializing VSS KV store");
         let vss_kv_store = Arc::new(
-            crate::vss_kv_store::VssKvStore::new(
+            crate::vss_kv_store::VssKvStore::new_with_retry(
                 vss_url.clone(),
                 identity.pubkey_hex.clone(),
                 identity.signing_key,
+                &static_state.config.vss,
             )
             .map_err(|e| APIError::FailedVssInit(e.to_string()))?,
         );
@@ -3970,6 +3997,7 @@ pub(crate) async fn start_ldk(
                 password,
                 tokio::runtime::Handle::current(),
                 Arc::clone(&logger),
+                static_state.config.chain.fee_refresh_interval_secs,
             )
             .await
             {
@@ -4006,6 +4034,8 @@ pub(crate) async fn start_ldk(
                     network,
                     tokio::runtime::Handle::current(),
                     Arc::clone(&logger),
+                    static_state.config.chain.indexer_timeout_secs,
+                    static_state.config.chain.fee_refresh_interval_secs,
                 )
                 .map_err(|e| APIError::InvalidIndexer(e.to_string()))?,
             );
@@ -4034,6 +4064,7 @@ pub(crate) async fn start_ldk(
                     network,
                     tokio::runtime::Handle::current(),
                     Arc::clone(&logger),
+                    static_state.config.chain.fee_refresh_interval_secs,
                 )
                 .map_err(|e| APIError::InvalidIndexer(e.to_string()))?,
             );
@@ -4245,13 +4276,24 @@ pub(crate) async fn start_ldk(
     ));
 
     // Initialize the ChannelManager
+    let channels_config = &static_state.config.channels;
     let mut user_config = UserConfig::default();
     user_config
         .channel_handshake_limits
         .force_announced_channel_preference = false;
+    user_config.channel_handshake_limits.their_to_self_delay = channels_config.their_to_self_delay;
+    user_config.channel_handshake_limits.max_minimum_depth = channels_config.max_minimum_depth;
     user_config
         .channel_handshake_config
         .negotiate_anchors_zero_fee_htlc_tx = true;
+    user_config.channel_handshake_config.our_to_self_delay = channels_config.our_to_self_delay;
+    user_config
+        .channel_handshake_config
+        .max_inbound_htlc_value_in_flight_percent_of_channel =
+        channels_config.max_inbound_htlc_value_in_flight_percent;
+    user_config.channel_handshake_config.our_max_accepted_htlcs =
+        channels_config.our_max_accepted_htlcs;
+    user_config.channel_config = channels_config.channel_config();
     user_config.accept_forwards_to_priv_channels = static_state.enable_virtual_channels_v0;
     user_config.manually_accept_inbound_channels = true;
     let mut restarting_node = true;
@@ -4625,6 +4667,14 @@ pub(crate) async fn start_ldk(
                 latest_sync_timestamp,
                 Arc::clone(&network_graph),
                 Arc::clone(&logger),
+                crate::gossip::RgsTuning {
+                    connect_timeout_secs: static_state.config.gossip.rgs_connect_timeout_secs,
+                    sync_timeout_secs: static_state.config.gossip.rgs_sync_timeout_secs,
+                    snapshot_max_size: (static_state.config.gossip.rgs_snapshot_max_size_mb
+                        as usize)
+                        * 1024
+                        * 1024,
+                },
             )
         }
     });
@@ -4683,6 +4733,7 @@ pub(crate) async fn start_ldk(
             lsp_base_url.clone(),
             static_state.lsp_bearer_token.clone(),
             Handle::current(),
+            static_state.config.lsp.request_timeout_secs,
         )),
         None => Arc::new(AsyncOrderMessageHandler::new(live_channel_access)),
     };
@@ -5020,6 +5071,7 @@ pub(crate) async fn start_ldk(
     }
 
     async_order_handler.set_invoice_provider(Arc::new(AsyncOrderRecipientInvoiceProvider {
+        config: static_state.config.clone(),
         channel_manager: Arc::clone(&channel_manager),
         inbound_payments: Arc::clone(&inbound_payments),
         async_payments_preimage_root: Arc::clone(&async_payments_preimage_root),
@@ -5030,6 +5082,7 @@ pub(crate) async fn start_ldk(
     }));
 
     let unlocked_state = Arc::new(UnlockedAppState {
+        config: static_state.config.clone(),
         channel_manager: Arc::clone(&channel_manager),
         gossip_source: Arc::clone(&gossip_source),
         inbound_payments,
@@ -5068,7 +5121,7 @@ pub(crate) async fn start_ldk(
         tokio::spawn(crate::gossip::run_rgs_sync_loop(
             Arc::clone(&unlocked_state.gossip_source),
             Arc::clone(&gossip_shutdown),
-            crate::gossip::RGS_SYNC_INTERVAL,
+            Duration::from_secs(static_state.config.gossip.rgs_sync_interval_secs),
         ));
     }
 
@@ -5131,8 +5184,9 @@ pub(crate) async fn start_ldk(
     let connect_pm = Arc::clone(&peer_manager);
     let connect_db = static_state.db();
     let stop_connect = Arc::clone(&stop_processing);
+    let reconnect_interval_secs = static_state.config.node.peer_reconnect_interval_secs;
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        let mut interval = tokio::time::interval(Duration::from_secs(reconnect_interval_secs));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             interval.tick().await;
@@ -5261,12 +5315,15 @@ pub(crate) async fn start_ldk(
     };
     let peer_man = Arc::clone(&peer_manager);
     let chan_man = Arc::clone(&channel_manager);
+    let announce_initial_delay_secs = static_state.config.node.announce_initial_delay_secs;
+    let announce_refresh_interval_secs = static_state.config.node.announce_refresh_interval_secs;
     tokio::spawn(async move {
-        // First wait a minute until we have some peers and maybe have opened a channel.
-        tokio::time::sleep(Duration::from_secs(60)).await;
-        // Then, update our announcement once an hour to keep it fresh but avoid unnecessary churn
+        // First wait until we have some peers and maybe have opened a channel.
+        tokio::time::sleep(Duration::from_secs(announce_initial_delay_secs)).await;
+        // Then, update our announcement periodically to keep it fresh but avoid unnecessary churn
         // in the global gossip network.
-        let mut interval = tokio::time::interval(Duration::from_secs(3600));
+        let mut interval =
+            tokio::time::interval(Duration::from_secs(announce_refresh_interval_secs));
         loop {
             interval.tick().await;
             // Don't bother trying to announce if we don't have any public channls, though our

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod auth;
 mod backup;
 mod bitcoind;
 mod chain_backend;
+mod config;
 mod core_types;
 mod database;
 mod disk;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod auth;
 mod backup;
 mod bitcoind;
 mod chain_backend;
+mod config;
 mod core_types;
 mod database;
 mod disk;

--- a/src/node.rs
+++ b/src/node.rs
@@ -60,6 +60,7 @@ impl NodeHandle {
             vss_allow_empty_restore: config.vss_allow_empty_restore,
             reuse_addresses: config.reuse_addresses,
             remote_signer_listen_addr: config.remote_signer_listen_addr,
+            config: Default::default(),
         };
         let state = start_daemon(&args).await?;
         Ok(Self { state })

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -18,7 +18,6 @@ use lightning::onion_message::messenger::Destination;
 use lightning::rgb_utils::{RgbInfo, RgbKvStoreExt, STATIC_BLINDING};
 use lightning::routing::gossip::RoutingFees;
 use lightning::routing::router::{Path as LnPath, Route, RouteHint, RouteHintHop};
-use lightning::util::config::ChannelConfig;
 use lightning::{
     ln::channel_state::ChannelShutdownState, onion_message::messenger::MessageSendInstructions,
 };
@@ -73,7 +72,7 @@ use tokio::{
 
 use crate::async_order::{
     write_async_payments_next_hash_index, AsyncOrderNewResultWire,
-    AsyncOrderOutboundInvoiceResultWire, ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
+    AsyncOrderOutboundInvoiceResultWire,
 };
 use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
@@ -98,11 +97,7 @@ use crate::utils::{
 };
 use crate::{
     backup::{do_backup, restore_backup},
-    core_types::{
-        HTLCStatus, SwapStatus, UnlockRequest as CoreUnlockRequest,
-        DEFAULT_FINAL_CLTV_EXPIRY_DELTA, DUST_LIMIT_MSAT, FEE_RATE, HTLC_MIN_MSAT,
-        MAX_SWAP_FEE_MSAT, MIN_CHANNEL_CONFIRMATIONS, UTXO_SIZE_SAT, VIRTUAL_HTLC_MIN_MSAT,
-    },
+    core_types::{HTLCStatus, SwapStatus, UnlockRequest as CoreUnlockRequest},
     rgb::{check_rgb_proxy_endpoint, get_rgb_channel_info_optional},
 };
 use crate::{
@@ -113,12 +108,6 @@ use crate::{
     },
 };
 
-const UTXO_NUM: u8 = 4;
-
-const OPENRGBCHANNEL_MIN_SAT: u64 = HTLC_MIN_MSAT / 1000 * 10 + 10;
-const OPENCHANNEL_MIN_SAT: u64 = 5506;
-const OPENCHANNEL_MAX_SAT: u64 = 16777215;
-const OPENCHANNEL_MIN_RGB_AMT: u64 = 1;
 const VIRTUAL_OPEN_MODE_TRUSTED_NO_BROADCAST: &str = "trusted_no_broadcast";
 
 #[derive(Deserialize, Serialize)]
@@ -817,11 +806,6 @@ pub(crate) struct ListPaymentsResponse {
     pub(crate) first_index_offset: u64,
     pub(crate) last_index_offset: u64,
 }
-
-const DEFAULT_MAX_PAYMENTS: u64 = 100;
-const DEFAULT_MAX_TRANSFERS: u64 = 100;
-const DEFAULT_MAX_UNSPENTS: u64 = 100;
-const DEFAULT_MAX_TRANSACTIONS: u64 = 100;
 
 /// Resolve a caller-supplied page size, treating absent or zero as the default.
 fn resolve_page_size(max: Option<u64>, default: u64) -> u64 {
@@ -1662,7 +1646,7 @@ pub(crate) async fn async_order_new(
         .map_err(|err| APIError::InvalidRequest(err.message))?;
     unlocked_state.peer_manager.process_events();
     let order_state_value = match timeout(
-        Duration::from_secs(ASYNC_ORDER_RESPONSE_TIMEOUT_SECS),
+        Duration::from_secs(unlocked_state.config.lsp.order_response_timeout_secs),
         response_rx,
     )
     .await
@@ -1756,7 +1740,7 @@ pub(crate) async fn async_order_outbound_invoice(
     unlocked_state.peer_manager.process_events();
 
     let response_value = match timeout(
-        Duration::from_secs(ASYNC_ORDER_RESPONSE_TIMEOUT_SECS),
+        Duration::from_secs(unlocked_state.config.lsp.order_response_timeout_secs),
         response_rx,
     )
     .await
@@ -1951,7 +1935,10 @@ pub(crate) async fn change_password(
             ));
         }
 
-        check_password_strength(payload.new_password.clone())?;
+        check_password_strength(
+            payload.new_password.clone(),
+            state.static_state.config.auth.password_min_length,
+        )?;
 
         let mnemonic = check_password_validity(&payload.old_password, &state.db())?;
 
@@ -2284,8 +2271,10 @@ pub(crate) async fn create_utxos(
         let guard = state.check_unlocked().await?;
         let unlocked_state = guard.as_ref().unwrap();
 
-        let num = payload.num.unwrap_or(UTXO_NUM);
-        let size = payload.size.unwrap_or(UTXO_SIZE_SAT);
+        let num = payload.num.unwrap_or(unlocked_state.config.rgb.utxo_num);
+        let size = payload
+            .size
+            .unwrap_or(unlocked_state.config.rgb.utxo_size_sat);
         if unlocked_state.external_signer_mode {
             let unsigned_psbt = unlocked_state.rgb_create_utxos_begin(
                 payload.up_to,
@@ -2682,7 +2671,10 @@ pub(crate) async fn init(
             return Err(APIError::ExternalSignerRequired);
         }
 
-        check_password_strength(payload.password.clone())?;
+        check_password_strength(
+            payload.password.clone(),
+            state.static_state.config.auth.password_min_length,
+        )?;
 
         check_already_initialized(&state.db())?;
 
@@ -3006,7 +2998,9 @@ pub(crate) async fn keysend(
             RecipientOnionFields::spontaneous_empty(),
             payment_id,
             route_params,
-            Retry::Timeout(Duration::from_secs(10)),
+            Retry::Timeout(Duration::from_secs(
+                unlocked_state.config.payments.retry_timeout_secs,
+            )),
         ) {
             Ok(_payment_hash) => {
                 tracing::info!(
@@ -3287,7 +3281,10 @@ pub(crate) async fn list_payments(
     let (payments, first_index_offset, last_index_offset) = paginate_newest_first(
         all,
         params.index_offset.unwrap_or(0),
-        resolve_page_size(params.max_payments, DEFAULT_MAX_PAYMENTS),
+        resolve_page_size(
+            params.max_payments,
+            state.static_state.config.api.default_page_size,
+        ),
     );
 
     Ok(Json(ListPaymentsResponse {
@@ -3412,7 +3409,10 @@ pub(crate) async fn list_transactions(
     let (transactions, first_index_offset, last_index_offset) = paginate_newest_first(
         indexed,
         payload.index_offset.unwrap_or(0),
-        resolve_page_size(payload.max_transactions, DEFAULT_MAX_TRANSACTIONS),
+        resolve_page_size(
+            payload.max_transactions,
+            state.static_state.config.api.default_page_size,
+        ),
     );
 
     Ok(Json(ListTransactionsResponse {
@@ -3497,7 +3497,10 @@ pub(crate) async fn list_transfers(
     let (transfers, first_index_offset, last_index_offset) = paginate_newest_first(
         indexed,
         payload.index_offset.unwrap_or(0),
-        resolve_page_size(payload.max_transfers, DEFAULT_MAX_TRANSFERS),
+        resolve_page_size(
+            payload.max_transfers,
+            state.static_state.config.api.default_page_size,
+        ),
     );
 
     Ok(Json(ListTransfersResponse {
@@ -3547,7 +3550,10 @@ pub(crate) async fn list_unspents(
     let (unspents, first_index_offset, last_index_offset) = paginate_newest_first(
         indexed,
         payload.index_offset.unwrap_or(0),
-        resolve_page_size(payload.max_unspents, DEFAULT_MAX_UNSPENTS),
+        resolve_page_size(
+            payload.max_unspents,
+            state.static_state.config.api.default_page_size,
+        ),
     );
 
     Ok(Json(ListUnspentsResponse {
@@ -3757,16 +3763,18 @@ pub(crate) async fn maker_execute(
         let rgb_payment = swap_info
             .to_asset
             .map(|to_asset| (to_asset, swap_info.qty_to));
+        let htlc_min_msat = unlocked_state.config.channels.htlc_min_msat;
         let first_leg = get_route(
+            &unlocked_state.config,
             &unlocked_state.channel_manager,
             &unlocked_state.router,
             unlocked_state.kv_store.as_ref(),
             unlocked_state.runtime_node_id(),
             taker_pk,
             if swap_info.is_to_btc() {
-                Some(swap_info.qty_to + HTLC_MIN_MSAT)
+                Some(swap_info.qty_to + htlc_min_msat)
             } else {
-                Some(HTLC_MIN_MSAT)
+                Some(htlc_min_msat)
             },
             rgb_payment,
             vec![],
@@ -3776,15 +3784,16 @@ pub(crate) async fn maker_execute(
             .from_asset
             .map(|from_asset| (from_asset, swap_info.qty_from));
         let second_leg = get_route(
+            &unlocked_state.config,
             &unlocked_state.channel_manager,
             &unlocked_state.router,
             unlocked_state.kv_store.as_ref(),
             taker_pk,
             unlocked_state.runtime_node_id(),
             if swap_info.is_to_btc() || swap_info.is_asset_asset() {
-                Some(HTLC_MIN_MSAT)
+                Some(htlc_min_msat)
             } else {
-                Some(swap_info.qty_from + HTLC_MIN_MSAT)
+                Some(swap_info.qty_from + htlc_min_msat)
             },
             rgb_payment,
             receive_hints,
@@ -3834,7 +3843,7 @@ pub(crate) async fn maker_execute(
             .map(|hop| hop.fee_msat)
             .sum::<u64>();
 
-        if total_fee >= MAX_SWAP_FEE_MSAT {
+        if total_fee >= unlocked_state.config.payments.max_swap_fee_msat {
             return Err(APIError::FailedPayment(format!(
                 "Fee too high: {total_fee}"
             )));
@@ -3848,7 +3857,7 @@ pub(crate) async fn maker_execute(
             route_params: Some(RouteParameters {
                 payment_params: PaymentParameters::for_keysend(
                     unlocked_state.runtime_node_id(),
-                    DEFAULT_FINAL_CLTV_EXPIRY_DELTA,
+                    unlocked_state.config.payments.final_cltv_expiry_delta,
                     false,
                 ),
                 // This value is not used anywhere, it's set by the router
@@ -3970,7 +3979,11 @@ pub(crate) async fn maker_init(
 
         let (payment_hash, payment_secret) = unlocked_state
             .channel_manager
-            .create_inbound_payment(Some(DUST_LIMIT_MSAT), payload.timeout_sec, None)
+            .create_inbound_payment(
+                Some(unlocked_state.config.channels.dust_limit_msat),
+                payload.timeout_sec,
+                None,
+            )
             .unwrap();
         unlocked_state.add_maker_swap(payment_hash, swap_data);
 
@@ -4055,11 +4068,11 @@ pub(crate) async fn node_info(
         account_xpub_vanilla: unlocked_state.rgb_get_keys().account_xpub_vanilla,
         account_xpub_colored: unlocked_state.rgb_get_keys().account_xpub_colored,
         max_media_upload_size_mb: state.static_state.max_media_upload_size_mb,
-        rgb_htlc_min_msat: HTLC_MIN_MSAT,
-        rgb_channel_capacity_min_sat: OPENRGBCHANNEL_MIN_SAT,
-        channel_capacity_min_sat: OPENCHANNEL_MIN_SAT,
-        channel_capacity_max_sat: OPENCHANNEL_MAX_SAT,
-        channel_asset_min_amount: OPENCHANNEL_MIN_RGB_AMT,
+        rgb_htlc_min_msat: unlocked_state.config.channels.htlc_min_msat,
+        rgb_channel_capacity_min_sat: unlocked_state.config.channels.open_rgb_min_sat(),
+        channel_capacity_min_sat: unlocked_state.config.channels.open_min_sat,
+        channel_capacity_max_sat: unlocked_state.config.channels.open_max_sat,
+        channel_asset_min_amount: unlocked_state.config.channels.open_min_rgb_amount,
         channel_asset_max_amount: u64::MAX,
         network_nodes,
         network_channels,
@@ -4141,10 +4154,12 @@ pub(crate) async fn open_channel(
             }
         }
 
+        let channels_config = &unlocked_state.config.channels;
         let colored_info = match (payload.asset_id, payload.asset_amount) {
-            (Some(_), Some(amt)) if amt < OPENCHANNEL_MIN_RGB_AMT => {
+            (Some(_), Some(amt)) if amt < channels_config.open_min_rgb_amount => {
                 return Err(APIError::InvalidAmount(format!(
-                    "Channel RGB amount must be equal to or higher than {OPENCHANNEL_MIN_RGB_AMT}"
+                    "Channel RGB amount must be equal to or higher than {}",
+                    channels_config.open_min_rgb_amount
                 )));
             }
             (Some(asset), Some(amt)) => {
@@ -4158,18 +4173,21 @@ pub(crate) async fn open_channel(
             }
         };
 
-        if colored_info.is_some() && payload.capacity_sat < OPENRGBCHANNEL_MIN_SAT {
+        if colored_info.is_some() && payload.capacity_sat < channels_config.open_rgb_min_sat() {
             return Err(APIError::InvalidAmount(format!(
-                "RGB channel amount must be equal to or higher than {OPENRGBCHANNEL_MIN_SAT} sats"
+                "RGB channel amount must be equal to or higher than {} sats",
+                channels_config.open_rgb_min_sat()
             )));
-        } else if payload.capacity_sat < OPENCHANNEL_MIN_SAT {
+        } else if payload.capacity_sat < channels_config.open_min_sat {
             return Err(APIError::InvalidAmount(format!(
-                "Channel amount must be equal to or higher than {OPENCHANNEL_MIN_SAT} sats"
+                "Channel amount must be equal to or higher than {} sats",
+                channels_config.open_min_sat
             )));
         }
-        if payload.capacity_sat > OPENCHANNEL_MAX_SAT {
+        if payload.capacity_sat > channels_config.open_max_sat {
             return Err(APIError::InvalidAmount(format!(
-                "Channel amount must be equal to or less than {OPENCHANNEL_MAX_SAT} sats"
+                "Channel amount must be equal to or less than {} sats",
+                channels_config.open_max_sat
             )));
         }
 
@@ -4243,7 +4261,7 @@ pub(crate) async fn open_channel(
             )));
         }
 
-        let mut channel_config = ChannelConfig::default();
+        let mut channel_config = channels_config.channel_config();
         if let Some(fee_base_msat) = payload.fee_base_msat {
             channel_config.forwarding_fee_base_msat = fee_base_msat;
         }
@@ -4253,8 +4271,9 @@ pub(crate) async fn open_channel(
         let config = UserConfig {
             channel_handshake_limits: ChannelHandshakeLimits {
                 trust_own_funding_0conf: is_virtual_open,
-                // lnd's max to_self_delay is 2016, so we want to be compatible.
-                their_to_self_delay: 2016,
+                // defaults to 2016 for compatibility with lnd's max to_self_delay
+                their_to_self_delay: channels_config.their_to_self_delay,
+                max_minimum_depth: channels_config.max_minimum_depth,
                 ..Default::default()
             },
             channel_handshake_config: ChannelHandshakeConfig {
@@ -4264,15 +4283,19 @@ pub(crate) async fn open_channel(
                     payload.public
                 },
                 our_htlc_minimum_msat: if is_virtual_open {
-                    VIRTUAL_HTLC_MIN_MSAT
+                    channels_config.virtual_htlc_min_msat
                 } else {
-                    HTLC_MIN_MSAT
+                    channels_config.htlc_min_msat
                 },
                 minimum_depth: if is_virtual_open {
                     0
                 } else {
-                    MIN_CHANNEL_CONFIRMATIONS as u32
+                    unlocked_state.config.rgb.min_channel_confirmations as u32
                 },
+                our_to_self_delay: channels_config.our_to_self_delay,
+                max_inbound_htlc_value_in_flight_percent_of_channel: channels_config
+                    .max_inbound_htlc_value_in_flight_percent,
+                our_max_accepted_htlcs: channels_config.our_max_accepted_htlcs,
                 negotiate_scid_privacy: is_virtual_open,
                 negotiate_anchors_zero_fee_htlc_tx: payload.with_anchors,
                 their_channel_reserve_satoshis_override: if is_virtual_open {
@@ -4331,13 +4354,16 @@ pub(crate) async fn open_channel(
                         transport_endpoints: vec![unlocked_state.proxy_endpoint.clone()]
                 }]};
 
+                let fee_rate_sat_vb = unlocked_state.config.rgb.fee_rate_sat_vb;
+                let min_channel_confirmations =
+                    unlocked_state.config.rgb.min_channel_confirmations;
                 let unlocked_state_copy = unlocked_state.clone();
                 tokio::task::spawn_blocking(move || {
                     unlocked_state_copy.rgb_send_begin(
                         recipient_map,
                         true,
-                        FEE_RATE,
-                        MIN_CHANNEL_CONFIRMATIONS,
+                        fee_rate_sat_vb,
+                        min_channel_confirmations,
                         None,
                         true,
                         // Channel-funding dry run: mirror the real funding tx's final locktime.
@@ -4764,7 +4790,9 @@ pub(crate) async fn send_payment(
             )?;
 
             let params = OptionalOfferPaymentParams {
-                retry_strategy: Retry::Timeout(Duration::from_secs(10)),
+                retry_strategy: Retry::Timeout(Duration::from_secs(
+                    unlocked_state.config.payments.retry_timeout_secs,
+                )),
                 ..Default::default()
             };
             let pay = unlocked_state.channel_manager
@@ -4893,7 +4921,9 @@ pub(crate) async fn send_payment(
                 payment_id,
                 Some(amt_msat),
                 RouteParametersConfig::default(),
-                Retry::Timeout(Duration::from_secs(10)),
+                Retry::Timeout(Duration::from_secs(
+                    unlocked_state.config.payments.retry_timeout_secs,
+                )),
             ) {
                 Ok(_) => {
                     let payee_pubkey = invoice.recover_payee_pub_key();
@@ -5248,11 +5278,13 @@ pub(crate) async fn vss_clear_fence(
             }
         };
 
+        let vss_retry = state.static_state.config.vss.clone();
         tokio::task::spawn_blocking(move || {
-            let store = crate::vss_kv_store::VssKvStore::new(
+            let store = crate::vss_kv_store::VssKvStore::new_with_retry(
                 vss_url,
                 identity.pubkey_hex,
                 identity.signing_key,
+                &vss_retry,
             )?;
             store.delete_fence()
         })

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -9,7 +9,6 @@ use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
     AsyncOrderOutboundInvoiceResponse,
 };
-use crate::core_types::{FEE_RATE, MIN_CHANNEL_CONFIRMATIONS, VIRTUAL_HTLC_MIN_MSAT};
 use crate::error::APIError;
 use crate::ldk::{
     clear_rgb_payment_pending, peer_has_live_channel, start_ldk, write_rgb_payment_info_file,
@@ -96,16 +95,6 @@ use rgb_lib::BitcoinNetwork as RgbBitcoinNetwork;
 use rgb_lib::{AssetSchema as RgbLibAssetSchema, Assignment as RgbLibAssignment};
 use serde_json::Value;
 
-const SDK_HTLC_MIN_MSAT: u64 = 3_000_000;
-const SDK_OPENRGBCHANNEL_MIN_SAT: u64 = SDK_HTLC_MIN_MSAT / 1000 * 10 + 10;
-const SDK_OPENCHANNEL_MIN_SAT: u64 = 5506;
-const SDK_OPENCHANNEL_MAX_SAT: u64 = 16_777_215;
-const SDK_OPENCHANNEL_MIN_RGB_AMT: u64 = 1;
-const SDK_UTXO_NUM: u8 = 4;
-const SDK_UTXO_SIZE_SAT: u32 = 32_000;
-const SDK_DUST_LIMIT_MSAT: u64 = 546_000;
-const SDK_MAX_SWAP_FEE_MSAT: u64 = SDK_HTLC_MIN_MSAT;
-const SDK_DEFAULT_FINAL_CLTV_EXPIRY_DELTA: u32 = 14;
 const SDK_VIRTUAL_OPEN_MODE_TRUSTED_NO_BROADCAST: &str = "trusted_no_broadcast";
 
 struct OpenChannelVirtualIntentGuard {
@@ -1119,11 +1108,11 @@ pub(crate) async fn node_info(state: Arc<AppState>) -> Result<NodeInfoData, APIE
         account_xpub_vanilla: wallet_data.account_xpub_vanilla,
         account_xpub_colored: wallet_data.account_xpub_colored,
         max_media_upload_size_mb: state.static_state.max_media_upload_size_mb,
-        rgb_htlc_min_msat: SDK_HTLC_MIN_MSAT,
-        rgb_channel_capacity_min_sat: SDK_OPENRGBCHANNEL_MIN_SAT,
-        channel_capacity_min_sat: SDK_OPENCHANNEL_MIN_SAT,
-        channel_capacity_max_sat: SDK_OPENCHANNEL_MAX_SAT,
-        channel_asset_min_amount: SDK_OPENCHANNEL_MIN_RGB_AMT,
+        rgb_htlc_min_msat: unlocked_state.config.channels.htlc_min_msat,
+        rgb_channel_capacity_min_sat: unlocked_state.config.channels.open_rgb_min_sat(),
+        channel_capacity_min_sat: unlocked_state.config.channels.open_min_sat,
+        channel_capacity_max_sat: unlocked_state.config.channels.open_max_sat,
+        channel_asset_min_amount: unlocked_state.config.channels.open_min_rgb_amount,
         channel_asset_max_amount: u64::MAX,
         network_nodes,
         network_channels,
@@ -2372,8 +2361,10 @@ pub(crate) async fn create_utxos(
     let guard = check_unlocked(&state).await?;
     let unlocked_state = guard.as_ref().unwrap();
 
-    let num = request.num.unwrap_or(SDK_UTXO_NUM);
-    let size = request.size.unwrap_or(SDK_UTXO_SIZE_SAT);
+    let num = request.num.unwrap_or(unlocked_state.config.rgb.utxo_num);
+    let size = request
+        .size
+        .unwrap_or(unlocked_state.config.rgb.utxo_size_sat);
     if unlocked_state.external_signer_mode {
         let unsigned_psbt = unlocked_state
             .rgb_create_utxos_begin(
@@ -2782,10 +2773,12 @@ pub(crate) async fn open_channel(
         }
     }
 
+    let channels_config = &unlocked_state.config.channels;
     let colored_info = match (request.asset_id, request.asset_amount) {
-        (Some(_), Some(amt)) if amt < SDK_OPENCHANNEL_MIN_RGB_AMT => {
+        (Some(_), Some(amt)) if amt < channels_config.open_min_rgb_amount => {
             return Err(APIError::InvalidAmount(format!(
-                "Channel RGB amount must be equal to or higher than {SDK_OPENCHANNEL_MIN_RGB_AMT}"
+                "Channel RGB amount must be equal to or higher than {}",
+                channels_config.open_min_rgb_amount
             )));
         }
         (Some(asset), Some(amt)) => {
@@ -2797,18 +2790,21 @@ pub(crate) async fn open_channel(
         _ => return Err(APIError::IncompleteRGBInfo),
     };
 
-    if colored_info.is_some() && request.capacity_sat < SDK_OPENRGBCHANNEL_MIN_SAT {
+    if colored_info.is_some() && request.capacity_sat < channels_config.open_rgb_min_sat() {
         return Err(APIError::InvalidAmount(format!(
-            "RGB channel amount must be equal to or higher than {SDK_OPENRGBCHANNEL_MIN_SAT} sats"
+            "RGB channel amount must be equal to or higher than {} sats",
+            channels_config.open_rgb_min_sat()
         )));
-    } else if request.capacity_sat < SDK_OPENCHANNEL_MIN_SAT {
+    } else if request.capacity_sat < channels_config.open_min_sat {
         return Err(APIError::InvalidAmount(format!(
-            "Channel amount must be equal to or higher than {SDK_OPENCHANNEL_MIN_SAT} sats"
+            "Channel amount must be equal to or higher than {} sats",
+            channels_config.open_min_sat
         )));
     }
-    if request.capacity_sat > SDK_OPENCHANNEL_MAX_SAT {
+    if request.capacity_sat > channels_config.open_max_sat {
         return Err(APIError::InvalidAmount(format!(
-            "Channel amount must be equal to or less than {SDK_OPENCHANNEL_MAX_SAT} sats"
+            "Channel amount must be equal to or less than {} sats",
+            channels_config.open_max_sat
         )));
     }
 
@@ -2881,7 +2877,7 @@ pub(crate) async fn open_channel(
         )));
     }
 
-    let mut channel_config = ChannelConfig::default();
+    let mut channel_config = channels_config.channel_config();
     if let Some(fee_base_msat) = request.fee_base_msat {
         channel_config.forwarding_fee_base_msat = fee_base_msat;
     }
@@ -2891,7 +2887,8 @@ pub(crate) async fn open_channel(
     let config = UserConfig {
         channel_handshake_limits: ChannelHandshakeLimits {
             trust_own_funding_0conf: true,
-            their_to_self_delay: 2016,
+            their_to_self_delay: channels_config.their_to_self_delay,
+            max_minimum_depth: channels_config.max_minimum_depth,
             ..Default::default()
         },
         channel_handshake_config: ChannelHandshakeConfig {
@@ -2901,15 +2898,19 @@ pub(crate) async fn open_channel(
                 request.public
             },
             our_htlc_minimum_msat: if is_virtual_open {
-                VIRTUAL_HTLC_MIN_MSAT
+                channels_config.virtual_htlc_min_msat
             } else {
-                SDK_HTLC_MIN_MSAT
+                channels_config.htlc_min_msat
             },
             minimum_depth: if is_virtual_open {
                 0
             } else {
-                MIN_CHANNEL_CONFIRMATIONS as u32
+                unlocked_state.config.rgb.min_channel_confirmations as u32
             },
+            our_to_self_delay: channels_config.our_to_self_delay,
+            max_inbound_htlc_value_in_flight_percent_of_channel: channels_config
+                .max_inbound_htlc_value_in_flight_percent,
+            our_max_accepted_htlcs: channels_config.our_max_accepted_htlcs,
             negotiate_scid_privacy: is_virtual_open,
             negotiate_anchors_zero_fee_htlc_tx: request.with_anchors,
             their_channel_reserve_satoshis_override: if is_virtual_open { Some(0) } else { None },
@@ -2957,13 +2958,15 @@ pub(crate) async fn open_channel(
                 transport_endpoints: vec![unlocked_state.proxy_endpoint.clone()],
         }]};
 
+        let fee_rate_sat_vb = unlocked_state.config.rgb.fee_rate_sat_vb;
+        let min_channel_confirmations = unlocked_state.config.rgb.min_channel_confirmations;
         let unlocked_state_copy = unlocked_state.clone();
         tokio::task::spawn_blocking(move || {
             unlocked_state_copy.rgb_send_begin(
                 recipient_map,
                 true,
-                FEE_RATE,
-                MIN_CHANNEL_CONFIRMATIONS,
+                fee_rate_sat_vb,
+                min_channel_confirmations,
                 None,
                 true,
                 Some(0),
@@ -3371,6 +3374,7 @@ pub(crate) async fn maker_execute(
     let rgb_payment = swap_info
         .to_asset
         .map(|to_asset| (to_asset, swap_info.qty_to));
+    let htlc_min_msat = unlocked_state.config.channels.htlc_min_msat;
     let first_leg = get_route(
         &unlocked_state.config,
         &unlocked_state.channel_manager,
@@ -3379,9 +3383,9 @@ pub(crate) async fn maker_execute(
         unlocked_state.runtime_node_id(),
         taker_pk,
         if swap_info.is_to_btc() {
-            Some(swap_info.qty_to + SDK_HTLC_MIN_MSAT)
+            Some(swap_info.qty_to + htlc_min_msat)
         } else {
-            Some(SDK_HTLC_MIN_MSAT)
+            Some(htlc_min_msat)
         },
         rgb_payment,
         vec![],
@@ -3398,9 +3402,9 @@ pub(crate) async fn maker_execute(
         taker_pk,
         unlocked_state.runtime_node_id(),
         if swap_info.is_to_btc() || swap_info.is_asset_asset() {
-            Some(SDK_HTLC_MIN_MSAT)
+            Some(htlc_min_msat)
         } else {
-            Some(swap_info.qty_from + SDK_HTLC_MIN_MSAT)
+            Some(swap_info.qty_from + htlc_min_msat)
         },
         rgb_payment,
         receive_hints,
@@ -3444,7 +3448,7 @@ pub(crate) async fn maker_execute(
         .map(|hop| hop.fee_msat)
         .sum::<u64>();
 
-    if total_fee >= SDK_MAX_SWAP_FEE_MSAT {
+    if total_fee >= unlocked_state.config.payments.max_swap_fee_msat {
         return Err(APIError::FailedPayment(format!(
             "Fee too high: {total_fee}"
         )));
@@ -3458,7 +3462,7 @@ pub(crate) async fn maker_execute(
         route_params: Some(RouteParameters {
             payment_params: PaymentParameters::for_keysend(
                 unlocked_state.runtime_node_id(),
-                SDK_DEFAULT_FINAL_CLTV_EXPIRY_DELTA,
+                unlocked_state.config.payments.final_cltv_expiry_delta,
                 false,
             ),
             final_value_msat: 0,
@@ -3557,7 +3561,11 @@ pub(crate) async fn maker_init(
 
     let (payment_hash, payment_secret) = unlocked_state
         .channel_manager
-        .create_inbound_payment(Some(SDK_DUST_LIMIT_MSAT), request.timeout_sec, None)
+        .create_inbound_payment(
+            Some(unlocked_state.config.channels.dust_limit_msat),
+            request.timeout_sec,
+            None,
+        )
         .unwrap();
     unlocked_state.add_maker_swap(payment_hash, swap_data);
 

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::async_order::{
     write_async_payments_next_hash_index, AsyncOrderNewResultWire,
-    AsyncOrderOutboundInvoiceResultWire, ASYNC_ORDER_RESPONSE_TIMEOUT_SECS,
+    AsyncOrderOutboundInvoiceResultWire,
 };
 use crate::core_types::async_order::{
     AsyncOrderNewRequest, AsyncOrderNewResponse, AsyncOrderOutboundInvoiceRequest,
@@ -1212,7 +1212,7 @@ pub(crate) async fn async_order_new(
         .map_err(|err| APIError::InvalidRequest(err.message))?;
     unlocked_state.peer_manager.process_events();
     let order_state_value = match timeout(
-        Duration::from_secs(ASYNC_ORDER_RESPONSE_TIMEOUT_SECS),
+        Duration::from_secs(unlocked_state.config.lsp.order_response_timeout_secs),
         response_rx,
     )
     .await
@@ -1303,7 +1303,7 @@ pub(crate) async fn async_order_outbound_invoice(
     unlocked_state.peer_manager.process_events();
 
     let response_value = match timeout(
-        Duration::from_secs(ASYNC_ORDER_RESPONSE_TIMEOUT_SECS),
+        Duration::from_secs(unlocked_state.config.lsp.order_response_timeout_secs),
         response_rx,
     )
     .await
@@ -1818,7 +1818,10 @@ pub(crate) async fn init(
         return Err(APIError::ExternalSignerRequired);
     }
 
-    check_password_strength(password.clone())?;
+    check_password_strength(
+        password.clone(),
+        state.static_state.config.auth.password_min_length,
+    )?;
     check_already_initialized(&state.db())?;
 
     let mnemonic = match mnemonic {
@@ -1930,11 +1933,13 @@ pub(crate) async fn vss_clear_fence(
             }
         };
 
+        let vss_retry = state.static_state.config.vss.clone();
         tokio::task::spawn_blocking(move || {
-            let store = crate::vss_kv_store::VssKvStore::new(
+            let store = crate::vss_kv_store::VssKvStore::new_with_retry(
                 vss_url,
                 identity.pubkey_hex,
                 identity.signing_key,
+                &vss_retry,
             )?;
             store.delete_fence()
         })
@@ -3367,6 +3372,7 @@ pub(crate) async fn maker_execute(
         .to_asset
         .map(|to_asset| (to_asset, swap_info.qty_to));
     let first_leg = get_route(
+        &unlocked_state.config,
         &unlocked_state.channel_manager,
         &unlocked_state.router,
         unlocked_state.kv_store.as_ref(),
@@ -3385,6 +3391,7 @@ pub(crate) async fn maker_execute(
         .from_asset
         .map(|from_asset| (from_asset, swap_info.qty_from));
     let second_leg = get_route(
+        &unlocked_state.config,
         &unlocked_state.channel_manager,
         &unlocked_state.router,
         unlocked_state.kv_store.as_ref(),
@@ -4453,6 +4460,7 @@ mod tests {
         crate::runtime::block_on(Migrator::up(&database, None)).expect("run migrations");
         Arc::new(AppState {
             static_state: Arc::new(StaticState {
+                config: Default::default(),
                 ldk_peer_listening_port: 9735,
                 network: BitcoinNetwork::Regtest,
                 storage_dir_path: storage_dir.clone(),

--- a/src/test/auth_db_persistence.rs
+++ b/src/test/auth_db_persistence.rs
@@ -18,6 +18,7 @@ use crate::utils::{AppState, StaticState};
 fn build_state(storage_dir_path: PathBuf, database: DatabaseConnection) -> AppState {
     AppState {
         static_state: Arc::new(StaticState {
+            config: Default::default(),
             ldk_peer_listening_port: 9735,
             network: rgb_lib::BitcoinNetwork::Regtest,
             storage_dir_path: storage_dir_path.clone(),

--- a/src/test/invoice.rs
+++ b/src/test/invoice.rs
@@ -37,7 +37,7 @@ async fn invoice() {
 
     // an invoice with RGB data and amt_msat below INVOICE_MIN_MSAT should fail
     let payload = LNInvoiceRequest {
-        amt_msat: Some(2999999),
+        amt_msat: Some(HTLC_MIN_MSAT - 1),
         expiry_sec: 900,
         asset_id: Some(asset_id.clone()),
         asset_amount: Some(1),

--- a/src/test/lib_sdk/external_signer.rs
+++ b/src/test/lib_sdk/external_signer.rs
@@ -607,7 +607,7 @@ fn rgb_native_external_signer_mixed_one_hop_payment_quick() {
             .createutxos(SdkCreateUtxosRequest {
                 up_to: false,
                 num: Some(25),
-                size: None,
+                size: Some(32_000),
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 skip_sync: false,
             })
@@ -752,7 +752,7 @@ fn rgb_native_external_signer_mixed_one_hop_payment_roundtrip() {
             .createutxos(SdkCreateUtxosRequest {
                 up_to: false,
                 num: Some(25),
-                size: None,
+                size: Some(32_000),
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 skip_sync: false,
             })
@@ -914,7 +914,7 @@ fn rgb_native_external_signer_mixed_one_hop_payment_coop_close_settles_to_chain(
             .createutxos(SdkCreateUtxosRequest {
                 up_to: false,
                 num: Some(25),
-                size: None,
+                size: Some(32_000),
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 skip_sync: false,
             })

--- a/src/test/lib_sdk/helpers.rs
+++ b/src/test/lib_sdk/helpers.rs
@@ -27,8 +27,9 @@ pub(crate) const OPEN_CHANNEL_CAPACITY_SAT: u64 = 100_000;
 pub(crate) const OPEN_CHANNEL_CONFIRM_BLOCKS: u32 = 6;
 pub(crate) const OPEN_CHANNEL_ASSET_AMOUNT: u64 = 600;
 pub(crate) const OPEN_CHANNEL_PUSH_MSAT: u64 = 3_500_000;
+// keep in sync with core_types::HTLC_MIN_MSAT
 pub(crate) const HTLC_MIN_MSAT: u64 = 3_000_000;
-pub(crate) const PAYMENT_MSAT: u64 = HTLC_MIN_MSAT;
+pub(crate) const PAYMENT_MSAT: u64 = 3_000_000;
 pub(crate) const LIQUIDITY_KEYSEND_MSAT: u64 = 10_000_000;
 pub(crate) const CREATE_UTXOS_NUM: u8 = 10;
 pub(crate) const CREATE_UTXOS_FEE_RATE: u64 = 7;

--- a/src/test/lib_sdk/helpers.rs
+++ b/src/test/lib_sdk/helpers.rs
@@ -351,7 +351,8 @@ pub(crate) fn fund_and_create_utxos(node: &SdkNode, node_name: &str) {
     node.createutxos(SdkCreateUtxosRequest {
         up_to: false,
         num: Some(CREATE_UTXOS_NUM),
-        size: None,
+        // explicit size keeps fixture balances independent of the default
+        size: Some(32_000),
         fee_rate: CREATE_UTXOS_FEE_RATE,
         skip_sync: false,
     })

--- a/src/test/lib_sdk/multi_hop.rs
+++ b/src/test/lib_sdk/multi_hop.rs
@@ -371,27 +371,23 @@ fn multi_hop() {
         assert_eq!(chan_3_23.asset_local_amount, Some(50));
         assert_eq!(chan_3_23.asset_remote_amount, Some(250));
 
-        let htlc_min_sat = node_a
-            .node_info()
-            .expect("node A node_info htlc min")
-            .rgb_htlc_min_msat
-            / 1000;
+        let payment_sat = PAYMENT_MSAT / 1000;
         let fees = 1;
         assert_eq!(
             chan_1_12.local_balance_sat,
-            chan_1_12_before.local_balance_sat - htlc_min_sat - fees
+            chan_1_12_before.local_balance_sat - payment_sat - fees
         );
         assert_eq!(
             chan_2_12.local_balance_sat,
-            chan_2_12_before.local_balance_sat + htlc_min_sat + fees
+            chan_2_12_before.local_balance_sat + payment_sat + fees
         );
         assert_eq!(
             chan_2_23.local_balance_sat,
-            chan_2_23_before.local_balance_sat - htlc_min_sat
+            chan_2_23_before.local_balance_sat - payment_sat
         );
         assert_eq!(
             chan_3_23.local_balance_sat,
-            chan_3_23_before.local_balance_sat + htlc_min_sat
+            chan_3_23_before.local_balance_sat + payment_sat
         );
 
         wait_for_usable_channel_counts(

--- a/src/test/lib_sdk/payment.rs
+++ b/src/test/lib_sdk/payment.rs
@@ -103,7 +103,7 @@ fn success() {
             node.createutxos(SdkCreateUtxosRequest {
                 up_to: false,
                 num: Some(CREATE_UTXOS_NUM),
-                size: None,
+                size: Some(32_000),
                 fee_rate: CREATE_UTXOS_FEE_RATE,
                 skip_sync: false,
             })

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -115,6 +115,7 @@ impl Default for UserArgs {
             vss_allow_empty_restore: false,
             reuse_addresses: false,
             remote_signer_listen_addr: None,
+            config: Default::default(),
         }
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -876,7 +876,8 @@ async fn fund_with_and_create_utxos(node_address: SocketAddr, num: Option<u8>, s
     fund_wallet(addr, sats);
     mine(false);
 
-    create_utxos(node_address, false, Some(num.unwrap_or(10)), None).await;
+    // explicit size keeps fixture balances independent of the default
+    create_utxos(node_address, false, Some(num.unwrap_or(10)), Some(32_000)).await;
     mine(false);
 }
 
@@ -1132,7 +1133,7 @@ async fn keysend_raw(
         "sending spontaneously {asset_amount:?} of asset {asset_id:?} from node {node_address} \
          to {dest_pubkey}"
     );
-    let amt_msat = amt_msat.unwrap_or(3000000);
+    let amt_msat = amt_msat.unwrap_or(HTLC_MIN_MSAT);
     let payload = KeysendRequest {
         dest_pubkey: dest_pubkey.to_string(),
         amt_msat,
@@ -1537,7 +1538,7 @@ async fn ln_invoice_with_description_hash(
         "generating invoice with description_hash {description_hash:?} for node {node_address}"
     );
     let payload = LNInvoiceRequest {
-        amt_msat: Some(amt_msat.unwrap_or(3000000)),
+        amt_msat: Some(amt_msat.unwrap_or(HTLC_MIN_MSAT)),
         expiry_sec,
         asset_id: None,
         asset_amount: None,
@@ -1593,7 +1594,7 @@ async fn ln_invoice_with_type(
         "generating {invoice_type:?} invoice for {asset_amount:?} of asset {asset_id:?} for node {node_address}"
     );
     let payload = LNInvoiceRequest {
-        amt_msat: Some(amt_msat.unwrap_or(3000000)),
+        amt_msat: Some(amt_msat.unwrap_or(HTLC_MIN_MSAT)),
         expiry_sec,
         asset_id: asset_id.map(|a| a.to_string()),
         asset_amount,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -24,6 +24,7 @@ pub fn mock_locked_app_state() -> TestAppState {
 
     TestAppState(Arc::new(AppState {
         static_state: Arc::new(StaticState {
+            config: Default::default(),
             ldk_peer_listening_port: 9735,
             network: rgb_lib::BitcoinNetwork::Regtest,
             storage_dir_path: path.clone(),

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -97,6 +97,7 @@ mod uniffi_smoke_tests {
                 .expect("mock database connection");
         Arc::new(AppState {
             static_state: Arc::new(StaticState {
+                config: Default::default(),
                 ldk_peer_listening_port: 9735,
                 network: BitcoinNetwork::Regtest,
                 storage_dir_path: tmp.path().to_path_buf(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,7 +37,6 @@ use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
 use tokio_util::sync::CancellationToken;
 
 use crate::async_order::{AsyncOrderMessageHandler, AsyncPaymentsPreimageRoot};
-use crate::core_types::{DEFAULT_FINAL_CLTV_EXPIRY_DELTA, HTLC_MIN_MSAT, VIRTUAL_HTLC_MIN_MSAT};
 use crate::ldk::{ChannelIdsMap, Router, VirtualChannelDraftStore, VirtualChannelSessionStore};
 use crate::rgb::{get_rgb_channel_info_optional, RgbLibWalletWrapper};
 use crate::signer::{
@@ -66,7 +65,6 @@ pub(crate) const ELECTRUM_URL_TESTNET4: &str = "ssl://electrum.iriswallet.com:50
 pub(crate) const ELECTRUM_URL_MAINNET: &str = "ssl://electrum.iriswallet.com:50003";
 pub(crate) const PROXY_ENDPOINT_LOCAL: &str = "rpc://127.0.0.1:3000/json-rpc";
 pub(crate) const PROXY_ENDPOINT_PUBLIC: &str = "rpcs://proxy.iriswallet.com/0.2/json-rpc";
-const PASSWORD_MIN_LENGTH: u8 = 8;
 
 pub(crate) struct AppState {
     pub(crate) static_state: Arc<StaticState>,
@@ -126,6 +124,7 @@ impl AppState {
 // `cfg_attr(dead_code)` annotations made the fields look optional; they
 // aren't, only their consumers are gated).
 pub(crate) struct StaticState {
+    pub(crate) config: Arc<crate::config::Config>,
     pub(crate) enable_virtual_channels_v0: bool,
     pub(crate) ldk_peer_listening_port: u16,
     pub(crate) network: BitcoinNetwork,
@@ -164,6 +163,7 @@ impl StaticState {
 }
 
 pub(crate) struct UnlockedAppState {
+    pub(crate) config: Arc<crate::config::Config>,
     pub(crate) channel_manager: Arc<ChannelManager>,
     pub(crate) gossip_source: Arc<crate::gossip::GossipSource>,
     pub(crate) inbound_payments: Arc<Mutex<InboundPaymentInfoStorage>>,
@@ -284,7 +284,7 @@ impl UnlockedAppState {
             })
             .filter_map(|chan_info| chan_info.inbound_htlc_minimum_msat)
             .min()
-            .unwrap_or(HTLC_MIN_MSAT)
+            .unwrap_or(self.config.channels.htlc_min_msat)
     }
 
     pub(crate) fn htlc_min_msat_for_peer(&self, peer: PublicKey) -> u64 {
@@ -293,9 +293,9 @@ impl UnlockedAppState {
                 channel.trusted_no_broadcast && channel.counterparty.node_id == peer
             });
         if has_virtual {
-            VIRTUAL_HTLC_MIN_MSAT
+            self.config.channels.virtual_htlc_min_msat
         } else {
-            HTLC_MIN_MSAT
+            self.config.channels.htlc_min_msat
         }
     }
 
@@ -435,10 +435,10 @@ pub(crate) fn validate_external_signer_init(
     Ok(())
 }
 
-pub(crate) fn check_password_strength(password: String) -> Result<(), APIError> {
-    if password.len() < PASSWORD_MIN_LENGTH as usize {
+pub(crate) fn check_password_strength(password: String, min_length: u8) -> Result<(), APIError> {
+    if password.len() < min_length as usize {
         return Err(APIError::InvalidPassword(format!(
-            "must have at least {PASSWORD_MIN_LENGTH} chars"
+            "must have at least {min_length} chars"
         )));
     }
     Ok(())
@@ -716,6 +716,7 @@ pub(crate) async fn start_daemon(args: &UserArgs) -> Result<Arc<AppState>, AppEr
     }
 
     let static_state = Arc::new(StaticState {
+        config: Arc::new(args.config.clone()),
         enable_virtual_channels_v0: args.enable_virtual_channels_v0,
         ldk_peer_listening_port: args.ldk_peer_listening_port,
         network: args.network,
@@ -781,6 +782,7 @@ pub(crate) fn get_max_local_rgb_amount<'r>(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn get_route(
+    config: &crate::config::Config,
     channel_manager: &crate::ldk::ChannelManager,
     router: &crate::ldk::Router,
     kv_store: &dyn KVStoreSync,
@@ -817,7 +819,7 @@ pub(crate) fn get_route(
             node_id: dest,
             route_hints: hints,
             features: None,
-            final_cltv_expiry_delta: DEFAULT_FINAL_CLTV_EXPIRY_DELTA,
+            final_cltv_expiry_delta: config.payments.final_cltv_expiry_delta,
         },
         expiry_time: None,
         max_total_cltv_expiry_delta: DEFAULT_MAX_TOTAL_CLTV_EXPIRY_DELTA,
@@ -831,7 +833,7 @@ pub(crate) fn get_route(
         &start,
         &RouteParameters {
             payment_params,
-            final_value_msat: final_value_msat.unwrap_or(HTLC_MIN_MSAT),
+            final_value_msat: final_value_msat.unwrap_or(config.channels.htlc_min_msat),
             max_total_routing_fee_msat: None,
             rgb_payment,
         },

--- a/src/vss_kv_store.rs
+++ b/src/vss_kv_store.rs
@@ -118,16 +118,32 @@ impl VssKvStore {
     /// * `store_id` - Keyspace identifier (derived from node pubkey)
     /// * `signing_key` - Secret key used both for sigs-auth and for deriving
     ///   the per-value encryption key via HKDF-SHA256.
+    #[cfg(test)]
     pub fn new(
         server_url: String,
         store_id: String,
         signing_key: SecretKey,
     ) -> Result<Self, io::Error> {
+        Self::new_with_retry(
+            server_url,
+            store_id,
+            signing_key,
+            &crate::config::VssSection::default(),
+        )
+    }
+
+    pub fn new_with_retry(
+        server_url: String,
+        store_id: String,
+        signing_key: SecretKey,
+        retry: &crate::config::VssSection,
+    ) -> Result<Self, io::Error> {
         let auth_provider = SigsAuthProvider::new(signing_key, HashMap::new());
 
-        let retry_policy = ExponentialBackoffRetryPolicy::new(Duration::from_millis(100))
-            .with_max_attempts(3)
-            .with_max_total_delay(Duration::from_secs(5));
+        let retry_policy =
+            ExponentialBackoffRetryPolicy::new(Duration::from_millis(retry.retry_backoff_ms))
+                .with_max_attempts(retry.retry_max_attempts)
+                .with_max_total_delay(Duration::from_secs(retry.retry_max_total_delay_secs));
 
         let client = VssClient::new_with_headers(server_url, retry_policy, Arc::new(auth_provider));
 


### PR DESCRIPTION
## What

The node can now be configured through a TOML file instead of hardcoded constants. The file is loaded from `<storage_directory_path>/config.toml` when it exists, or from an explicit path via the new `--config <path>` CLI option (an explicit path that doesn't exist is a startup error). All keys are optional and documented with their defaults in the new `sample-config.toml` at the repo root; the README points to it.

Resolution order, lowest to highest precedence:

1. built-in defaults (identical to the previously hardcoded values)
2. config file
3. explicit CLI options (only options actually passed on the command line override the file)
4. `/unlock` body params, for the values that were already unlock-time overrides (indexer URL, proxy endpoint, announce alias/addresses, chain credentials)

With no config file and no new flags, behavior matches the previous hardcoded values — a dedicated test pins every default — with two deliberate retunes: `utxo_size_sat` 32000 → 20000 (lnd's `MinChanFundingSize`) and `min_channel_confirmations` 6 → 3. (`htlc_min_msat` stays at 3000000: RGB assets ride the HTLC output, so the floor must clear the commitment dust limit plus HTLC-tx fees or asset payments get dust-trimmed and cannot settle.) The embedded SDK entry point (`NodeHandle`) keeps using the defaults, and the SDK's duplicated `SDK_*` constants were removed — SDK endpoints now read the same shared config, so node and SDK can no longer drift.

The config is strict: unknown sections or keys, wrong types, and out-of-range values abort startup with an error naming the offending key (e.g. `Invalid configuration: rgb.fee_rate_sat_vb must be greater than 0`).

## Migrated settings

### `[rgb]` — RGB economics

| Key | Previously | Default | Validation |
|---|---|---|---|
| `fee_rate_sat_vb` | `FEE_RATE` const | 7 | > 0 |
| `utxo_size_sat` | `UTXO_SIZE_SAT` const | 20000 (lnd's `MinChanFundingSize`) | > 0 |
| `utxo_num` | `UTXO_NUM` const | 4 | > 0 |
| `min_channel_confirmations` | `MIN_CHANNEL_CONFIRMATIONS` const | 3 | > 0 |

### `[channels]` — channel policy

| Key | Previously | Default | Validation |
|---|---|---|---|
| `htlc_min_msat` | `HTLC_MIN_MSAT` const | 3000000 (must clear HTLC dust) | > 0; derived RGB channel minimum must not exceed `open_max_sat` |
| `virtual_htlc_min_msat` | `VIRTUAL_HTLC_MIN_MSAT` const | 1000 | > 0 |
| `dust_limit_msat` | `DUST_LIMIT_MSAT` const | 546000 | > 0 |
| `open_min_sat` | `OPENCHANNEL_MIN_SAT` const | 5506 | > 0, ≤ `open_max_sat` |
| `open_max_sat` | `OPENCHANNEL_MAX_SAT` const | 16777215 | ≤ 16777215 (protocol cap) |
| `open_min_rgb_amount` | `OPENCHANNEL_MIN_RGB_AMT` const | 1 | > 0 |
| `their_to_self_delay` | inline `2016` in the open-channel handshake config | 2016 | 1–2016 (lnd compatibility ceiling) |
| `cltv_expiry_delta` | inherited LDK default | 72 | ≥ 48 (BOLT-2 / LDK minimum) |
| `our_to_self_delay` | inherited LDK default | 144 | 144–2016 (LDK enforces 144 as floor) |
| `forwarding_fee_base_msat` | inherited LDK default | 1000 | — |
| `forwarding_fee_proportional_millionths` | inherited LDK default | 0 | — |
| `max_dust_htlc_exposure_multiplier` / `..._fixed_msat` | inherited LDK default | multiplier 10000 | > 0; the two keys are mutually exclusive |
| `max_inbound_htlc_value_in_flight_percent` | inherited LDK default | 10 | 1–100 |
| `our_max_accepted_htlcs` | inherited LDK default | 50 | 1–483 (BOLT-2 cap, LDK clamps silently above it) |
| `max_minimum_depth` | inherited LDK default | 144 | > 0 |
| `enable_virtual_channels_v0` | CLI-only flag | false | — |
| `virtual_peer_pubkeys` | CLI-only flag | [] | valid compressed pubkeys |

The RGB channel capacity minimum (`OPENRGBCHANNEL_MIN_SAT`) is no longer an independent constant: it is derived from `htlc_min_msat` (ten minimum HTLCs plus margin) and validated against `open_max_sat`.

The "inherited LDK default" rows never appeared as constants in this codebase — they arrived silently through `ChannelConfig::default()` / `ChannelHandshakeConfig::default()` when building the per-open and node-wide `UserConfig`. Their config defaults are sourced from LDK at compile time (not copied numbers), so they keep tracking the fork. They apply to new channels; existing channels keep their negotiated values. Other LDK knobs stay unexposed on purpose — the policy is to expose on demand, since every exposed knob is support surface.

### `[payments]`

| Key | Previously | Default | Validation |
|---|---|---|---|
| `final_cltv_expiry_delta` | `DEFAULT_FINAL_CLTV_EXPIRY_DELTA` const | 14 | > 0 |
| `retry_timeout_secs` | inline `Retry::Timeout(10s)` at every payment call site | 10 | > 0 |
| `max_swap_fee_msat` | `MAX_SWAP_FEE_MSAT` const | 3000000 | > 0 |

### `[chain]` — backend defaults and timing

| Key | Previously | Default | Validation |
|---|---|---|---|
| `indexer_url` | per-network `ELECTRUM_URL_*` consts (public iriswallet servers) | unset → per-network default | checked against the network at unlock |
| `proxy_endpoint` | `PROXY_ENDPOINT_LOCAL/PUBLIC` consts | unset → per-network default | proxy reachability checked at unlock |
| `indexer_timeout_secs` | inline `10` in the esplora client | 10 | > 0 |
| `fee_refresh_interval_secs` | inline `60` duplicated in the esplora, electrum and bitcoind fee pollers | 60 | > 0 |

`indexer_url` and `proxy_endpoint` act as defaults for the `/unlock` body: a value in the unlock request still wins, so existing clients are unaffected and orchestrated deployments can keep overriding per session.

### `[gossip]` — rapid gossip sync

| Key | Previously | Default | Validation |
|---|---|---|---|
| `rgs_sync_interval_secs` | `RGS_SYNC_INTERVAL` const | 3600 | > 0 |
| `rgs_snapshot_max_size_mb` | `RGS_SNAPSHOT_MAX_SIZE` const | 15 | > 0 |
| `rgs_connect_timeout_secs` | `RGS_CONNECT_TIMEOUT_SECS` const | 5 | > 0 |
| `rgs_sync_timeout_secs` | `RGS_SYNC_TIMEOUT_SECS` const | 60 | > 0 |

### `[node]`

| Key | Previously | Default | Validation |
|---|---|---|---|
| `network` | CLI-only | Testnet | valid network name |
| `daemon_listening_port` | CLI-only | 3001 | ≠ peer port, availability checked |
| `ldk_peer_listening_port` | CLI-only | 9735 | ≠ daemon port, availability checked |
| `announce_alias` | `/unlock`-only | unset | ≤ 32 bytes |
| `announce_addresses` | `/unlock`-only | [] | parsed as socket addresses at unlock |
| `reuse_addresses` | CLI-only flag | false | — |
| `peer_reconnect_interval_secs` | inline `1` | 1 | > 0 |
| `announce_initial_delay_secs` | inline `60` | 60 | 0 allowed (announce immediately) |
| `announce_refresh_interval_secs` | inline `3600` | 3600 | > 0 |

### `[lsp]`

| Key | Previously | Default | Validation |
|---|---|---|---|
| `base_url` / `bearer_token` | CLI-only | unset | — |
| `order_response_timeout_secs` | `ASYNC_ORDER_RESPONSE_TIMEOUT_SECS` const | 30 | > 0 |
| `request_timeout_secs` | `ASYNC_ORDER_LSP_REQUEST_TIMEOUT_SECS` const | 25 | > 0; keep above the LSP's own 15s HTTP timeout |

### `[vss]`

| Key | Previously | Default | Validation |
|---|---|---|---|
| `url` / `allow_http` / `allow_empty_restore` | CLI-only | unset / false / false | https required for non-loopback unless `allow_http` |
| `retry_backoff_ms` | inline `100` | 100 | > 0 |
| `retry_max_attempts` | inline `3` | 3 | > 0 |
| `retry_max_total_delay_secs` | inline `5` | 5 | > 0 |

### `[auth]` and `[api]`

| Key | Previously | Default | Validation |
|---|---|---|---|
| `disable_authentication` / `root_public_key` | CLI-only | false / unset | exactly one of the two must be effective |
| `password_min_length` | `PASSWORD_MIN_LENGTH` const | 8 | > 0 |
| `max_media_upload_size_mb` | CLI-only | 5 | — |
| `default_page_size` | `DEFAULT_MAX_PAYMENTS/TRANSFERS/UNSPENTS/TRANSACTIONS` consts | 100 | > 0 |

## Deliberately not configurable

- **Wallet password** — never in a file; it decrypts the mnemonic and stays in `/init`/`/unlock`.
- **Protocol and crypto invariants** — backup framing, VSS encryption framing, BIP32 derivation indices, `STATIC_BLINDING`, commitment numbers: wire/consensus constants, not knobs.
- **SQLite pool sizing** — the single-connection pool is a correctness requirement, not tuning.

## Testing

- 48 unit tests on the config layer: every default pinned to its historical value, section-by-section parsing, unknown key/section/type rejection, every validation bound, and CLI-over-file-over-default precedence (including bool flags, network parsing, port collision, VSS URL rules and pubkey parsing).
- Manual verification on regtest: file-set port and auth honored, CLI override wins, invalid value and unknown key abort startup with the expected messages.
- `clippy --all-targets -D warnings` clean; builds clean with `uniffi,vls,vss`.
