### PR TITLE
retry transient VSS failures in monitor persistence instead of stalling

### DIFF
--- a/src/async_kv_store.rs
+++ b/src/async_kv_store.rs
@@ -1,23 +1,38 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use bitcoin::io;
 use lightning::util::async_poll::AsyncResult;
 use lightning::util::persist::{KVStore, KVStoreSync};
 
 use crate::kv_store::SeaOrmKvStore;
-use crate::vss_kv_store::{vss_key, VssKvStore};
+use crate::vss_kv_store::{is_transient_io_error, vss_key, VssKvStore};
+
+/// Initial delay between VSS retry attempts during an outage.
+const RETRY_INITIAL_DELAY: Duration = Duration::from_millis(500);
+
+/// Cap for the exponential retry backoff.
+const RETRY_MAX_DELAY: Duration = Duration::from_secs(10);
 
 /// Remote-first async `KVStore`: a write resolves only after VSS durably stores
 /// it, then mirrors to the local store best-effort; a VSS failure fails the write
-/// (no silent local-only `Ok`). The local mirror goes through the synchronous
-/// `KVStoreSync` path (the node's dedicated DB runtime) so it never re-enters the
-/// calling runtime. Per-key writes/removes are serialized to preserve ordering.
-/// `remote == None` degrades to local-only (VSS not configured).
+/// (no silent local-only `Ok`). Transient VSS failures (outage) are retried with
+/// backoff until the server recovers — the pending monitor update keeps the
+/// channel paused meanwhile — so an outage never permanently wedges a channel.
+/// Permanent errors (auth, conflict) still fail the write. The local mirror goes
+/// through the synchronous `KVStoreSync` path (the node's dedicated DB runtime)
+/// so it never re-enters the calling runtime. Per-key writes/removes are
+/// serialized to preserve ordering. `remote == None` degrades to local-only
+/// (VSS not configured).
 pub struct RemoteFirstKvStore {
     local: Arc<SeaOrmKvStore>,
     remote: Option<Arc<VssKvStore>>,
     key_locks: Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    /// Flipped by [`Self::stop`] at node teardown: pending retries must abort
+    /// before the VSS fence is released, or a write delayed by an outage could
+    /// land after another instance owns the store.
+    shutdown: tokio::sync::watch::Sender<bool>,
 }
 
 impl RemoteFirstKvStore {
@@ -26,6 +41,7 @@ impl RemoteFirstKvStore {
             local,
             remote,
             key_locks: Mutex::new(HashMap::new()),
+            shutdown: tokio::sync::watch::channel(false).0,
         }
     }
 
@@ -36,6 +52,57 @@ impl RemoteFirstKvStore {
             .entry(vss_key.to_string())
             .or_default()
             .clone()
+    }
+
+    /// Aborts all pending VSS retry loops. Call at node teardown, before the
+    /// VSS fence is released.
+    pub fn stop(&self) {
+        let _ = self.shutdown.send(true);
+    }
+}
+
+/// Runs `op` until it succeeds, retrying transient VSS failures with capped
+/// exponential backoff. Returns the last error on a permanent failure or once
+/// `shutdown` flips to true.
+async fn retry_transient<F, Fut>(
+    vss_key: &str,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+    op: F,
+) -> Result<(), io::Error>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<(), io::Error>>,
+{
+    let mut delay = RETRY_INITIAL_DELAY;
+    let mut attempts = 0u64;
+    loop {
+        match op().await {
+            Ok(()) => {
+                if attempts > 0 {
+                    tracing::info!(vss_key, attempts, "VSS write recovered after outage");
+                }
+                return Ok(());
+            }
+            Err(e) if is_transient_io_error(&e) => {
+                attempts += 1;
+                tracing::warn!(
+                    vss_key,
+                    attempts,
+                    retry_in = ?delay,
+                    error = %e,
+                    "VSS unreachable; persistence pending, retrying"
+                );
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = shutdown.wait_for(|stopped| *stopped) => {
+                        tracing::warn!(vss_key, "node stopping; abandoning VSS retry");
+                        return Err(e);
+                    }
+                }
+                delay = (delay * 2).min(RETRY_MAX_DELAY);
+            }
+            Err(e) => return Err(e),
+        }
     }
 }
 
