### PR TITLE
fix: use PAT for PR creation in bump-rgb-lib workflow

### DIFF
--- a/.github/workflows/bump-rgb-lib.yml
+++ b/.github/workflows/bump-rgb-lib.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RGB_LIB_RLN_PAT }}
         run: |
           gh pr create \
             --title "chore: bump rgb-lib to ${{ steps.version.outputs.version }}" \
@@ -62,6 +62,6 @@ jobs:
 
       - name: Dispatch CI on bump branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RGB_LIB_RLN_PAT }}
         run: |
           gh workflow run test.yaml --ref "${{ steps.version.outputs.branch }}"


### PR DESCRIPTION
## Summary
- Replace `secrets.GITHUB_TOKEN` with `secrets.RGB_LIB_RLN_PAT` in both `Create pull request` and `Dispatch CI on bump branch` steps
- `GITHUB_TOKEN` fails with `GitHub Actions is not permitted to create or approve pull requests` due to org-level restriction

## Test plan
- [ ] Trigger `bump-rgb-lib` workflow via `workflow_dispatch` with a test version after merging
- [ ] Verify PR is created successfully on `dev` branch