### PR TITLE
Run VSS full-restore e2e test in CI and update VSS recovery docs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,6 +143,8 @@ jobs:
         run: VSS=1 ./regtest.sh start
       - name: Run VSS tests (e2e against regtest + VSS server)
         run: cargo test --features vss "test::vss::tests" -- --test-threads=1
+      - name: Run VSS full-restore e2e test (wipe node dir, restore from seed)
+        run: cargo test --features "uniffi,test-utils,vls,vss" --test lib_sdk vss_restore -- --test-threads=1
       - name: Stop regtest and VSS services
         if: always()
         run: docker compose --profile vss down -v --remove-orphans

--- a/README.md
+++ b/README.md
@@ -423,9 +423,7 @@ the node behaves exactly as before.
 
 Two independent data streams are backed up:
 
-- **Node KV state** — channel manager, channel monitors, payment info, swap
-  data and RGB channel info. Every update is written to both the local SQLite
-  database and the remote VSS server.
+- **Node KV state** — channel manager, channel monitors, payment info, swap data and RGB channel info. Every update is written to both the local SQLite database and the remote VSS server; channel-monitor updates are persisted remote-first, completing only once the VSS server has durably stored them.
 - **RGB wallet data** — the wallet files managed by rgb-lib, backed up
   automatically after every state-changing wallet operation.
 
@@ -479,22 +477,9 @@ the node finishes coming up:
 - the **RGB wallet directory** (assets, transfers, allocations) is restored
   when the local wallet directory for this mnemonic's fingerprint is absent.
 
-Together these recover BTC balance, channels, and RGB assets without any
-extra calls — `unlock` is the only entry point. Each VSS store is owned by a
-single running node instance, so a second node pointed at the same store
-refuses to start to avoid corrupting state. After a previous owner shuts
-down its fence is intentionally left behind; on a legitimate device wipe and
-restore the operator must call `POST /vssclearfence` (or
-`SdkNode::vss_clear_fence`) once between `init` and `unlock` to take over
-the store. In internal-mnemonic mode this is authenticated by the wallet
-password; in external-signer mode (no mnemonic on the node) the password is
-ignored and the VSS identity is reconstructed from the persisted
-`key_source.json`, matching the identity the node acquires the fence under.
+Together these recover BTC balance, channels, and RGB assets without any extra calls — `unlock` is the only entry point, provided the node was initialized (`/init`) with the same mnemonic as the original device and started with the same `--vss-url` and `--network`. A different mnemonic maps to a different VSS store, so the node finds no backup and starts fresh without an error. Each VSS store is owned by a single running node instance, so a second node pointed at the same store refuses to start to avoid corrupting state. A graceful teardown (lock, shutdown, signal) releases the fence; after a crash or hard kill it is left behind and the operator must call `POST /vssclearfence` (or `SdkNode::vss_clear_fence`) once between `init` and `unlock` to take over the store. In internal-mnemonic mode this is authenticated by the wallet password; in external-signer mode (no mnemonic on the node) the password is ignored and the VSS identity is reconstructed from the persisted `key_source.json`, matching the identity the node acquires the fence under.
 
-VSS replication is best-effort: a write that fails to reach the server is
-queued and retried on later successful writes. The number of pending writes is
-reported by `GET /vssbackupinfo` so monitoring can alert on persistent
-staleness.
+Replication guarantees differ per stream. Channel-monitor writes are remote-first: each write completes only after the VSS server durably stores it, and transient server failures are retried with capped exponential backoff until the server recovers. All other KV writes land in the local database first and are replicated to VSS best-effort: a write that fails to reach the server is queued and retried on later successful writes. The number of pending best-effort writes is reported by `GET /vssbackupinfo` so monitoring can alert on persistent staleness.
 
 ### API endpoints (when VSS is enabled)
 - `POST /vssbackup` — trigger a manual RGB wallet backup

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -145,9 +145,11 @@ fn poll_esplora_fee_estimates(
                         .store(background_estimate, Ordering::Release);
                 }
                 Ok(Err(e)) => {
-                    log_warn!(logger, "Error getting fee estimate from esplora: {}", e)
+                    log_warn!(logger, "Error getting fee estimate from esplora: {}", e);
                 }
-                Err(e) => log_warn!(logger, "Error polling esplora fee estimates: {}", e),
+                Err(e) => {
+                    log_warn!(logger, "Error polling esplora fee estimates: {}", e);
+                }
             }
 
             tokio::time::sleep(Duration::from_secs(60)).await;
@@ -217,8 +219,12 @@ impl BroadcasterInterface for EsploraIndexerClient {
             .await;
             match res {
                 Ok(Ok(())) => {}
-                Ok(Err(e)) => log_warn!(logger, "esplora broadcast failed: {}", e),
-                Err(e) => log_warn!(logger, "esplora broadcast task spawn failed: {}", e),
+                Ok(Err(e)) => {
+                    log_warn!(logger, "esplora broadcast failed: {}", e);
+                }
+                Err(e) => {
+                    log_warn!(logger, "esplora broadcast task spawn failed: {}", e);
+                }
             }
         });
     }
@@ -339,8 +345,12 @@ impl BroadcasterInterface for ElectrumIndexerClient {
             .await;
             match res {
                 Ok(Ok(())) => {}
-                Ok(Err(e)) => log_warn!(logger, "electrum broadcast failed: {}", e),
-                Err(e) => log_warn!(logger, "electrum broadcast task spawn failed: {}", e),
+                Ok(Err(e)) => {
+                    log_warn!(logger, "electrum broadcast failed: {}", e);
+                }
+                Err(e) => {
+                    log_warn!(logger, "electrum broadcast task spawn failed: {}", e);
+                }
             }
         });
     }
@@ -426,8 +436,12 @@ fn poll_electrum_fee_estimates(
                         .unwrap()
                         .store(bg_e, Ordering::Release);
                 }
-                Ok(Err(e)) => log_warn!(logger, "Error getting fee estimate from electrum: {}", e),
-                Err(e) => log_warn!(logger, "Error polling electrum fee estimates: {}", e),
+                Ok(Err(e)) => {
+                    log_warn!(logger, "Error getting fee estimate from electrum: {}", e);
+                }
+                Err(e) => {
+                    log_warn!(logger, "Error polling electrum fee estimates: {}", e);
+                }
             }
             tokio::time::sleep(Duration::from_secs(60)).await;
         }


### PR DESCRIPTION
The vss-tests CI job now runs the full wipe-nodedir-and-restore-from-seed e2e test; the README VSS section is corrected (per-stream replication guarantees, fence released on graceful teardown, restore requires the original mnemonic + same --vss-url/--network)