@@ -75,7 +142,9 @@ impl KVStore for RemoteFirstKvStore {
     ) -> AsyncResult<'static, (), io::Error> {
         let local = Arc::clone(&self.local);
         let remote = self.remote.clone();
-        let lock = self.key_lock(&vss_key(primary_namespace, secondary_namespace, key));
+        let vss_key_str = vss_key(primary_namespace, secondary_namespace, key);
+        let lock = self.key_lock(&vss_key_str);
+        let shutdown = self.shutdown.subscribe();
         let (primary, secondary, key) = (
             primary_namespace.to_string(),
             secondary_namespace.to_string(),
@@ -85,9 +154,10 @@ impl KVStore for RemoteFirstKvStore {
             let _guard = lock.lock().await;
             if let Some(remote) = &remote {
                 // VSS first (durable before ack), then mirror locally best-effort.
-                remote
-                    .write_async(&primary, &secondary, &key, buf.clone())
-                    .await?;
+                retry_transient(&vss_key_str, shutdown, || {
+                    remote.write_async(&primary, &secondary, &key, buf.clone())
+                })
+                .await?;
                 if let Err(e) = KVStoreSync::write(&*local, &primary, &secondary, &key, buf) {
                     tracing::warn!(
                         primary = %primary,
@@ -113,7 +183,9 @@ impl KVStore for RemoteFirstKvStore {
     ) -> AsyncResult<'static, (), io::Error> {
         let local = Arc::clone(&self.local);
         let remote = self.remote.clone();
-        let lock = self.key_lock(&vss_key(primary_namespace, secondary_namespace, key));
+        let vss_key_str = vss_key(primary_namespace, secondary_namespace, key);
+        let lock = self.key_lock(&vss_key_str);
+        let shutdown = self.shutdown.subscribe();
         let (primary, secondary, key) = (
             primary_namespace.to_string(),
             secondary_namespace.to_string(),
@@ -122,7 +194,10 @@ impl KVStore for RemoteFirstKvStore {
         Box::pin(async move {
             let _guard = lock.lock().await;
             if let Some(remote) = &remote {
-                remote.remove_async(&primary, &secondary, &key).await?;
+                retry_transient(&vss_key_str, shutdown, || {
+                    remote.remove_async(&primary, &secondary, &key)
+                })
+                .await?;
                 if let Err(e) = KVStoreSync::remove(&*local, &primary, &secondary, &key, false) {
                     tracing::warn!(
                         primary = %primary,

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -4931,6 +4931,8 @@ pub(crate) async fn start_ldk(
         async_order_handler,
         async_payments_preimage_root,
         kv_store: Arc::clone(&kv_store),
+        #[cfg(feature = "vss")]
+        monitor_kv_store: Arc::clone(&monitor_kv_store),
         bump_tx_event_handler,
         rgb_wallet_wrapper,
         maker_swaps,
@@ -5208,12 +5210,21 @@ pub(crate) async fn stop_ldk(app_state: Arc<AppState>) {
     // /vssclearfence. Hard kills still leave the fence behind by design.
     #[cfg(feature = "vss")]
     {
-        let kv_store = app_state
+        let stores = app_state
             .get_unlocked_app_state()
             .await
             .as_ref()
-            .map(|unlocked| Arc::clone(&unlocked.kv_store));
-        if let Some(kv_store) = kv_store {
+            .map(|unlocked| {
+                (
+                    Arc::clone(&unlocked.kv_store),
+                    Arc::clone(&unlocked.monitor_kv_store),
+                )
+            });
+        if let Some((kv_store, monitor_kv_store)) = stores {
+            // Abort outage-pending monitor writes before giving up the fence:
+            // a retry landing after another instance owns the store would
+            // corrupt its state.
+            monitor_kv_store.stop();
             match tokio::task::spawn_blocking(move || kv_store.release_vss_fence_if_owned()).await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2985,3 +2985,5 @@ mod vanilla_payment_on_rgb_channel;
 mod virtual_channels;
 #[cfg(feature = "vss")]
 mod vss;
+#[cfg(feature = "vss")]
+mod vss_offline_force_close;

--- a/src/test/remote_first_kv.rs
+++ b/src/test/remote_first_kv.rs
@@ -92,10 +92,12 @@ mod tests {
         assert_eq!(store.read(ns, sub, key).await.expect("read"), data);
     }
 
-    /// If the VSS write fails, the whole write must resolve `Err` — never a
-    /// silent local-only `Ok`. The local store must be left untouched.
+    /// While VSS is unreachable a write must neither resolve nor mirror
+    /// locally — never a silent local-only `Ok`. It keeps retrying until
+    /// [`RemoteFirstKvStore::stop`] aborts it at node teardown, at which point
+    /// it resolves `Err` with the local store still untouched.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn remote_first_write_fails_when_vss_unreachable() {
+    async fn remote_first_write_pends_when_vss_unreachable() {
         let (signing_key, store_id) = generate_test_keys();
         let local = Arc::new(SeaOrmKvStore::from_connection(create_test_sqlite()));
         // Point the remote at a closed port so every VSS write errors.
@@ -107,17 +109,33 @@ mod tests {
 
         let (ns, sub, key) = ("monitors", "", "chan1");
 
-        let err = store
-            .write(ns, sub, key, b"should-not-persist".to_vec())
-            .await
-            .expect_err("write must fail when VSS is unreachable");
-        eprintln!("expected write failure: {err}");
+        let mut write = std::pin::pin!(store.write(ns, sub, key, b"should-not-persist".to_vec()));
+        assert!(
+            tokio::time::timeout(Duration::from_secs(5), write.as_mut())
+                .await
+                .is_err(),
+            "write must stay pending (retrying) while VSS is unreachable"
+        );
 
-        // No silent local-only write: local must still be empty for this key.
+        // No silent local-only write while the retry loop runs.
         let local_read = KVStoreSync::read(&*local, ns, sub, key);
         assert!(
             matches!(&local_read, Err(e) if e.kind() == bitcoin::io::ErrorKind::NotFound),
-            "local store must not contain the key after a failed remote-first write, got {local_read:?}"
+            "local store must not contain the key while the VSS write is pending, got {local_read:?}"
+        );
+
+        // Node teardown aborts the retry loop and the write resolves Err.
+        store.stop();
+        let err = tokio::time::timeout(Duration::from_secs(15), write)
+            .await
+            .expect("write must resolve once stop() aborts the retries")
+            .expect_err("write must fail once retries are aborted");
+        eprintln!("expected write failure: {err}");
+
+        let local_read = KVStoreSync::read(&*local, ns, sub, key);
+        assert!(
+            matches!(&local_read, Err(e) if e.kind() == bitcoin::io::ErrorKind::NotFound),
+            "local store must not contain the key after an aborted remote-first write, got {local_read:?}"
         );
     }
 }

--- a/src/test/vss_offline_force_close.rs
+++ b/src/test/vss_offline_force_close.rs
@@ -1,0 +1,328 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/vss_offline_force_close/";
+const VSS_SERVER_ADDR: &str = "127.0.0.1:8081";
+
+/// TCP proxy in front of the VSS server that can go offline and back online,
+/// simulating a VSS outage for a single node without touching the shared
+/// service. Offline: established connections are cut and new ones are closed
+/// on accept.
+struct VssProxy {
+    port: u16,
+    online: tokio::sync::watch::Sender<bool>,
+}
+
+impl VssProxy {
+    // The proxy gets a dedicated thread + runtime: the shared test runtime can
+    // stall for seconds on synchronous KVStore calls and would starve it.
+    fn start() -> Self {
+        let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        std_listener.set_nonblocking(true).unwrap();
+        let port = std_listener.local_addr().unwrap().port();
+        let (online, rx) = tokio::sync::watch::channel(true);
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async move {
+                let listener = TcpListener::from_std(std_listener).unwrap();
+                loop {
+                    let Ok((mut inbound, _)) = listener.accept().await else {
+                        break;
+                    };
+                    if !*rx.borrow() {
+                        continue; // offline: drop the connection immediately
+                    }
+                    let mut rx_conn = rx.clone();
+                    tokio::spawn(async move {
+                        let Ok(mut outbound) = TcpStream::connect(VSS_SERVER_ADDR).await else {
+                            return;
+                        };
+                        tokio::select! {
+                            _ = tokio::io::copy_bidirectional(&mut inbound, &mut outbound) => {}
+                            _ = rx_conn.wait_for(|online| !online) => {}
+                        }
+                    });
+                }
+            });
+        });
+        Self { port, online }
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}/vss", self.port)
+    }
+
+    fn go_offline(&self) {
+        self.online.send(false).unwrap();
+    }
+
+    fn go_online(&self) {
+        self.online.send(true).unwrap();
+    }
+}
+
+fn node_log_contains(node_test_dir: &str, needle: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir(node_test_dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let log_file = entry.path().join(LOGS_DIR).join(LDK_LOGS_FILE);
+        if let Ok(content) = std::fs::read_to_string(&log_file) {
+            if content.contains(needle) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// A VSS outage while an HTLC is in flight must pause the channel, not wedge
+/// it: node2 (payee, VSS-replicated) cannot persist monitor updates while VSS
+/// is down, so the payment from node1 (no VSS) hangs Pending; once VSS is back
+/// the pending writes go through, the payment settles and the channel stays
+/// open and usable — no force close, no restart. Regression test for the bug
+/// where a failed monitor persist was never retried, permanently stalling the
+/// channel until node1 force-closed at HTLC expiry.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[traced_test]
+async fn vss_outage_payment_recovers_without_force_close() {
+    tokio::time::timeout(
+        std::time::Duration::from_secs(300),
+        vss_outage_payment_recovers_without_force_close_inner(),
+    )
+    .await
+    .expect("vss_outage_payment_recovers_without_force_close timed out");
+}
+
+async fn vss_outage_payment_recovers_without_force_close_inner() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}node2");
+
+    let proxy = VssProxy::start();
+
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _, _) = start_node_with_vss(
+        &test_dir_node2,
+        NODE2_PEER_PORT,
+        false,
+        &proxy.url(),
+        None,
+        false,
+    )
+    .await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    connect_peer(
+        node1_addr,
+        &node2_pubkey,
+        &format!("127.0.0.1:{NODE2_PEER_PORT}"),
+    )
+    .await;
+
+    let channel = open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(600_000),
+        Some(100_000_000),
+        None,
+        None,
+    )
+    .await;
+    wait_for_usable_channels(node1_addr, 1).await;
+    wait_for_usable_channels(node2_addr, 1).await;
+
+    let LNInvoiceResponse { invoice } =
+        ln_invoice(node2_addr, Some(50_000_000), None, None, 86400).await;
+
+    proxy.go_offline();
+
+    let send = send_payment_raw(node1_addr, invoice.clone()).await;
+    let payment_hash = send.payment_hash.unwrap();
+
+    // Long enough for node2 to exhaust the VSS client retries and enter the
+    // outage retry loop.
+    tokio::time::sleep(std::time::Duration::from_secs(25)).await;
+
+    assert!(
+        check_payment_status_by_type(
+            node1_addr,
+            &payment_hash,
+            PaymentType::Outbound,
+            HTLCStatus::Pending,
+        )
+        .await
+        .is_some(),
+        "payment must be Pending while node2 cannot persist to VSS"
+    );
+    assert!(
+        list_channels(node1_addr)
+            .await
+            .iter()
+            .any(|c| c.channel_id == channel.channel_id),
+        "channel must stay open during the outage"
+    );
+    assert!(
+        !node_log_contains(&test_dir_node2, "Failed to persist new ChannelMonitor"),
+        "monitor persistence must never fail permanently during an outage"
+    );
+
+    proxy.go_online();
+
+    // Pending writes go through and the stalled commitment dance completes.
+    wait_for_ln_payment(node1_addr, &payment_hash, HTLCStatus::Succeeded).await;
+
+    assert!(
+        !node_log_contains(&test_dir_node1, "Force-closing channel"),
+        "node1 must not force-close once VSS is back"
+    );
+    assert!(
+        !node_log_contains(&test_dir_node2, "Failed to persist new ChannelMonitor"),
+        "monitor persistence must have recovered, not failed"
+    );
+
+    // The channel is still open and fully usable: route a second payment.
+    let LNInvoiceResponse { invoice } =
+        ln_invoice(node2_addr, Some(10_000_000), None, None, 86400).await;
+    send_payment(node1_addr, invoice).await;
+}
+
+async fn spendable_sats(node_address: SocketAddr) -> u64 {
+    let balance = btc_balance(node_address).await;
+    balance.vanilla.spendable + balance.colored.spendable
+}
+
+// Generous budget: maturity needs 144+ blocks, then the monitor holds the
+// output for ANTI_REORG_DELAY, the sweeper acts on ~30s background ticks and
+// its tx is locktimed to broadcast-height + 1.
+async fn wait_for_spendable_above(node_address: SocketAddr, threshold: u64, what: &str) {
+    for _ in 0..70 {
+        mine_n_blocks(false, 20);
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        let spendable = spendable_sats(node_address).await;
+        if spendable > threshold {
+            return;
+        }
+        println!("{what}: spendable {spendable} <= {threshold}, waiting");
+    }
+    panic!("{what}: spendable did not exceed {threshold}");
+}
+
+/// If the outage outlasts the HTLC expiry the payer force-closes anyway (the
+/// protocol backstop). Funds must still be recovered afterwards: node1 sweeps
+/// its commitment output back to spendable balance once the to_self_delay
+/// (144 blocks) matures, and node2 claims its pushed balance once VSS is back.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[traced_test]
+async fn vss_outage_force_close_funds_are_swept() {
+    tokio::time::timeout(
+        std::time::Duration::from_secs(900),
+        vss_outage_force_close_funds_are_swept_inner(),
+    )
+    .await
+    .expect("vss_outage_force_close_funds_are_swept timed out");
+}
+
+async fn vss_outage_force_close_funds_are_swept_inner() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}fc_node1");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}fc_node2");
+
+    let proxy = VssProxy::start();
+
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _, _) = start_node_with_vss(
+        &test_dir_node2,
+        NODE2_PEER_PORT,
+        false,
+        &proxy.url(),
+        None,
+        false,
+    )
+    .await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    connect_peer(
+        node1_addr,
+        &node2_pubkey,
+        &format!("127.0.0.1:{NODE2_PEER_PORT}"),
+    )
+    .await;
+
+    let channel = open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(600_000),
+        Some(100_000_000),
+        None,
+        None,
+    )
+    .await;
+    wait_for_usable_channels(node1_addr, 1).await;
+    wait_for_usable_channels(node2_addr, 1).await;
+
+    let LNInvoiceResponse { invoice } =
+        ln_invoice(node2_addr, Some(50_000_000), None, None, 86400).await;
+
+    // VSS goes offline and never comes back before the HTLC expires.
+    proxy.go_offline();
+    send_payment_raw(node1_addr, invoice).await;
+    tokio::time::sleep(std::time::Duration::from_secs(20)).await;
+
+    let node1_spendable_stuck = spendable_sats(node1_addr).await;
+    let node2_spendable_stuck = spendable_sats(node2_addr).await;
+
+    // Mine past the HTLC expiry; node1 force-closes.
+    let mut force_closed = false;
+    for _ in 0..30 {
+        mine_n_blocks(false, 20);
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        let still_open = list_channels(node1_addr)
+            .await
+            .iter()
+            .any(|c| c.channel_id == channel.channel_id);
+        if !still_open {
+            force_closed = true;
+            break;
+        }
+    }
+    assert!(force_closed, "node1 must force-close once the HTLC expires");
+    assert!(
+        node_log_contains(&test_dir_node1, "Force-closing channel"),
+        "node1 must have logged the force close"
+    );
+
+    // node1 (no VSS) must sweep its commitment output back to balance once the
+    // 144-block to_self_delay matures: ~500k sat (600k capacity - 100k pushed -
+    // commitment/sweep fees).
+    wait_for_spendable_above(
+        node1_addr,
+        node1_spendable_stuck + 400_000,
+        "node1 post-force-close sweep",
+    )
+    .await;
+
+    // node2 recovers its pushed balance too (VSS back on; whether the claim
+    // already happened during the outage is not part of the contract).
+    proxy.go_online();
+    wait_for_spendable_above(
+        node2_addr,
+        node2_spendable_stuck + 50_000,
+        "node2 pushed-balance claim",
+    )
+    .await;
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -170,6 +170,8 @@ pub(crate) struct UnlockedAppState {
     pub(crate) async_order_handler: Arc<AsyncOrderMessageHandler>,
     pub(crate) async_payments_preimage_root: Arc<AsyncPaymentsPreimageRoot>,
     pub(crate) kv_store: Arc<SyncedKvStore>,
+    #[cfg(feature = "vss")]
+    pub(crate) monitor_kv_store: Arc<crate::async_kv_store::RemoteFirstKvStore>,
     pub(crate) bump_tx_event_handler: Arc<BumpTxEventHandler>,
     pub(crate) maker_swaps: Arc<Mutex<SwapMap>>,
     pub(crate) taker_swaps: Arc<Mutex<SwapMap>>,

--- a/src/vss_kv_store.rs
+++ b/src/vss_kv_store.rs
@@ -35,6 +35,34 @@ static VSS_RUNTIME: std::sync::LazyLock<tokio::runtime::Runtime> = std::sync::La
 /// means the key disappeared between list and get (race; benign).
 type FetchResult = Result<Option<(String, Vec<u8>)>, VssError>;
 
+/// Whether a VSS failure is worth retrying: transport failures (connection
+/// refused/timeouts surface as `InternalError`) and server 5xx. Auth,
+/// bad-request and version-conflict errors are permanent.
+fn is_transient_vss_error(e: &VssError) -> bool {
+    matches!(
+        e,
+        VssError::InternalServerError(_) | VssError::InternalError(_)
+    )
+}
+
+/// Maps a `VssError` to `io::Error`, encoding transience in the kind so
+/// callers (see `RemoteFirstKvStore`) can decide whether to retry.
+/// [`is_transient_io_error`] is the matching decoder.
+fn vss_err_to_io(e: VssError, msg: String) -> io::Error {
+    let kind = if is_transient_vss_error(&e) {
+        io::ErrorKind::TimedOut
+    } else {
+        io::ErrorKind::Other
+    };
+    io::Error::new(kind, msg)
+}
+
+/// True when the error came from a VSS outage (see [`vss_err_to_io`]) rather
+/// than a permanent failure.
+pub(crate) fn is_transient_io_error(e: &io::Error) -> bool {
+    e.kind() == io::ErrorKind::TimedOut
+}
+
 /// HKDF info tag used to derive this KV stream's per-value encryption key.
 /// Domain-separates it from rgb-lib's wallet-backup stream so the two derived
 /// keys are distinct even when the signing key and salt happen to match.
@@ -452,7 +480,8 @@ impl VssKvStore {
         };
         self.client.put_object(&request).await.map_err(|e| {
             tracing::error!(vss_key, error = %e, "VssKvStore write_async failed");
-            io::Error::new(io::ErrorKind::Other, format!("VSS write failed: {e}"))
+            let msg = format!("VSS write failed: {e}");
+            vss_err_to_io(e, msg)
         })?;
         Ok(())
     }
@@ -477,7 +506,8 @@ impl VssKvStore {
         };
         self.client.put_object(&request).await.map_err(|e| {
             tracing::error!(vss_key, error = %e, "VssKvStore remove_async failed");
-            io::Error::new(io::ErrorKind::Other, format!("VSS remove failed: {e}"))
+            let msg = format!("VSS remove failed: {e}");
+            vss_err_to_io(e, msg)
         })?;
         Ok(())
     }


### PR DESCRIPTION
When the VSS server is unreachable, a channel monitor persist fails after ~30s and is never retried. The channel is then permanently wedged: the node can't revoke, an in-flight payment hangs forever, and the counterparty eventually force-closes when the HTLC expires. The node stays wedged even after VSS comes back — only a restart recovers it.

Note there is no way to prevent this earlier in the protocol: once a peer offers an HTLC, every possible response (even failing it back) requires persisting a monitor update, i.e. a VSS write.

## Change

A VSS outage now pauses the channel instead of wedging it. Monitor writes retry unreachable/5xx errors with capped backoff (0.5s → 10s) and the monitor update simply stays in progress; when VSS recovers, the pending writes land, LDK completes the update and the channel resumes on its own — the stuck payment settles, no force close, no restart.

Permanent errors (auth, version conflict, bad request) still fail immediately as before.

## Safety

- Durability is unchanged: a monitor update is still never acked before VSS has stored it, and nothing is written locally first.
- On node teardown the pending retries are aborted before the single-writer fence is released, so a delayed write can't land on a store another instance has taken over.
- If an outage lasts past the HTLC's CLTV expiry, the counterparty still force-closes — that's the Lightning safety backstop and out of the node's control.

## Tests

- `vss_outage_payment_recovers_without_force_close` (e2e, regtest + VSS behind a killable proxy): payment hangs Pending during the outage, settles once VSS is back, channel stays open and routes a second payment, no force close.
- `remote_first_write_pends_when_vss_unreachable`: a write neither resolves nor touches the local store while VSS is down, and resolves with an error once teardown aborts it (replaces the old fail-fast test).
