### PR TITLE
feat: expose Lightning message verification

### DIFF
--- a/bindings/c-ffi/Cargo.lock
+++ b/bindings/c-ffi/Cargo.lock
@@ -5124,7 +5124,7 @@ dependencies = [
 [[package]]
 name = "signer-external"
 version = "0.1.0-alpha"
-source = "git+https://github.com/UTEXO-Protocol/rln-external-signer.git?branch=main#1efe6a61fc18af264188f99ac28482e74a2c0964"
+source = "git+https://github.com/UTEXO-Protocol/rln-external-signer.git?branch=main#594d8c08e812aa9d237a177391ea6f56b7c58e8f"
 dependencies = [
  "base64 0.22.1",
  "bitcoin",

--- a/bindings/c-ffi/rln.h
+++ b/bindings/c-ffi/rln.h
@@ -242,3 +242,7 @@ struct CResultString rln_taker(const struct COpaqueStruct *node, const char *req
 struct CResultString rln_uniffi_healthcheck(void);
 
 struct CResultString rln_uniffi_is_initialized(void);
+
+struct CResultString rln_verify_message(const struct COpaqueStruct *node,
+                                        const char *message,
+                                        const char *signature);

--- a/bindings/c-ffi/rln.hpp
+++ b/bindings/c-ffi/rln.hpp
@@ -217,4 +217,8 @@ CResultString rln_uniffi_healthcheck();
 
 CResultString rln_uniffi_is_initialized();
 
+CResultString rln_verify_message(const COpaqueStruct *node,
+                                 const char *message,
+                                 const char *signature);
+
 }  // extern "C"

--- a/bindings/c-ffi/src/api.rs
+++ b/bindings/c-ffi/src/api.rs
@@ -531,6 +531,16 @@ pub(crate) fn sign_message(
     json(JsonSignMessageResponse::from(resp))
 }
 
+pub(crate) fn verify_message(
+    node: &COpaqueStruct,
+    message: *const c_char,
+    signature: *const c_char,
+) -> Result<String, Error> {
+    let node = require_handle(node)?;
+    let resp = node.verify_message(ptr_to_string(message), ptr_to_string(signature))?;
+    json(JsonVerifyMessageResponse::from(resp))
+}
+
 pub(crate) fn estimate_fee(node: &COpaqueStruct, blocks: u16) -> Result<String, Error> {
     let node = require_handle(node)?;
     let resp = node.estimate_fee(blocks)?;

--- a/bindings/c-ffi/src/json_types.rs
+++ b/bindings/c-ffi/src/json_types.rs
@@ -33,7 +33,7 @@ use rgb_lightning_node::{
     AssetRecipients, RgbRecipient,
     SignMessageResponse, Swap, SwapList, SwapStatus, Token, TokenLight, Transaction,
     TransactionType, Transfer, TransferTransportEndpoint, TransportEndpoint, Txid, Unspent, Utxo,
-    WitnessData,
+    VerifyMessageResponse, WitnessData,
 };
 use serde::{Deserialize, Serialize};
 
@@ -1590,6 +1590,19 @@ impl From<SignMessageResponse> for JsonSignMessageResponse {
     fn from(s: SignMessageResponse) -> Self {
         JsonSignMessageResponse {
             signed_message: s.signed_message,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct JsonVerifyMessageResponse {
+    pub valid: bool,
+}
+
+impl From<VerifyMessageResponse> for JsonVerifyMessageResponse {
+    fn from(response: VerifyMessageResponse) -> Self {
+        JsonVerifyMessageResponse {
+            valid: response.valid,
         }
     }
 }

--- a/bindings/c-ffi/src/lib.rs
+++ b/bindings/c-ffi/src/lib.rs
@@ -66,6 +66,9 @@ pub struct CResultString {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn free_sdk_node(obj: COpaqueStruct) {
+    if obj.ptr.is_null() {
+        return;
+    }
     unsafe {
         let _ = Box::from_raw(obj.ptr as *mut SdkNode);
     }
@@ -471,6 +474,18 @@ pub extern "C" fn rln_sign_message(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn rln_verify_message(
+    node: &COpaqueStruct,
+    message: *const c_char,
+    signature: *const c_char,
+) -> CResultString {
+    ffi_call!(
+        "rln_verify_message",
+        api::verify_message(node, message, signature)
+    )
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn rln_estimate_fee(node: &COpaqueStruct, blocks: u16) -> CResultString {
     ffi_call!("rln_estimate_fee", api::estimate_fee(node, blocks))
 }
@@ -614,8 +629,22 @@ pub extern "C" fn rln_sdk_shutdown() -> CResultString {
 /// attach / init / unlock succeeds: RLN holds its own `Arc` clone.
 #[unsafe(no_mangle)]
 pub extern "C" fn free_native_external_signer(obj: COpaqueStruct) {
+    if obj.ptr.is_null() {
+        return;
+    }
     unsafe {
         let _ = Box::from_raw(obj.ptr as *mut Arc<NativeExternalSigner>);
+    }
+}
+
+#[cfg(test)]
+mod free_tests {
+    use super::*;
+
+    #[test]
+    fn free_functions_accept_null_handles() {
+        free_sdk_node(COpaqueStruct::null());
+        free_native_external_signer(COpaqueStruct::null());
     }
 }
 

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -37,6 +37,8 @@ interface SdkNode {
     [Throws=RlnError]
     SignMessageResponse sign_message(string message);
     [Throws=RlnError]
+    VerifyMessageResponse verify_message(string message, string signature);
+    [Throws=RlnError]
     string init(string password, string? mnemonic);
     [Throws=RlnError]
     void init_with_external_signer(SdkExternalSignerBootstrap bootstrap);
@@ -196,6 +198,10 @@ dictionary BtcBalanceInfo {
 
 dictionary SignMessageResponse {
     string signed_message;
+};
+
+dictionary VerifyMessageResponse {
+    boolean valid;
 };
 
 dictionary EstimateFeeResponse {

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -58,6 +58,7 @@ use lightning::util::config::{
     ChannelConfig, ChannelHandshakeConfig, ChannelHandshakeLimits, UserConfig,
 };
 use lightning::util::errors::APIError as LDKAPIError;
+use lightning::util::message_signing;
 use lightning::util::IS_SWAP_SCID;
 use lightning::{
     onion_message::messenger::Destination, onion_message::messenger::MessageSendInstructions,
@@ -1372,6 +1373,54 @@ pub(crate) async fn sign_message(
     let trimmed = message.trim();
     let signed_message = unlocked_state.sign_node_message(trimmed.as_bytes())?;
     Ok(SignMessageData { signed_message })
+}
+
+pub(crate) async fn verify_message(
+    state: Arc<AppState>,
+    message: String,
+    signature: String,
+) -> Result<bool, APIError> {
+    let node_id = message_verification_node_id(&state).await?;
+
+    Ok(verify_message_signature(
+        message.trim().as_bytes(),
+        signature.trim(),
+        &node_id,
+    ))
+}
+
+async fn message_verification_node_id(state: &Arc<AppState>) -> Result<PublicKey, APIError> {
+    check_changing_state(state)?;
+
+    {
+        let unlocked_state = state.get_unlocked_app_state().await;
+        if let Some(unlocked_state) = unlocked_state.as_ref() {
+            return Ok(unlocked_state.runtime_node_id());
+        }
+    }
+
+    // Verification is a public-key operation. In external-signer mode the
+    // persisted key source is the authoritative account identity even while
+    // the node is locked. Prefer it over a newly attached signer so seed
+    // migration/fallback cannot temporarily verify against the wrong node id.
+    let persisted_node_id = read_key_source_file(&state.static_state.storage_dir_path)
+        .map_err(|e| APIError::ExternalSignerProtocolError(e.to_string()))?
+        .map(|key_source| key_source.node_id);
+    let attached_node_id = {
+        let attachment = state.get_attached_external_signer();
+        attachment
+            .as_ref()
+            .map(|attachment| attachment.bootstrap.identity.node_id.clone())
+    };
+    let node_id = persisted_node_id
+        .or(attached_node_id)
+        .ok_or(APIError::LockedNode)?;
+
+    PublicKey::from_str(&node_id).map_err(|_| APIError::InvalidPubkey)
+}
+
+fn verify_message_signature(message: &[u8], signature: &str, node_id: &PublicKey) -> bool {
+    message_signing::verify(message, signature, node_id)
 }
 
 pub(crate) async fn get_channel_id(
@@ -4327,7 +4376,9 @@ mod tests {
         WalletInputMetadata,
     };
     use crate::signer::vls_adapter::ExternalSignerBackend;
-    use crate::signer::{read_key_source_file, RlnSignerError, SignerIdentity};
+    use crate::signer::{
+        read_key_source_file, write_key_source_file, KeySourceFile, RlnSignerError, SignerIdentity,
+    };
     use crate::utils::{AppState, StaticState};
     use rgb_lib::BitcoinNetwork;
     use rln_migration::{Migrator, MigratorTrait};
@@ -4336,6 +4387,66 @@ mod tests {
     use std::sync::{Arc, Mutex, RwLock};
     use tokio::sync::Mutex as TokioMutex;
     use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn verify_message_signature_accepts_known_lightning_vector_and_rejects_tampering() {
+        let message = b"is this compatible?";
+        let signature = "rbgfioj114mh48d8egqx8o9qxqw4fmhe8jbeeabdioxnjk8z3t1ma1hu1fiswpakgucwwzwo6ofycffbsqusqdimugbh41n1g698hr9t";
+        let node_id = PublicKey::from_str(
+            "02b80cabdf82638aac86948e4c06e82064f547768dcef977677b9ea931ea75bab5",
+        )
+        .expect("valid node id");
+
+        assert!(verify_message_signature(message, signature, &node_id));
+        assert!(!verify_message_signature(b"tampered", signature, &node_id));
+        assert!(!verify_message_signature(message, "invalid", &node_id));
+    }
+
+    #[tokio::test]
+    async fn verify_message_uses_persisted_external_identity_while_locked() {
+        let state = mock_locked_state();
+        let storage_dir = state.static_state.storage_dir_path.clone();
+        let mut bootstrap = sample_bootstrap();
+        bootstrap.identity.node_id =
+            "02b80cabdf82638aac86948e4c06e82064f547768dcef977677b9ea931ea75bab5".to_string();
+        write_key_source_file(
+            &state.static_state.storage_dir_path,
+            &KeySourceFile::from_bootstrap(&bootstrap),
+        )
+        .expect("persist key source");
+
+        let valid = verify_message(
+            state,
+            "is this compatible?".to_string(),
+            "rbgfioj114mh48d8egqx8o9qxqw4fmhe8jbeeabdioxnjk8z3t1ma1hu1fiswpakgucwwzwo6ofycffbsqusqdimugbh41n1g698hr9t".to_string(),
+        )
+        .await
+        .expect("locked public-key verification");
+
+        assert!(valid);
+        std::fs::remove_dir_all(storage_dir).expect("remove temp storage dir");
+    }
+
+    #[tokio::test]
+    async fn verify_message_uses_attached_external_identity_before_init() {
+        let state = mock_locked_state();
+        let storage_dir = state.static_state.storage_dir_path.clone();
+        let mut bootstrap = sample_bootstrap();
+        bootstrap.identity.node_id =
+            "02b80cabdf82638aac86948e4c06e82064f547768dcef977677b9ea931ea75bab5".to_string();
+        attach_test_external_signer(&state, bootstrap).expect("attach external signer");
+
+        let valid = verify_message(
+            state,
+            "is this compatible?".to_string(),
+            "rbgfioj114mh48d8egqx8o9qxqw4fmhe8jbeeabdioxnjk8z3t1ma1hu1fiswpakgucwwzwo6ofycffbsqusqdimugbh41n1g698hr9t".to_string(),
+        )
+        .await
+        .expect("attached public-key verification");
+
+        assert!(valid);
+        std::fs::remove_dir_all(storage_dir).expect("remove temp storage dir");
+    }
 
     fn mock_locked_state() -> Arc<AppState> {
         let unique = format!(

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -1066,6 +1066,16 @@ impl SdkNode {
         })
     }
 
+    pub fn verify_message(
+        &self,
+        message: String,
+        signature: String,
+    ) -> Result<VerifyMessageResponse, RlnError> {
+        let state = self.handle.app_state();
+        let valid = block_on_sdk(sdk::verify_message(state, message, signature))?;
+        Ok(VerifyMessageResponse { valid })
+    }
+
     pub fn estimate_fee(&self, blocks: u16) -> Result<EstimateFeeResponse, RlnError> {
         let state = self.handle.app_state();
         let resp = block_on_sdk(sdk::estimate_fee(state, blocks))?;
@@ -1645,6 +1655,14 @@ pub fn sdk_btc_balance(skip_sync: bool) -> Result<BtcBalanceInfo, RlnError> {
 pub fn sdk_sign_message(message: String) -> Result<SignMessageResponse, RlnError> {
     let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
     SdkNode { handle }.sign_message(message)
+}
+
+pub fn sdk_verify_message(
+    message: String,
+    signature: String,
+) -> Result<VerifyMessageResponse, RlnError> {
+    let handle = NodeHandle::from_app_state(get_uniffi_app_state()?);
+    SdkNode { handle }.verify_message(message, signature)
 }
 
 pub fn sdk_estimate_fee(blocks: u16) -> Result<EstimateFeeResponse, RlnError> {

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -106,6 +106,10 @@ pub struct SignMessageResponse {
     pub signed_message: String,
 }
 
+pub struct VerifyMessageResponse {
+    pub valid: bool,
+}
+
 pub struct EstimateFeeResponse {
     pub fee_rate: f64,
 }


### PR DESCRIPTION
## Summary

- add canonical Lightning signed-message verification to the SDK, UniFFI object/global surfaces, and C-FFI JSON ABI
- resolve the account node identity from the unlocked runtime, persisted external-signer key source while locked, or an attached signer before initialization
- prefer the persisted identity during seed migration so verification cannot temporarily target the wrong node id
- make C-FFI opaque-handle free functions null-safe after the Node binding canary exposed a double-destroy crash
- align the C-FFI lockfile's `signer-external` revision with the root lockfile

## Why

The current WDK account contract requires `verify(message, signature)` on concrete read-only accounts. RLN already signs with Lightning's standard recoverable zbase32 format, but did not expose the matching verifier to native consumers.

Malformed or tampered signatures return `valid: false`. A locked node with no persisted or attached public identity still returns the existing locked-node error rather than guessing an identity.

## Validation

- `cargo test --lib --features vls` (116 passed)
- `cargo test --locked` in `bindings/c-ffi` (1 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- release C-FFI static library built and consumed successfully by both Bare and Node addon canaries

## Dependency order

This is the foundational PR. The Bare and Node binding PRs depend on a released RLN tag containing this C-FFI symbol; the WDK read-only account depends on those binding releases.
