### PR TITLE
Prevent VSS restore channel loss: fix replication queue regression and guard inconsistent restores

### DIFF
--- a/src/async_kv_store.rs
+++ b/src/async_kv_store.rs
@@ -229,17 +229,17 @@ impl KVStore for RemoteFirstKvStore {
 }
 
 /// Routes the background processor's persistence per key: the channel manager
-/// is remote-first (the backup must never lag the monitors), network graph and
-/// scorer are local-only (rebuildable), anything else keeps best-effort
-/// replication.
+/// and sweeper state are remote-first (the backup must never lag the monitors,
+/// and forgotten sweeper outputs are unrecoverable), network graph and scorer
+/// are local-only (rebuildable), anything else keeps best-effort replication.
 pub struct BpKvStoreRouter {
-    manager: Arc<RemoteFirstKvStore>,
+    remote_first: Arc<RemoteFirstKvStore>,
     local: Arc<SeaOrmKvStore>,
     rest: Arc<crate::synced_kv_store::SyncedKvStore>,
 }
 
 enum BpRoute {
-    Manager,
+    RemoteFirst,
     LocalOnly,
     Rest,
 }
@@ -249,8 +249,9 @@ fn bp_route(primary: &str, secondary: &str, key: &str) -> BpRoute {
         CHANNEL_MANAGER_PERSISTENCE_KEY, CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
         CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE, NETWORK_GRAPH_PERSISTENCE_KEY,
         NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE, NETWORK_GRAPH_PERSISTENCE_SECONDARY_NAMESPACE,
-        SCORER_PERSISTENCE_KEY, SCORER_PERSISTENCE_PRIMARY_NAMESPACE,
-        SCORER_PERSISTENCE_SECONDARY_NAMESPACE,
+        OUTPUT_SWEEPER_PERSISTENCE_KEY, OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
+        OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE, SCORER_PERSISTENCE_KEY,
+        SCORER_PERSISTENCE_PRIMARY_NAMESPACE, SCORER_PERSISTENCE_SECONDARY_NAMESPACE,
     };
     if (primary, secondary, key)
         == (
@@ -258,8 +259,14 @@ fn bp_route(primary: &str, secondary: &str, key: &str) -> BpRoute {
             CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
             CHANNEL_MANAGER_PERSISTENCE_KEY,
         )
+        || (primary, secondary, key)
+            == (
+                OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
+                OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
+                OUTPUT_SWEEPER_PERSISTENCE_KEY,
+            )
     {
-        BpRoute::Manager
+        BpRoute::RemoteFirst
     } else if (primary, secondary, key)
         == (
             NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE,
@@ -281,12 +288,12 @@ fn bp_route(primary: &str, secondary: &str, key: &str) -> BpRoute {
 
 impl BpKvStoreRouter {
     pub fn new(
-        manager: Arc<RemoteFirstKvStore>,
+        remote_first: Arc<RemoteFirstKvStore>,
         local: Arc<SeaOrmKvStore>,
         rest: Arc<crate::synced_kv_store::SyncedKvStore>,
     ) -> Self {
         Self {
-            manager,
+            remote_first,
             local,
             rest,
         }
@@ -301,9 +308,10 @@ impl KVStore for BpKvStoreRouter {
         key: &str,
     ) -> AsyncResult<'static, Vec<u8>, io::Error> {
         match bp_route(primary_namespace, secondary_namespace, key) {
-            BpRoute::Manager => self
-                .manager
-                .read(primary_namespace, secondary_namespace, key),
+            BpRoute::RemoteFirst => {
+                self.remote_first
+                    .read(primary_namespace, secondary_namespace, key)
+            }
             BpRoute::LocalOnly => {
                 let res =
                     KVStoreSync::read(&*self.local, primary_namespace, secondary_namespace, key);
@@ -325,8 +333,8 @@ impl KVStore for BpKvStoreRouter {
         buf: Vec<u8>,
     ) -> AsyncResult<'static, (), io::Error> {
         match bp_route(primary_namespace, secondary_namespace, key) {
-            BpRoute::Manager => {
-                self.manager
+            BpRoute::RemoteFirst => {
+                self.remote_first
                     .write(primary_namespace, secondary_namespace, key, buf)
             }
             BpRoute::LocalOnly => {
@@ -360,8 +368,8 @@ impl KVStore for BpKvStoreRouter {
         lazy: bool,
     ) -> AsyncResult<'static, (), io::Error> {
         match bp_route(primary_namespace, secondary_namespace, key) {
-            BpRoute::Manager => {
-                self.manager
+            BpRoute::RemoteFirst => {
+                self.remote_first
                     .remove(primary_namespace, secondary_namespace, key, lazy)
             }
             BpRoute::LocalOnly => {

--- a/src/async_kv_store.rs
+++ b/src/async_kv_store.rs
@@ -227,3 +227,172 @@ impl KVStore for RemoteFirstKvStore {
         Box::pin(async move { KVStoreSync::list(&*local, &primary, &secondary) })
     }
 }
+
+/// Routes the background processor's persistence per key: the channel manager
+/// is remote-first (the backup must never lag the monitors), network graph and
+/// scorer are local-only (rebuildable), anything else keeps best-effort
+/// replication.
+pub struct BpKvStoreRouter {
+    manager: Arc<RemoteFirstKvStore>,
+    local: Arc<SeaOrmKvStore>,
+    rest: Arc<crate::synced_kv_store::SyncedKvStore>,
+}
+
+enum BpRoute {
+    Manager,
+    LocalOnly,
+    Rest,
+}
+
+fn bp_route(primary: &str, secondary: &str, key: &str) -> BpRoute {
+    use lightning::util::persist::{
+        CHANNEL_MANAGER_PERSISTENCE_KEY, CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+        CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE, NETWORK_GRAPH_PERSISTENCE_KEY,
+        NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE, NETWORK_GRAPH_PERSISTENCE_SECONDARY_NAMESPACE,
+        SCORER_PERSISTENCE_KEY, SCORER_PERSISTENCE_PRIMARY_NAMESPACE,
+        SCORER_PERSISTENCE_SECONDARY_NAMESPACE,
+    };
+    if (primary, secondary, key)
+        == (
+            CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+            CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
+            CHANNEL_MANAGER_PERSISTENCE_KEY,
+        )
+    {
+        BpRoute::Manager
+    } else if (primary, secondary, key)
+        == (
+            NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE,
+            NETWORK_GRAPH_PERSISTENCE_SECONDARY_NAMESPACE,
+            NETWORK_GRAPH_PERSISTENCE_KEY,
+        )
+        || (primary, secondary, key)
+            == (
+                SCORER_PERSISTENCE_PRIMARY_NAMESPACE,
+                SCORER_PERSISTENCE_SECONDARY_NAMESPACE,
+                SCORER_PERSISTENCE_KEY,
+            )
+    {
+        BpRoute::LocalOnly
+    } else {
+        BpRoute::Rest
+    }
+}
+
+impl BpKvStoreRouter {
+    pub fn new(
+        manager: Arc<RemoteFirstKvStore>,
+        local: Arc<SeaOrmKvStore>,
+        rest: Arc<crate::synced_kv_store::SyncedKvStore>,
+    ) -> Self {
+        Self {
+            manager,
+            local,
+            rest,
+        }
+    }
+}
+
+impl KVStore for BpKvStoreRouter {
+    fn read(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+    ) -> AsyncResult<'static, Vec<u8>, io::Error> {
+        match bp_route(primary_namespace, secondary_namespace, key) {
+            BpRoute::Manager => self
+                .manager
+                .read(primary_namespace, secondary_namespace, key),
+            BpRoute::LocalOnly => {
+                let res =
+                    KVStoreSync::read(&*self.local, primary_namespace, secondary_namespace, key);
+                Box::pin(async move { res })
+            }
+            BpRoute::Rest => {
+                let res =
+                    KVStoreSync::read(&*self.rest, primary_namespace, secondary_namespace, key);
+                Box::pin(async move { res })
+            }
+        }
+    }
+
+    fn write(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        buf: Vec<u8>,
+    ) -> AsyncResult<'static, (), io::Error> {
+        match bp_route(primary_namespace, secondary_namespace, key) {
+            BpRoute::Manager => {
+                self.manager
+                    .write(primary_namespace, secondary_namespace, key, buf)
+            }
+            BpRoute::LocalOnly => {
+                let res = KVStoreSync::write(
+                    &*self.local,
+                    primary_namespace,
+                    secondary_namespace,
+                    key,
+                    buf,
+                );
+                Box::pin(async move { res })
+            }
+            BpRoute::Rest => {
+                let res = KVStoreSync::write(
+                    &*self.rest,
+                    primary_namespace,
+                    secondary_namespace,
+                    key,
+                    buf,
+                );
+                Box::pin(async move { res })
+            }
+        }
+    }
+
+    fn remove(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        lazy: bool,
+    ) -> AsyncResult<'static, (), io::Error> {
+        match bp_route(primary_namespace, secondary_namespace, key) {
+            BpRoute::Manager => {
+                self.manager
+                    .remove(primary_namespace, secondary_namespace, key, lazy)
+            }
+            BpRoute::LocalOnly => {
+                let res = KVStoreSync::remove(
+                    &*self.local,
+                    primary_namespace,
+                    secondary_namespace,
+                    key,
+                    lazy,
+                );
+                Box::pin(async move { res })
+            }
+            BpRoute::Rest => {
+                let res = KVStoreSync::remove(
+                    &*self.rest,
+                    primary_namespace,
+                    secondary_namespace,
+                    key,
+                    lazy,
+                );
+                Box::pin(async move { res })
+            }
+        }
+    }
+
+    fn list(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+    ) -> AsyncResult<'static, Vec<String>, io::Error> {
+        let res = KVStoreSync::list(&*self.local, primary_namespace, secondary_namespace);
+        Box::pin(async move { res })
+    }
+}

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -98,6 +98,8 @@ use rgb_lib::{
     Fascia, FileContent, RgbTransfer, RgbTxid, WitnessOrd,
 };
 use std::collections::HashMap;
+#[cfg(feature = "vss")]
+use std::collections::HashSet;
 use std::convert::TryInto;
 use std::fs;
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -3880,6 +3882,8 @@ pub(crate) async fn start_ldk(
     #[cfg(feature = "vss")]
     let mut fence_guard: Option<crate::vss_kv_store::FenceReleaseGuard> = None;
     #[cfg(feature = "vss")]
+    let mut vss_restored_keys: usize = 0;
+    #[cfg(feature = "vss")]
     let (kv_store, monitor_kv_store) = if let (Some(ref vss_url), Some(ref identity)) =
         (&static_state.vss_url, &vss_identity)
     {
@@ -3931,7 +3935,10 @@ pub(crate) async fn start_ldk(
         if !has_local_data {
             match synced.restore_from_vss(false) {
                 Ok(0) => tracing::info!("No VSS backup data found, starting fresh"),
-                Ok(n) => tracing::info!(keys_restored = n, "Restored node KV state from VSS"),
+                Ok(n) => {
+                    vss_restored_keys = n;
+                    tracing::info!(keys_restored = n, "Restored node KV state from VSS");
+                }
                 Err(e) => {
                     if static_state.vss_allow_empty_restore {
                         tracing::warn!(
@@ -4358,6 +4365,53 @@ pub(crate) async fn start_ldk(
             }
         }
     };
+
+    // A restored manager lagging a still-open monitor (it reports
+    // `Balance::ClaimableOnChannelClose`) would force-close on load; refuse
+    // before anything watches monitors or broadcasts.
+    #[cfg(feature = "vss")]
+    if vss_restored_keys > 0 {
+        use lightning::chain::channelmonitor::Balance;
+        let manager_channel_ids: HashSet<ChannelId> = channel_manager
+            .list_channels()
+            .iter()
+            .map(|c| c.channel_id)
+            .collect();
+        let lost_channels: Vec<String> = channelmonitors
+            .iter()
+            .filter(|(_, m)| !manager_channel_ids.contains(&m.channel_id()))
+            .filter(|(_, m)| {
+                m.get_claimable_balances()
+                    .iter()
+                    .any(|b| matches!(b, Balance::ClaimableOnChannelClose { .. }))
+            })
+            .map(|(_, m)| m.channel_id().to_string())
+            .collect();
+        if !lost_channels.is_empty() {
+            if static_state.vss_allow_empty_restore {
+                tracing::warn!(
+                    channels = ?lost_channels,
+                    "restored channel manager lags the restored monitors; proceeding due to \
+                     --vss-allow-empty-restore — these channels WILL be force-closed"
+                );
+            } else {
+                // Drop the restored manager so the next unlock re-runs restore + guard.
+                if let Err(e) = kv_store.remove_local_only(
+                    CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+                    CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
+                    CHANNEL_MANAGER_PERSISTENCE_KEY,
+                ) {
+                    tracing::warn!(error = %e, "failed to drop restored channel manager key");
+                }
+                return Err(APIError::FailedVssInit(format!(
+                    "VSS restore is inconsistent: the restored channel manager does not know \
+                     channel(s) {lost_channels:?} that the restored channel monitors consider \
+                     open. Unlocking would force-close them. Pass --vss-allow-empty-restore \
+                     to proceed anyway and accept the force-close."
+                )));
+            }
+        }
+    }
 
     // Prepare the RGB wallet
     let (account_xpub_vanilla, account_xpub_colored, master_fingerprint, rgb_wallet_mnemonic) =

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -5252,6 +5252,26 @@ pub(crate) async fn start_ldk(
         },
     ));
 
+    // Periodically drain queued VSS replications so an idle node still heals
+    // after an outage (drains are otherwise only triggered by new writes).
+    #[cfg(feature = "vss")]
+    {
+        let drain_store = Arc::clone(&kv_store);
+        let stop_drain = Arc::clone(&stop_processing);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                interval.tick().await;
+                if stop_drain.load(Ordering::Acquire) {
+                    break;
+                }
+                let store = Arc::clone(&drain_store);
+                let _ = tokio::task::spawn_blocking(move || store.drain_pending()).await;
+            }
+        });
+    }
+
     // Regularly reconnect to channel peers.
     let connect_cm = Arc::clone(&channel_manager);
     let connect_pm = Arc::clone(&peer_manager);
@@ -5565,9 +5585,27 @@ pub(crate) async fn stop_ldk(app_state: Arc<AppState>) {
     #[cfg(feature = "vss")]
     {
         if let Some((kv_store, monitor_kv_store)) = stores {
-            // Abort outage-pending monitor writes before giving up the fence:
-            // a retry landing after another instance owns the store would
-            // corrupt its state.
+            // Best-effort flush of queued replications before the fence goes.
+            let flush_store = Arc::clone(&kv_store);
+            let flush = tokio::task::spawn_blocking(move || {
+                flush_store.flush_pending_until(std::time::Instant::now() + Duration::from_secs(10))
+            });
+            match flush.await {
+                Ok(0) => {}
+                Ok(n) => tracing::error!(
+                    pending = n,
+                    "VSS replications still queued at shutdown; they persist locally and \
+                     will retry on next unlock"
+                ),
+                Err(e) => tracing::warn!(error = %e, "pending-queue flush task failed"),
+            }
+            // Stop drains and abort outage-pending monitor writes before
+            // giving up the fence: a write landing after another instance
+            // owns the store would corrupt its state.
+            let stop_store = Arc::clone(&kv_store);
+            if let Err(e) = tokio::task::spawn_blocking(move || stop_store.stop()).await {
+                tracing::warn!(error = %e, "pending-queue stop task failed");
+            }
             monitor_kv_store.stop();
             match tokio::task::spawn_blocking(move || kv_store.release_vss_fence_if_owned()).await {
                 Ok(Ok(())) => {}

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -56,14 +56,15 @@ use lightning::util::hash_tables::{new_hash_map, HashMap as LdkHashMap};
 #[cfg(feature = "vss")]
 use lightning::util::native_async::FutureSpawner;
 #[cfg(not(feature = "vss"))]
+use lightning::util::persist::KVStoreSyncWrapper;
+#[cfg(not(feature = "vss"))]
 use lightning::util::persist::MonitorUpdatingPersister;
 #[cfg(feature = "vss")]
 use lightning::util::persist::MonitorUpdatingPersisterAsync;
 use lightning::util::persist::{
-    KVStoreSync, KVStoreSyncWrapper, CHANNEL_MANAGER_PERSISTENCE_KEY,
-    CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE, CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
-    OUTPUT_SWEEPER_PERSISTENCE_KEY, OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
-    OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
+    KVStoreSync, CHANNEL_MANAGER_PERSISTENCE_KEY, CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+    CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE, OUTPUT_SWEEPER_PERSISTENCE_KEY,
+    OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE, OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
 };
 use lightning::util::ser::{Readable, ReadableArgs, Writeable};
 use lightning::util::sweep as ldk_sweep;
@@ -1131,12 +1132,19 @@ pub(crate) struct RgbOutputSpender {
     proxy_endpoint: String,
 }
 
+// The sweeper store type is shared with the background processor's persister
+// (same generic in `process_events_async`).
+#[cfg(feature = "vss")]
+pub(crate) type BpKvStore = Arc<crate::async_kv_store::BpKvStoreRouter>;
+#[cfg(not(feature = "vss"))]
+pub(crate) type BpKvStore = KVStoreSyncWrapper<Arc<SyncedKvStore>>;
+
 pub(crate) type OutputSweeper = ldk_sweep::OutputSweeper<
     Arc<ChainBackend>,
     Arc<RgbLibWalletWrapper>,
     Arc<ChainBackend>,
     Arc<dyn Filter + Send + Sync>,
-    KVStoreSyncWrapper<Arc<SyncedKvStore>>,
+    BpKvStore,
     Arc<FilesystemLogger>,
     Arc<RgbOutputSpender>,
 >;
@@ -3876,9 +3884,11 @@ pub(crate) async fn start_ldk(
         None
     };
 
-    // Monitors persist remote-first through `monitor_kv_store` (async, VSS-durable
-    // before ack); ChannelManager and aux state keep the local-first `kv_store`
-    // sync facade. Both share the same local DB and (when configured) VSS store.
+    // Monitors and the channel manager persist remote-first (VSS-durable before
+    // ack); aux state keeps the local-first `kv_store` sync facade. All share
+    // the same local DB and (when configured) VSS store.
+    #[cfg(feature = "vss")]
+    let bp_local_kv_store = Arc::clone(&local_kv_store);
     #[cfg(feature = "vss")]
     let mut fence_guard: Option<crate::vss_kv_store::FenceReleaseGuard> = None;
     #[cfg(feature = "vss")]
@@ -3965,6 +3975,15 @@ pub(crate) async fn start_ldk(
 
     #[cfg(not(feature = "vss"))]
     let kv_store = Arc::new(SyncedKvStore::local_only(local_kv_store));
+
+    #[cfg(feature = "vss")]
+    let bp_kv_store: BpKvStore = Arc::new(crate::async_kv_store::BpKvStoreRouter::new(
+        Arc::clone(&monitor_kv_store),
+        bp_local_kv_store,
+        Arc::clone(&kv_store),
+    ));
+    #[cfg(not(feature = "vss"))]
+    let bp_kv_store: BpKvStore = KVStoreSyncWrapper(Arc::clone(&kv_store));
 
     // Sync config from database to KVStore
     sync_config_to_kvstore(&static_state.db(), kv_store.as_ref())?;
@@ -4606,7 +4625,7 @@ pub(crate) async fn start_ldk(
                 chain_source.clone(),
                 rgb_output_spender,
                 rgb_wallet_wrapper.clone(),
-                KVStoreSyncWrapper(kv_store.clone()),
+                Clone::clone(&bp_kv_store),
                 logger.clone(),
             );
             (channel_manager.current_best_block(), sweeper)
@@ -4618,7 +4637,7 @@ pub(crate) async fn start_ldk(
                 chain_source.clone(),
                 rgb_output_spender.clone(),
                 rgb_wallet_wrapper.clone(),
-                KVStoreSyncWrapper(kv_store.clone()),
+                Clone::clone(&bp_kv_store),
                 logger.clone(),
             );
             let mut reader = io::Cursor::new(&mut bytes);
@@ -5044,8 +5063,8 @@ pub(crate) async fn start_ldk(
         Arc::clone(&logger),
     ));
 
-    // Persist ChannelManager and NetworkGraph
-    let persister = KVStoreSyncWrapper(Arc::clone(&kv_store));
+    // Persist ChannelManager (remote-first with VSS), NetworkGraph and scorer.
+    let persister = Clone::clone(&bp_kv_store);
 
     // Read swaps info from KVStore
     let maker_swaps = Arc::new(Mutex::new({
@@ -5487,9 +5506,55 @@ impl AppState {
     }
 }
 
+#[cfg(feature = "vss")]
+const BP_SHUTDOWN_FLUSH_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[cfg(feature = "vss")]
+fn log_bp_shutdown_result(res: Result<Result<(), io::Error>, tokio::task::JoinError>) {
+    match res {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::error!(error = %e, "background processor exited with error during shutdown")
+        }
+        Err(e) => tracing::error!(error = %e, "background processor task join failed"),
+    }
+}
+
 pub(crate) async fn stop_ldk(app_state: Arc<AppState>) {
     tracing::info!("Stopping LDK");
 
+    #[cfg(feature = "vss")]
+    let stores = app_state
+        .get_unlocked_app_state()
+        .await
+        .as_ref()
+        .map(|unlocked| {
+            (
+                Arc::clone(&unlocked.kv_store),
+                Arc::clone(&unlocked.monitor_kv_store),
+            )
+        });
+
+    #[cfg(feature = "vss")]
+    if let Some(mut join_handle) = app_state.stop_ldk() {
+        // Bounded flush: give the final remote-first persists time to reach
+        // VSS, then abort outage-pending retries so shutdown cannot hang.
+        match tokio::time::timeout(BP_SHUTDOWN_FLUSH_TIMEOUT, &mut join_handle).await {
+            Ok(res) => log_bp_shutdown_result(res),
+            Err(_) => {
+                tracing::error!(
+                    "final VSS flush did not complete in {:?}; aborting pending \
+                     retries — last channel-manager state may not have replicated",
+                    BP_SHUTDOWN_FLUSH_TIMEOUT
+                );
+                if let Some((_, ref monitor_kv_store)) = stores {
+                    monitor_kv_store.stop();
+                }
+                log_bp_shutdown_result(join_handle.await);
+            }
+        }
+    }
+    #[cfg(not(feature = "vss"))]
     if let Some(join_handle) = app_state.stop_ldk() {
         join_handle.await.unwrap().unwrap();
     }
@@ -5499,16 +5564,6 @@ pub(crate) async fn stop_ldk(app_state: Arc<AppState>) {
     // /vssclearfence. Hard kills still leave the fence behind by design.
     #[cfg(feature = "vss")]
     {
-        let stores = app_state
-            .get_unlocked_app_state()
-            .await
-            .as_ref()
-            .map(|unlocked| {
-                (
-                    Arc::clone(&unlocked.kv_store),
-                    Arc::clone(&unlocked.monitor_kv_store),
-                )
-            });
         if let Some((kv_store, monitor_kv_store)) = stores {
             // Abort outage-pending monitor writes before giving up the fence:
             // a retry landing after another instance owns the store would

--- a/src/synced_kv_store.rs
+++ b/src/synced_kv_store.rs
@@ -18,6 +18,11 @@ const PENDING_QUEUE_CAP: usize = 1000;
 #[cfg(feature = "vss")]
 const PENDING_DRAIN_BATCH: usize = 16;
 
+/// Local-only namespace persisting the pending queue across restarts. Rows are
+/// written straight to the local store, so they never replicate to VSS.
+#[cfg(feature = "vss")]
+const PENDING_NS: &str = "vss_pending";
+
 /// KVStore wrapper that writes to the local SeaORM store and (optionally)
 /// replicates to a remote VSS server. Reads always go to the local store for
 /// latency. When `remote` is `None`, this behaves identically to a plain
@@ -37,6 +42,16 @@ pub struct SyncedKvStore {
     /// removal correctly).
     #[cfg(feature = "vss")]
     pending: Arc<std::sync::Mutex<std::collections::HashMap<String, Option<Vec<u8>>>>>,
+    /// Serializes VSS puts per key across writes and drains so a drained stale
+    /// value can never land after a newer one.
+    #[cfg(feature = "vss")]
+    key_locks: std::sync::Mutex<std::collections::HashMap<String, Arc<std::sync::Mutex<()>>>>,
+    /// Set at teardown; [`Self::stop`] then waits out an in-flight drain via
+    /// `drain_gate` so no queued put can land after the fence is released.
+    #[cfg(feature = "vss")]
+    stopped: std::sync::atomic::AtomicBool,
+    #[cfg(feature = "vss")]
+    drain_gate: std::sync::Mutex<()>,
 }
 
 impl SyncedKvStore {
@@ -48,19 +63,96 @@ impl SyncedKvStore {
             remote: None,
             #[cfg(feature = "vss")]
             pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            #[cfg(feature = "vss")]
+            key_locks: std::sync::Mutex::new(std::collections::HashMap::new()),
+            #[cfg(feature = "vss")]
+            stopped: std::sync::atomic::AtomicBool::new(false),
+            #[cfg(feature = "vss")]
+            drain_gate: std::sync::Mutex::new(()),
         }
     }
 
-    /// Creates a SyncedKvStore with local storage and VSS replication.
+    /// Creates a SyncedKvStore with local storage and VSS replication,
+    /// reloading queued replications persisted by a previous run.
     #[cfg(feature = "vss")]
     pub fn with_vss(
         local: Arc<SeaOrmKvStore>,
         remote: Arc<crate::vss_kv_store::VssKvStore>,
     ) -> Self {
+        let mut pending = std::collections::HashMap::new();
+        if let Ok(keys) = local.list(PENDING_NS, "") {
+            for key in keys {
+                match local.read(PENDING_NS, "", &key) {
+                    Ok(row) => match row.split_first() {
+                        Some((1, buf)) => {
+                            pending.insert(key, Some(buf.to_vec()));
+                        }
+                        Some((0, _)) => {
+                            pending.insert(key, None);
+                        }
+                        _ => tracing::warn!(key, "dropping malformed pending VSS row"),
+                    },
+                    Err(e) => tracing::warn!(key, error = %e, "failed to load pending VSS row"),
+                }
+            }
+        }
+        if !pending.is_empty() {
+            tracing::info!(
+                count = pending.len(),
+                "reloaded pending VSS replications from previous run"
+            );
+        }
         Self {
             local,
             remote: Some(remote),
-            pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            pending: Arc::new(std::sync::Mutex::new(pending)),
+            key_locks: std::sync::Mutex::new(std::collections::HashMap::new()),
+            stopped: std::sync::atomic::AtomicBool::new(false),
+            drain_gate: std::sync::Mutex::new(()),
+        }
+    }
+
+    #[cfg(feature = "vss")]
+    fn key_lock(&self, vss_key: &str) -> Arc<std::sync::Mutex<()>> {
+        self.key_locks
+            .lock()
+            .unwrap()
+            .entry(vss_key.to_string())
+            .or_default()
+            .clone()
+    }
+
+    /// Stops future drains and waits for an in-flight one to finish. Call at
+    /// teardown before releasing the VSS fence.
+    #[cfg(feature = "vss")]
+    pub(crate) fn stop(&self) {
+        self.stopped
+            .store(true, std::sync::atomic::Ordering::Release);
+        drop(self.drain_gate.lock().unwrap());
+    }
+
+    /// Persist a queue entry so it survives restarts.
+    #[cfg(feature = "vss")]
+    fn persist_pending_row(&self, vss_key: &str, value: &Option<Vec<u8>>) {
+        let mut row = Vec::with_capacity(1 + value.as_ref().map_or(0, |v| v.len()));
+        match value {
+            Some(buf) => {
+                row.push(1);
+                row.extend_from_slice(buf);
+            }
+            None => row.push(0),
+        }
+        if let Err(e) = self.local.write(PENDING_NS, "", vss_key, row) {
+            tracing::warn!(vss_key, error = %e, "failed to persist pending VSS row");
+        }
+    }
+
+    #[cfg(feature = "vss")]
+    fn clear_pending_row(&self, vss_key: &str) {
+        if let Err(e) = self.local.remove(PENDING_NS, "", vss_key, false) {
+            if e.kind() != io::ErrorKind::NotFound {
+                tracing::warn!(vss_key, error = %e, "failed to clear pending VSS row");
+            }
         }
     }
 
@@ -164,17 +256,20 @@ impl SyncedKvStore {
         self.pending.lock().unwrap().len()
     }
 
-    /// Enqueue a failed VSS replication for later retry.
+    /// Enqueue a failed VSS replication for later retry, persisted so it
+    /// survives restarts.
     #[cfg(feature = "vss")]
     fn enqueue_pending(&self, vss_key: String, value: Option<Vec<u8>>) {
+        self.persist_pending_row(&vss_key, &value);
         let mut pending = self.pending.lock().unwrap();
         if pending.len() >= PENDING_QUEUE_CAP && !pending.contains_key(&vss_key) {
-            // Drop one entry to make room. HashMap iteration order is
-            // arbitrary; for "drop newest of the same key" we still want the
-            // newer value for that key, so we just evict an arbitrary other
-            // key. Logged as a metric so the operator can alert on it.
+            // Evict an arbitrary other key to bound the queue; logged so the
+            // operator can alert on it.
             if let Some(evict) = pending.keys().next().cloned() {
                 pending.remove(&evict);
+                drop(pending);
+                self.clear_pending_row(&evict);
+                pending = self.pending.lock().unwrap();
                 tracing::warn!(
                     evicted_key = evict,
                     cap = PENDING_QUEUE_CAP,
@@ -186,45 +281,84 @@ impl SyncedKvStore {
     }
 
     /// Attempt to drain up to [`PENDING_DRAIN_BATCH`] entries from the
-    /// pending queue. Called opportunistically after each successful VSS
-    /// write. Entries that re-fail are re-queued.
+    /// pending queue. Called after each successful VSS write and periodically
+    /// from a background task. Entries that re-fail are re-queued.
     #[cfg(feature = "vss")]
-    fn drain_pending(&self) {
+    pub(crate) fn drain_pending(&self) {
         let Some(ref remote) = self.remote else {
             return;
         };
-        let to_retry: Vec<(String, Option<Vec<u8>>)> = {
-            let mut pending = self.pending.lock().unwrap();
-            let take_n = pending.len().min(PENDING_DRAIN_BATCH);
-            let keys: Vec<String> = pending.keys().take(take_n).cloned().collect();
-            keys.into_iter()
-                .filter_map(|k| pending.remove(&k).map(|v| (k, v)))
-                .collect()
-        };
-        if to_retry.is_empty() {
+        if self.stopped.load(std::sync::atomic::Ordering::Acquire) {
             return;
         }
-        let drained = to_retry.len();
-        for (vss_key, value) in to_retry {
+        let _gate = self.drain_gate.lock().unwrap();
+        // Snapshot without removing: entries leave the queue only once VSS
+        // confirms them, so nothing is ever in flight outside the map.
+        let snapshot: Vec<(String, Option<Vec<u8>>)> = {
+            let pending = self.pending.lock().unwrap();
+            pending
+                .iter()
+                .take(PENDING_DRAIN_BATCH)
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        };
+        if snapshot.is_empty() {
+            return;
+        }
+        let mut drained = 0usize;
+        for (vss_key, value) in snapshot {
+            let lock = self.key_lock(&vss_key);
+            let _guard = lock.lock().unwrap();
+            // Re-check under the key lock: a concurrent write may have
+            // superseded or delivered this entry.
+            if self.pending.lock().unwrap().get(&vss_key) != Some(&value) {
+                continue;
+            }
             let parsed = crate::vss_kv_store::parse_vss_key(&vss_key);
             let Some((primary, secondary, key)) = parsed else {
                 tracing::warn!(vss_key, "Dropping unparseable key from pending queue");
+                self.pending.lock().unwrap().remove(&vss_key);
+                self.clear_pending_row(&vss_key);
                 continue;
             };
             let result = match &value {
                 Some(buf) => remote.write(&primary, &secondary, &key, buf.clone()),
                 None => remote.remove(&primary, &secondary, &key, false),
             };
-            if let Err(e) = result {
-                tracing::debug!(
-                    vss_key,
-                    error = %e,
-                    "Pending VSS replication still failing; re-queued"
-                );
-                self.enqueue_pending(vss_key, value);
+            match result {
+                Ok(()) => {
+                    self.pending.lock().unwrap().remove(&vss_key);
+                    self.clear_pending_row(&vss_key);
+                    drained += 1;
+                }
+                Err(e) => {
+                    // VSS is likely still down; the entry stays queued.
+                    tracing::debug!(
+                        vss_key,
+                        error = %e,
+                        "Pending VSS replication still failing"
+                    );
+                    break;
+                }
             }
         }
         tracing::debug!(drained, "Drained pending VSS writes");
+    }
+
+    /// Drain until the queue is empty, the deadline passes, or no progress is
+    /// made (VSS unreachable). Returns the number of entries still pending.
+    #[cfg(feature = "vss")]
+    pub(crate) fn flush_pending_until(&self, deadline: std::time::Instant) -> usize {
+        loop {
+            let before = self.pending_remote_writes();
+            if before == 0 || std::time::Instant::now() >= deadline {
+                return before;
+            }
+            self.drain_pending();
+            if self.pending_remote_writes() >= before {
+                return self.pending_remote_writes();
+            }
+        }
     }
 }
 
@@ -254,22 +388,32 @@ impl KVStoreSync for SyncedKvStore {
         #[cfg(feature = "vss")]
         if let Some(ref remote) = self.remote {
             let vss_key = crate::vss_kv_store::vss_key(primary_namespace, secondary_namespace, key);
-            match remote.write(primary_namespace, secondary_namespace, key, buf.clone()) {
-                Ok(()) => {
-                    // Drop any stale queued value so the drain can't regress the remote.
-                    self.pending.lock().unwrap().remove(&vss_key);
-                    self.drain_pending();
+            let replicated = {
+                let lock = self.key_lock(&vss_key);
+                let _guard = lock.lock().unwrap();
+                match remote.write(primary_namespace, secondary_namespace, key, buf.clone()) {
+                    Ok(()) => {
+                        // Drop any stale queued value so a drain can't regress the remote.
+                        if self.pending.lock().unwrap().remove(&vss_key).is_some() {
+                            self.clear_pending_row(&vss_key);
+                        }
+                        true
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            primary_namespace,
+                            secondary_namespace,
+                            key,
+                            error = %e,
+                            "VSS replication write failed; queued for retry"
+                        );
+                        self.enqueue_pending(vss_key, Some(buf));
+                        false
+                    }
                 }
-                Err(e) => {
-                    tracing::warn!(
-                        primary_namespace,
-                        secondary_namespace,
-                        key,
-                        error = %e,
-                        "VSS replication write failed; queued for retry"
-                    );
-                    self.enqueue_pending(vss_key, Some(buf));
-                }
+            };
+            if replicated {
+                self.drain_pending();
             }
         }
 
@@ -291,22 +435,32 @@ impl KVStoreSync for SyncedKvStore {
         #[cfg(feature = "vss")]
         if let Some(ref remote) = self.remote {
             let vss_key = crate::vss_kv_store::vss_key(primary_namespace, secondary_namespace, key);
-            match remote.remove(primary_namespace, secondary_namespace, key, lazy) {
-                Ok(()) => {
-                    // Same as in `write`.
-                    self.pending.lock().unwrap().remove(&vss_key);
-                    self.drain_pending();
+            let replicated = {
+                let lock = self.key_lock(&vss_key);
+                let _guard = lock.lock().unwrap();
+                match remote.remove(primary_namespace, secondary_namespace, key, lazy) {
+                    Ok(()) => {
+                        // Same as in `write`.
+                        if self.pending.lock().unwrap().remove(&vss_key).is_some() {
+                            self.clear_pending_row(&vss_key);
+                        }
+                        true
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            primary_namespace,
+                            secondary_namespace,
+                            key,
+                            error = %e,
+                            "VSS replication remove failed; queued for retry"
+                        );
+                        self.enqueue_pending(vss_key, None);
+                        false
+                    }
                 }
-                Err(e) => {
-                    tracing::warn!(
-                        primary_namespace,
-                        secondary_namespace,
-                        key,
-                        error = %e,
-                        "VSS replication remove failed; queued for retry"
-                    );
-                    self.enqueue_pending(vss_key, None);
-                }
+            };
+            if replicated {
+                self.drain_pending();
             }
         }
 

--- a/src/synced_kv_store.rs
+++ b/src/synced_kv_store.rs
@@ -144,6 +144,18 @@ impl SyncedKvStore {
         Ok(restored)
     }
 
+    /// Local-only removal; lets the restore guard discard a restored key.
+    #[cfg(feature = "vss")]
+    pub(crate) fn remove_local_only(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+    ) -> Result<(), io::Error> {
+        self.local
+            .remove(primary_namespace, secondary_namespace, key, false)
+    }
+
     /// Returns the number of pending VSS-replication entries that failed and
     /// are awaiting retry. Surfaced via `/vssbackupinfo` so operators can
     /// alert on persistent backup-staleness.
@@ -241,8 +253,11 @@ impl KVStoreSync for SyncedKvStore {
         // Replicate to VSS (best-effort, queue for retry on failure).
         #[cfg(feature = "vss")]
         if let Some(ref remote) = self.remote {
+            let vss_key = crate::vss_kv_store::vss_key(primary_namespace, secondary_namespace, key);
             match remote.write(primary_namespace, secondary_namespace, key, buf.clone()) {
                 Ok(()) => {
+                    // Drop any stale queued value so the drain can't regress the remote.
+                    self.pending.lock().unwrap().remove(&vss_key);
                     self.drain_pending();
                 }
                 Err(e) => {
@@ -253,8 +268,6 @@ impl KVStoreSync for SyncedKvStore {
                         error = %e,
                         "VSS replication write failed; queued for retry"
                     );
-                    let vss_key =
-                        crate::vss_kv_store::vss_key(primary_namespace, secondary_namespace, key);
                     self.enqueue_pending(vss_key, Some(buf));
                 }
             }
@@ -277,8 +290,11 @@ impl KVStoreSync for SyncedKvStore {
         // Replicate removal to VSS (best-effort, queue for retry on failure).
         #[cfg(feature = "vss")]
         if let Some(ref remote) = self.remote {
+            let vss_key = crate::vss_kv_store::vss_key(primary_namespace, secondary_namespace, key);
             match remote.remove(primary_namespace, secondary_namespace, key, lazy) {
                 Ok(()) => {
+                    // Same as in `write`.
+                    self.pending.lock().unwrap().remove(&vss_key);
                     self.drain_pending();
                 }
                 Err(e) => {
@@ -289,8 +305,6 @@ impl KVStoreSync for SyncedKvStore {
                         error = %e,
                         "VSS replication remove failed; queued for retry"
                     );
-                    let vss_key =
-                        crate::vss_kv_store::vss_key(primary_namespace, secondary_namespace, key);
                     self.enqueue_pending(vss_key, None);
                 }
             }

--- a/src/test/lib_sdk/helpers.rs
+++ b/src/test/lib_sdk/helpers.rs
@@ -247,6 +247,34 @@ pub(crate) fn make_node_with_vss(
     )
 }
 
+/// Like [`make_node_with_vss`] but with `--vss-allow-empty-restore`: the
+/// operator's escape hatch for restores refused as inconsistent.
+#[allow(dead_code)] // used by VSS-only tests
+pub(crate) fn make_node_with_vss_allow_empty(
+    storage_dir_path: &Path,
+    daemon_listening_port: u16,
+    ldk_peer_listening_port: u16,
+    vss_url: &str,
+) -> SdkNode {
+    fs::create_dir_all(storage_dir_path).expect("create storage dir");
+    SdkNode::create(SdkInitRequest {
+        storage_dir_path: storage_dir_path.display().to_string(),
+        daemon_listening_port,
+        ldk_peer_listening_port,
+        network: "regtest".to_string(),
+        max_media_upload_size_mb: 20,
+        enable_virtual_channels_v0: Some(false),
+        virtual_peer_pubkeys: None,
+        lsp_base_url: None,
+        lsp_bearer_token: None,
+        vss_url: Some(vss_url.to_string()),
+        vss_allow_http: true,
+        vss_allow_empty_restore: true,
+        reuse_addresses: false,
+    })
+    .expect("create SDK node")
+}
+
 /// Like [`make_node`], but with trusted virtual channels (v0) enabled. `virtual_peer_pubkeys`
 /// is the acceptor-side allowlist: inbound `trusted_no_broadcast` opens are only accepted from
 /// these peers. Openers just need the feature enabled (pass `None`).

--- a/src/test/lib_sdk/mod.rs
+++ b/src/test/lib_sdk/mod.rs
@@ -17,4 +17,6 @@ mod send_receive;
 mod swap_roundtrip_buy;
 mod vanilla_payment_on_rgb_channel;
 #[cfg(feature = "vss")]
+mod vss_manager_lag;
+#[cfg(feature = "vss")]
 mod vss_restore;

--- a/src/test/lib_sdk/vss_manager_lag.rs
+++ b/src/test/lib_sdk/vss_manager_lag.rs
@@ -1,15 +1,5 @@
-//! Reproduces the 2026-07 field incident: the channel-manager key on VSS lags
-//! behind the (remote-first) channel monitors, so a fresh-device restore loads
-//! a manager that does not know the channel and LDK force-closes it
-//! (`OutdatedChannelManager`) — `listchannels` comes back empty even though
-//! the restore itself "succeeded".
-//!
-//! The lag is driven through the production write path: an HTTP proxy in
-//! front of VSS rejects only PUTs of the `_/_/manager` key (a transient-style
-//! 502), which the best-effort `SyncedKvStore` replication absorbs into its
-//! in-memory pending queue. Monitor writes (RemoteFirstKvStore) pass through
-//! untouched. A graceful shutdown then discards the queue silently.
-//!
+//! A restore whose channel manager lags the (remote-first) channel monitors
+//! must refuse to unlock or keep the channel — never silently force-close.
 //! Requires the regtest stack (`./regtest.sh start`) and the VSS server
 //! (`docker compose --profile vss up -d`).
 
@@ -32,9 +22,7 @@ fn vss_server_available() -> bool {
         .is_ok()
 }
 
-/// HTTP proxy for the VSS server that can reject writes of the
-/// channel-manager key while passing everything else through — most
-/// importantly all channel-monitor writes.
+/// VSS proxy that can reject channel-manager-key writes, passing all else through.
 struct ManagerFilterProxy {
     port: u16,
     filter: Arc<AtomicBool>,
@@ -109,7 +97,10 @@ fn read_http_request(
 fn handle_conn(mut client: std::net::TcpStream, filter: Arc<AtomicBool>) -> std::io::Result<()> {
     while let Some((head, body)) = read_http_request(&mut client)? {
         let head_str = String::from_utf8_lossy(&head).to_string();
-        let is_put = head_str.lines().next().is_some_and(|l| l.contains("putObject"));
+        let is_put = head_str
+            .lines()
+            .next()
+            .is_some_and(|l| l.contains("putObject"));
         let has_manager_key = body
             .windows(MANAGER_VSS_KEY.len())
             .any(|w| w == MANAGER_VSS_KEY);
@@ -119,8 +110,7 @@ fn handle_conn(mut client: std::net::TcpStream, filter: Arc<AtomicBool>) -> std:
             )?;
             return Ok(());
         }
-        // Forward on a fresh upstream connection with `Connection: close` so
-        // the response is delimited by EOF and needs no framing of its own.
+        // Fresh upstream connection with `Connection: close`: response is EOF-delimited.
         let mut upstream = std::net::TcpStream::connect(VSS_SERVER_ADDR)?;
         let mut new_head = String::new();
         for line in head_str.split("\r\n") {
@@ -183,8 +173,7 @@ fn restore_keeps_channel_when_manager_replication_lagged() {
 
     let proxy = ManagerFilterProxy::start();
 
-    // --- Phase 1: node A (VSS via proxy) + peer B, channel while manager
-    // replication silently fails. ---
+    // Phase 1: open a channel while manager replication silently fails.
     let node_a = make_node_with_vss(
         &node_a_dir,
         NODE_A_DAEMON_PORT + NODE_A_PORT_OFFSET,
@@ -223,8 +212,6 @@ fn restore_keeps_channel_when_manager_replication_lagged() {
         .expect("node A issueassetnia");
     let asset_id = asset.asset_id;
 
-    // From here on the manager key never reaches VSS again (transient-style
-    // 502s absorbed by the best-effort replication queue); monitors do.
     proxy.block_manager_writes();
 
     let node_b_pubkey = node_b.node_info().expect("node B node_info").pubkey;
@@ -259,15 +246,14 @@ fn restore_keeps_channel_when_manager_replication_lagged() {
         .get_channel_id(open_channel.temporary_channel_id)
         .expect("node A get_channel_id");
 
-    // --- Phase 2: graceful shutdown (drops the pending replication queue),
-    // outage "ends", node A device is wiped. ---
+    // Phase 2: graceful shutdown drops the pending queue; wipe the device.
     node_a.shutdown();
     drop(node_a);
     proxy.allow_all();
 
     fs::remove_dir_all(&node_a_dir).expect("wipe node A storage");
 
-    // --- Phase 3: fresh device, same mnemonic, by-the-book restore. ---
+    // Phase 3: fresh device, same mnemonic, by-the-book restore.
     let node_a = make_node_with_vss(
         &node_a_dir,
         NODE_A_DAEMON_PORT + NODE_A_PORT_OFFSET,
@@ -283,22 +269,26 @@ fn restore_keeps_channel_when_manager_replication_lagged() {
             password: PASSWORD_A.to_string(),
         })
         .expect("node A vss_clear_fence");
-    node_a
-        .unlock(unlock_request(PASSWORD_A))
-        .expect("node A unlock after restore");
 
-    // --- Phase 4: the channel must have survived the restore. ---
-    let channels = node_a.list_channels().expect("node A list_channels");
-    let channel_ids: Vec<_> = channels.iter().map(|c| c.channel_id).collect();
-    let force_closed_evidence =
-        node_ldk_log_contains(&node_a_dir, "hen we loaded") // "...was not found... when we loaded"
-            || node_ldk_log_contains(&node_a_dir, "Force-closing");
-    assert!(
-        channel_ids.contains(&channel_id),
-        "channel {channel_id} must survive a VSS restore even when manager replication lagged \
-         behind monitor replication; got channels: {channel_ids:?} \
-         (force-close evidence in LDK log: {force_closed_evidence})"
-    );
+    // Phase 4: refuse loudly or keep the channel; silent empty success is the bug.
+    match node_a.unlock(unlock_request(PASSWORD_A)) {
+        Err(e) => {
+            eprintln!("unlock refused as expected: {e:?}");
+            assert!(
+                !node_ldk_log_contains(&node_a_dir, "force closed, should broadcast: true"),
+                "a refused unlock must not have broadcast a force-close"
+            );
+        }
+        Ok(()) => {
+            let channels = node_a.list_channels().expect("node A list_channels");
+            let channel_ids: Vec<_> = channels.iter().map(|c| c.channel_id).collect();
+            assert!(
+                channel_ids.contains(&channel_id),
+                "unlock succeeded after the restore, so channel {channel_id} must be intact; \
+                 got channels: {channel_ids:?}"
+            );
+        }
+    }
 
     // Cleanup
     node_a.shutdown();

--- a/src/test/lib_sdk/vss_manager_lag.rs
+++ b/src/test/lib_sdk/vss_manager_lag.rs
@@ -26,6 +26,7 @@ fn vss_server_available() -> bool {
 struct ManagerFilterProxy {
     port: u16,
     filter: Arc<AtomicBool>,
+    blocked: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl ManagerFilterProxy {
@@ -33,17 +34,28 @@ impl ManagerFilterProxy {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let filter = Arc::new(AtomicBool::new(false));
+        let blocked = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let flag = Arc::clone(&filter);
+        let hits = Arc::clone(&blocked);
         std::thread::spawn(move || {
             for conn in listener.incoming() {
                 let Ok(stream) = conn else { break };
                 let flag = Arc::clone(&flag);
+                let hits = Arc::clone(&hits);
                 std::thread::spawn(move || {
-                    let _ = handle_conn(stream, flag);
+                    let _ = handle_conn(stream, flag, hits);
                 });
             }
         });
-        Self { port, filter }
+        Self {
+            port,
+            filter,
+            blocked,
+        }
+    }
+
+    fn blocked_count(&self) -> usize {
+        self.blocked.load(Ordering::SeqCst)
     }
 
     fn url(&self) -> String {
@@ -94,7 +106,11 @@ fn read_http_request(
     Ok(Some((head, body)))
 }
 
-fn handle_conn(mut client: std::net::TcpStream, filter: Arc<AtomicBool>) -> std::io::Result<()> {
+fn handle_conn(
+    mut client: std::net::TcpStream,
+    filter: Arc<AtomicBool>,
+    blocked: Arc<std::sync::atomic::AtomicUsize>,
+) -> std::io::Result<()> {
     while let Some((head, body)) = read_http_request(&mut client)? {
         let head_str = String::from_utf8_lossy(&head).to_string();
         let is_put = head_str
@@ -105,6 +121,7 @@ fn handle_conn(mut client: std::net::TcpStream, filter: Arc<AtomicBool>) -> std:
             .windows(MANAGER_VSS_KEY.len())
             .any(|w| w == MANAGER_VSS_KEY);
         if filter.load(Ordering::SeqCst) && is_put && has_manager_key {
+            blocked.fetch_add(1, Ordering::SeqCst);
             client.write_all(
                 b"HTTP/1.1 502 Bad Gateway\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
             )?;
@@ -154,16 +171,20 @@ fn node_ldk_log_contains(dir: &std::path::Path, needle: &str) -> bool {
     false
 }
 
-#[test]
-#[serial]
-fn restore_keeps_channel_when_manager_replication_lagged() {
-    ensure_regtest_available();
-    if !vss_server_available() {
-        eprintln!("SKIP: VSS server not available at {VSS_SERVER_ADDR}");
-        return;
-    }
+struct LagSetup {
+    proxy: ManagerFilterProxy,
+    node_a: SdkNode,
+    node_b: SdkNode,
+    node_a_dir: std::path::PathBuf,
+    mnemonic_a: String,
+    node_b_pubkey: bitcoin::secp256k1::PublicKey,
+    peer_uri: String,
+    channel_id: lightning::ln::types::ChannelId,
+}
 
-    let test_dir = test_dir("vss_manager_lag");
+/// Init both nodes and open an RGB channel with full VSS replication.
+fn setup_with_open_channel(test_name: &str) -> LagSetup {
+    let test_dir = test_dir(test_name);
     if test_dir.exists() {
         fs::remove_dir_all(&test_dir).expect("clean previous test dir");
     }
@@ -173,7 +194,6 @@ fn restore_keeps_channel_when_manager_replication_lagged() {
 
     let proxy = ManagerFilterProxy::start();
 
-    // Phase 1: open a channel while manager replication silently fails.
     let node_a = make_node_with_vss(
         &node_a_dir,
         NODE_A_DAEMON_PORT + NODE_A_PORT_OFFSET,
@@ -212,8 +232,6 @@ fn restore_keeps_channel_when_manager_replication_lagged() {
         .expect("node A issueassetnia");
     let asset_id = asset.asset_id;
 
-    proxy.block_manager_writes();
-
     let node_b_pubkey = node_b.node_info().expect("node B node_info").pubkey;
     let peer_uri = format!(
         "{node_b_pubkey}@127.0.0.1:{}",
@@ -246,51 +264,206 @@ fn restore_keeps_channel_when_manager_replication_lagged() {
         .get_channel_id(open_channel.temporary_channel_id)
         .expect("node A get_channel_id");
 
-    // Phase 2: graceful shutdown drops the pending queue; wipe the device.
-    node_a.shutdown();
-    drop(node_a);
-    proxy.allow_all();
+    LagSetup {
+        proxy,
+        node_a,
+        node_b,
+        node_a_dir,
+        mnemonic_a,
+        node_b_pubkey,
+        peer_uri,
+        channel_id,
+    }
+}
 
-    fs::remove_dir_all(&node_a_dir).expect("wipe node A storage");
+fn keysend_raw(node: &SdkNode, dest: bitcoin::secp256k1::PublicKey) -> PaymentHash {
+    node.keysend(SdkKeysendRequest {
+        dest_pubkey: dest,
+        amt_msat: 3_000_000,
+        asset_id: None,
+        asset_amount: None,
+    })
+    .expect("keysend")
+    .payment_hash
+}
 
-    // Phase 3: fresh device, same mnemonic, by-the-book restore.
+fn payment_is_succeeded(node: &SdkNode, hash: &PaymentHash) -> bool {
+    node.list_payments()
+        .expect("list_payments")
+        .into_iter()
+        .any(|p| p.payment_hash == *hash && matches!(p.status, HtlcStatus::Succeeded))
+}
+
+fn restore_node_a(setup: &LagSetup) -> (SdkNode, Result<(), rgb_lightning_node::RlnError>) {
+    fs::remove_dir_all(&setup.node_a_dir).expect("wipe node A storage");
     let node_a = make_node_with_vss(
-        &node_a_dir,
+        &setup.node_a_dir,
         NODE_A_DAEMON_PORT + NODE_A_PORT_OFFSET,
         NODE_A_PEER_PORT + NODE_A_PORT_OFFSET,
-        &proxy.url(),
+        &setup.proxy.url(),
     );
     let mnemonic_returned = node_a
-        .init(PASSWORD_A.to_string(), Some(mnemonic_a.clone()))
+        .init(PASSWORD_A.to_string(), Some(setup.mnemonic_a.clone()))
         .expect("node A re-init");
-    assert_eq!(mnemonic_returned, mnemonic_a);
+    assert_eq!(mnemonic_returned, setup.mnemonic_a);
     node_a
         .vss_clear_fence(SdkVssClearFenceRequest {
             password: PASSWORD_A.to_string(),
         })
         .expect("node A vss_clear_fence");
+    let unlock_res = node_a.unlock(unlock_request(PASSWORD_A));
+    (node_a, unlock_res)
+}
 
-    // Phase 4: refuse loudly or keep the channel; silent empty success is the bug.
-    match node_a.unlock(unlock_request(PASSWORD_A)) {
-        Err(e) => {
-            eprintln!("unlock refused as expected: {e:?}");
-            assert!(
-                !node_ldk_log_contains(&node_a_dir, "force closed, should broadcast: true"),
-                "a refused unlock must not have broadcast a force-close"
-            );
-        }
-        Ok(()) => {
-            let channels = node_a.list_channels().expect("node A list_channels");
-            let channel_ids: Vec<_> = channels.iter().map(|c| c.channel_id).collect();
-            assert!(
-                channel_ids.contains(&channel_id),
-                "unlock succeeded after the restore, so channel {channel_id} must be intact; \
-                 got channels: {channel_ids:?}"
-            );
-        }
+/// A VSS outage pauses event processing (manager persists are remote-first)
+/// instead of letting the backup lag: after recovery and a graceful shutdown,
+/// a wipe-and-restore keeps the channel.
+#[test]
+#[serial]
+fn manager_replication_outage_cannot_poison_restore() {
+    ensure_regtest_available();
+    if !vss_server_available() {
+        eprintln!("SKIP: VSS server not available at {VSS_SERVER_ADDR}");
+        return;
     }
 
-    // Cleanup
+    let setup = setup_with_open_channel("vss_manager_lag_recovers");
+
+    setup.proxy.block_manager_writes();
+
+    // First payment's events may process before its manager persist blocks;
+    // the second payment's events sit behind the blocked persist.
+    let hash1 = keysend_raw(&setup.node_a, setup.node_b_pubkey);
+    std::thread::sleep(Duration::from_secs(5));
+    let hash2 = keysend_raw(&setup.node_a, setup.node_b_pubkey);
+    std::thread::sleep(Duration::from_secs(15));
+    assert!(
+        setup.proxy.blocked_count() > 0,
+        "the proxy must have rejected manager puts, or this test exercises nothing"
+    );
+    assert!(
+        !payment_is_succeeded(&setup.node_a, &hash2),
+        "second payment must stay pending while the manager cannot reach VSS"
+    );
+
+    setup.proxy.allow_all();
+    wait_for_succeeded_payment_in_list(&setup.node_a, &hash1, Duration::from_secs(60));
+    wait_for_succeeded_payment_in_list(&setup.node_a, &hash2, Duration::from_secs(60));
+
+    setup.node_a.shutdown();
+
+    let (node_a, unlock_res) = restore_node_a(&setup);
+    unlock_res.expect("restore after a recovered outage must unlock");
+    let channels = node_a.list_channels().expect("node A list_channels");
+    assert!(
+        channels.iter().any(|c| c.channel_id == setup.channel_id),
+        "channel must survive the restore"
+    );
+    assert!(
+        payment_is_succeeded(&node_a, &hash1) && payment_is_succeeded(&node_a, &hash2),
+        "restored node must know both payments as succeeded"
+    );
+
+    // The channel must be functional, not just listed.
+    node_a
+        .connectpeer(setup.peer_uri.clone())
+        .expect("node A reconnect");
+    wait_for_channel_ready(&node_a, setup.channel_id, Duration::from_secs(60));
+
     node_a.shutdown();
-    node_b.shutdown();
+    setup.node_b.shutdown();
+}
+
+/// If the node stops while VSS is still down, the bounded shutdown flush gives
+/// up and the backup keeps the stale manager; the restore must then refuse to
+/// unlock instead of silently force-closing.
+#[test]
+#[serial]
+fn restore_refuses_when_final_flush_fails() {
+    ensure_regtest_available();
+    if !vss_server_available() {
+        eprintln!("SKIP: VSS server not available at {VSS_SERVER_ADDR}");
+        return;
+    }
+
+    let setup = setup_with_open_channel("vss_manager_lag_refuses");
+
+    setup.proxy.block_manager_writes();
+    let _hash = keysend_raw(&setup.node_a, setup.node_b_pubkey);
+    std::thread::sleep(Duration::from_secs(10));
+    assert!(
+        setup.proxy.blocked_count() > 0,
+        "the proxy must have rejected manager puts, or this test exercises nothing"
+    );
+
+    // Monitors advanced past the last manager that reached VSS; the bounded
+    // flush gives up on the newer manager while the proxy still blocks it.
+    let shutdown_started = std::time::Instant::now();
+    setup.node_a.shutdown();
+    let shutdown_elapsed = shutdown_started.elapsed();
+    assert!(
+        shutdown_elapsed >= Duration::from_secs(25),
+        "shutdown must have waited for the bounded flush (took {shutdown_elapsed:?})"
+    );
+    setup.proxy.allow_all();
+
+    let (node_a, unlock_res) = restore_node_a(&setup);
+    assert!(
+        unlock_res.is_err(),
+        "restore with a stale manager must refuse to unlock"
+    );
+    // A retry must hit the guard again, not skip the restore and force-close.
+    assert!(
+        node_a.unlock(unlock_request(PASSWORD_A)).is_err(),
+        "second unlock attempt must be refused again"
+    );
+    assert!(
+        !node_ldk_log_contains(&setup.node_a_dir, "force closed, should broadcast: true"),
+        "a refused unlock must not have broadcast a force-close"
+    );
+    // Nothing was broadcast: node B must still see the channel open on-chain.
+    mine(6);
+    std::thread::sleep(Duration::from_secs(5));
+    assert!(
+        setup
+            .node_b
+            .list_channels()
+            .expect("node B list_channels")
+            .iter()
+            .any(|c| c.channel_id == setup.channel_id),
+        "counterparty must still see the channel open after a refused restore"
+    );
+    node_a.shutdown();
+    drop(node_a);
+
+    // The explicit override accepts the force-close: unlock proceeds and the
+    // channel is gone, proving the refusal above was the consistency guard.
+    fs::remove_dir_all(&setup.node_a_dir).expect("wipe refused node dir");
+    let node_a = make_node_with_vss_allow_empty(
+        &setup.node_a_dir,
+        NODE_A_DAEMON_PORT + NODE_A_PORT_OFFSET,
+        NODE_A_PEER_PORT + NODE_A_PORT_OFFSET,
+        &setup.proxy.url(),
+    );
+    node_a
+        .init(PASSWORD_A.to_string(), Some(setup.mnemonic_a.clone()))
+        .expect("override re-init");
+    node_a
+        .vss_clear_fence(SdkVssClearFenceRequest {
+            password: PASSWORD_A.to_string(),
+        })
+        .expect("override clear fence");
+    node_a
+        .unlock(unlock_request(PASSWORD_A))
+        .expect("unlock with --vss-allow-empty-restore must proceed");
+    assert!(
+        node_a
+            .list_channels()
+            .expect("node A list_channels")
+            .is_empty(),
+        "override accepts the force-close: the stale-manager channel is gone"
+    );
+
+    node_a.shutdown();
+    setup.node_b.shutdown();
 }

--- a/src/test/lib_sdk/vss_manager_lag.rs
+++ b/src/test/lib_sdk/vss_manager_lag.rs
@@ -1,0 +1,306 @@
+//! Reproduces the 2026-07 field incident: the channel-manager key on VSS lags
+//! behind the (remote-first) channel monitors, so a fresh-device restore loads
+//! a manager that does not know the channel and LDK force-closes it
+//! (`OutdatedChannelManager`) — `listchannels` comes back empty even though
+//! the restore itself "succeeded".
+//!
+//! The lag is driven through the production write path: an HTTP proxy in
+//! front of VSS rejects only PUTs of the `_/_/manager` key (a transient-style
+//! 502), which the best-effort `SyncedKvStore` replication absorbs into its
+//! in-memory pending queue. Monitor writes (RemoteFirstKvStore) pass through
+//! untouched. A graceful shutdown then discards the queue silently.
+//!
+//! Requires the regtest stack (`./regtest.sh start`) and the VSS server
+//! (`docker compose --profile vss up -d`).
+
+use crate::helpers::*;
+use serial_test::serial;
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::{fs, time::Duration};
+
+const VSS_SERVER_ADDR: &str = "127.0.0.1:8081";
+const NODE_A_PORT_OFFSET: u16 = 110;
+const NODE_B_PORT_OFFSET: u16 = 110;
+const PASSWORD_A: &str = "nodeApass";
+const PASSWORD_B: &str = "nodeBpass";
+const MANAGER_VSS_KEY: &[u8] = b"_/_/manager";
+
+fn vss_server_available() -> bool {
+    std::net::TcpStream::connect_timeout(&VSS_SERVER_ADDR.parse().unwrap(), Duration::from_secs(2))
+        .is_ok()
+}
+
+/// HTTP proxy for the VSS server that can reject writes of the
+/// channel-manager key while passing everything else through — most
+/// importantly all channel-monitor writes.
+struct ManagerFilterProxy {
+    port: u16,
+    filter: Arc<AtomicBool>,
+}
+
+impl ManagerFilterProxy {
+    fn start() -> Self {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let filter = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&filter);
+        std::thread::spawn(move || {
+            for conn in listener.incoming() {
+                let Ok(stream) = conn else { break };
+                let flag = Arc::clone(&flag);
+                std::thread::spawn(move || {
+                    let _ = handle_conn(stream, flag);
+                });
+            }
+        });
+        Self { port, filter }
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}/vss", self.port)
+    }
+
+    fn block_manager_writes(&self) {
+        self.filter.store(true, Ordering::SeqCst);
+    }
+
+    fn allow_all(&self) {
+        self.filter.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Reads one HTTP/1.1 request; `None` on a clean close between requests.
+fn read_http_request(
+    stream: &mut std::net::TcpStream,
+) -> std::io::Result<Option<(Vec<u8>, Vec<u8>)>> {
+    let mut head = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        if stream.read(&mut byte)? == 0 {
+            return Ok(None);
+        }
+        head.push(byte[0]);
+        if head.ends_with(b"\r\n\r\n") {
+            break;
+        }
+        if head.len() > 64 * 1024 {
+            return Ok(None);
+        }
+    }
+    let head_str = String::from_utf8_lossy(&head).to_string();
+    let content_length = head_str
+        .lines()
+        .find_map(|l| {
+            let (name, value) = l.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+                value.trim().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
+    let mut body = vec![0u8; content_length];
+    stream.read_exact(&mut body)?;
+    Ok(Some((head, body)))
+}
+
+fn handle_conn(mut client: std::net::TcpStream, filter: Arc<AtomicBool>) -> std::io::Result<()> {
+    while let Some((head, body)) = read_http_request(&mut client)? {
+        let head_str = String::from_utf8_lossy(&head).to_string();
+        let is_put = head_str.lines().next().is_some_and(|l| l.contains("putObject"));
+        let has_manager_key = body
+            .windows(MANAGER_VSS_KEY.len())
+            .any(|w| w == MANAGER_VSS_KEY);
+        if filter.load(Ordering::SeqCst) && is_put && has_manager_key {
+            client.write_all(
+                b"HTTP/1.1 502 Bad Gateway\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            )?;
+            return Ok(());
+        }
+        // Forward on a fresh upstream connection with `Connection: close` so
+        // the response is delimited by EOF and needs no framing of its own.
+        let mut upstream = std::net::TcpStream::connect(VSS_SERVER_ADDR)?;
+        let mut new_head = String::new();
+        for line in head_str.split("\r\n") {
+            if line.is_empty() {
+                continue;
+            }
+            if let Some((name, _)) = line.split_once(':') {
+                if name.eq_ignore_ascii_case("connection") {
+                    continue;
+                }
+            }
+            new_head.push_str(line);
+            new_head.push_str("\r\n");
+        }
+        new_head.push_str("connection: close\r\n\r\n");
+        upstream.write_all(new_head.as_bytes())?;
+        upstream.write_all(&body)?;
+        std::io::copy(&mut upstream, &mut client)?;
+        return Ok(());
+    }
+    Ok(())
+}
+
+/// Recursively searches a node dir for LDK `logs.txt` files containing `needle`.
+fn node_ldk_log_contains(dir: &std::path::Path, needle: &str) -> bool {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if node_ldk_log_contains(&path, needle) {
+                return true;
+            }
+        } else if path.file_name().is_some_and(|n| n == "logs.txt") {
+            if fs::read_to_string(&path).is_ok_and(|c| c.contains(needle)) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[test]
+#[serial]
+fn restore_keeps_channel_when_manager_replication_lagged() {
+    ensure_regtest_available();
+    if !vss_server_available() {
+        eprintln!("SKIP: VSS server not available at {VSS_SERVER_ADDR}");
+        return;
+    }
+
+    let test_dir = test_dir("vss_manager_lag");
+    if test_dir.exists() {
+        fs::remove_dir_all(&test_dir).expect("clean previous test dir");
+    }
+    fs::create_dir_all(&test_dir).expect("create test dir");
+    let node_a_dir = test_dir.join("node_a");
+    let node_b_dir = test_dir.join("node_b");
+
+    let proxy = ManagerFilterProxy::start();
+
+    // --- Phase 1: node A (VSS via proxy) + peer B, channel while manager
+    // replication silently fails. ---
+    let node_a = make_node_with_vss(
+        &node_a_dir,
+        NODE_A_DAEMON_PORT + NODE_A_PORT_OFFSET,
+        NODE_A_PEER_PORT + NODE_A_PORT_OFFSET,
+        &proxy.url(),
+    );
+    let node_b = make_node(
+        &node_b_dir,
+        NODE_B_DAEMON_PORT + NODE_B_PORT_OFFSET,
+        NODE_B_PEER_PORT + NODE_B_PORT_OFFSET,
+    );
+
+    let mnemonic_a = node_a
+        .init(PASSWORD_A.to_string(), None)
+        .expect("node A init");
+    node_b
+        .init(PASSWORD_B.to_string(), None)
+        .expect("node B init");
+    node_a
+        .unlock(unlock_request(PASSWORD_A))
+        .expect("node A initial unlock");
+    node_b
+        .unlock(unlock_request(PASSWORD_B))
+        .expect("node B initial unlock");
+
+    fund_and_create_utxos(&node_a, "node A");
+    fund_and_create_utxos(&node_b, "node B");
+
+    let asset = node_a
+        .issueassetnia(SdkIssueAssetNiaRequest {
+            amounts: vec![1_000],
+            ticker: "USDT".to_string(),
+            name: "Tether".to_string(),
+            precision: 0,
+        })
+        .expect("node A issueassetnia");
+    let asset_id = asset.asset_id;
+
+    // From here on the manager key never reaches VSS again (transient-style
+    // 502s absorbed by the best-effort replication queue); monitors do.
+    proxy.block_manager_writes();
+
+    let node_b_pubkey = node_b.node_info().expect("node B node_info").pubkey;
+    let peer_uri = format!(
+        "{node_b_pubkey}@127.0.0.1:{}",
+        NODE_B_PEER_PORT + NODE_B_PORT_OFFSET
+    );
+    node_a
+        .connectpeer(peer_uri.clone())
+        .expect("node A connectpeer");
+
+    let open_channel = node_a
+        .openchannel(SdkOpenChannelRequest {
+            peer_pubkey_and_opt_addr: peer_uri.clone(),
+            capacity_sat: OPEN_CHANNEL_CAPACITY_SAT,
+            push_msat: 0,
+            public: true,
+            with_anchors: true,
+            fee_base_msat: None,
+            fee_proportional_millionths: None,
+            temporary_channel_id: None,
+            asset_id: Some(asset_id.clone()),
+            asset_amount: Some(600),
+            push_asset_amount: None,
+            virtual_open_mode: None,
+        })
+        .expect("node A openchannel");
+    wait_for_channel_funding_tx(&node_a, &node_b, &asset_id, Duration::from_secs(120));
+    mine(OPEN_CHANNEL_CONFIRM_BLOCKS);
+    wait_for_usable_channel(&node_a, &node_b, &asset_id, Duration::from_secs(300));
+    let channel_id = node_a
+        .get_channel_id(open_channel.temporary_channel_id)
+        .expect("node A get_channel_id");
+
+    // --- Phase 2: graceful shutdown (drops the pending replication queue),
+    // outage "ends", node A device is wiped. ---
+    node_a.shutdown();
+    drop(node_a);
+    proxy.allow_all();
+
+    fs::remove_dir_all(&node_a_dir).expect("wipe node A storage");
+
+    // --- Phase 3: fresh device, same mnemonic, by-the-book restore. ---
+    let node_a = make_node_with_vss(
+        &node_a_dir,
+        NODE_A_DAEMON_PORT + NODE_A_PORT_OFFSET,
+        NODE_A_PEER_PORT + NODE_A_PORT_OFFSET,
+        &proxy.url(),
+    );
+    let mnemonic_returned = node_a
+        .init(PASSWORD_A.to_string(), Some(mnemonic_a.clone()))
+        .expect("node A re-init");
+    assert_eq!(mnemonic_returned, mnemonic_a);
+    node_a
+        .vss_clear_fence(SdkVssClearFenceRequest {
+            password: PASSWORD_A.to_string(),
+        })
+        .expect("node A vss_clear_fence");
+    node_a
+        .unlock(unlock_request(PASSWORD_A))
+        .expect("node A unlock after restore");
+
+    // --- Phase 4: the channel must have survived the restore. ---
+    let channels = node_a.list_channels().expect("node A list_channels");
+    let channel_ids: Vec<_> = channels.iter().map(|c| c.channel_id).collect();
+    let force_closed_evidence =
+        node_ldk_log_contains(&node_a_dir, "hen we loaded") // "...was not found... when we loaded"
+            || node_ldk_log_contains(&node_a_dir, "Force-closing");
+    assert!(
+        channel_ids.contains(&channel_id),
+        "channel {channel_id} must survive a VSS restore even when manager replication lagged \
+         behind monitor replication; got channels: {channel_ids:?} \
+         (force-close evidence in LDK log: {force_closed_evidence})"
+    );
+
+    // Cleanup
+    node_a.shutdown();
+    node_b.shutdown();
+}

--- a/src/test/vss.rs
+++ b/src/test/vss.rs
@@ -1058,6 +1058,28 @@ mod tests {
         );
 
         router
+            .write(
+                lightning::util::persist::OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
+                lightning::util::persist::OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
+                lightning::util::persist::OUTPUT_SWEEPER_PERSISTENCE_KEY,
+                b"sw1".to_vec(),
+            )
+            .await
+            .expect("sweeper write");
+        assert_eq!(
+            remote
+                .read_async(
+                    lightning::util::persist::OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE,
+                    lightning::util::persist::OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE,
+                    lightning::util::persist::OUTPUT_SWEEPER_PERSISTENCE_KEY,
+                )
+                .await
+                .expect("on VSS"),
+            b"sw1".to_vec(),
+            "sweeper state must be durable on VSS when the write completes"
+        );
+
+        router
             .write("", "", NETWORK_GRAPH_PERSISTENCE_KEY, b"g1".to_vec())
             .await
             .expect("graph write");
@@ -1105,5 +1127,110 @@ mod tests {
             remote.read_async("", "", "manager").await.expect("on VSS"),
             b"m2".to_vec(),
         );
+    }
+
+    /// Queued replications must survive a restart: a new SyncedKvStore over
+    /// the same local DB reloads them and a drain delivers them to VSS.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_queue_survives_restart_and_drains() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let proxy = super::super::vss_offline_force_close::VssProxy::start();
+        let (signing_key, store_id) = generate_test_keys();
+        let remote =
+            Arc::new(VssKvStore::new(proxy.url(), store_id, signing_key).expect("vss store"));
+        let conn = create_test_sqlite();
+        let local = Arc::new(SeaOrmKvStore::from_connection(Arc::clone(&conn)));
+
+        proxy.go_offline();
+        {
+            let synced = SyncedKvStore::with_vss(Arc::clone(&local), Arc::clone(&remote));
+            synced
+                .write("", "", "aux_a", b"v_a".to_vec())
+                .expect("local write during outage");
+            synced
+                .write("", "", "aux_b", b"v_b".to_vec())
+                .expect("local write during outage");
+            assert_eq!(synced.pending_remote_writes(), 2);
+        }
+
+        // "Restart": fresh store instance over the same local DB.
+        let synced = SyncedKvStore::with_vss(
+            Arc::new(SeaOrmKvStore::from_connection(conn)),
+            Arc::clone(&remote),
+        );
+        assert_eq!(
+            synced.pending_remote_writes(),
+            2,
+            "pending replications must be reloaded from the local DB"
+        );
+
+        proxy.go_online();
+        synced.drain_pending();
+        assert_eq!(synced.pending_remote_writes(), 0);
+        assert_eq!(
+            KVStoreSync::read(&*remote, "", "", "aux_a").expect("on VSS"),
+            b"v_a".to_vec()
+        );
+        assert_eq!(
+            KVStoreSync::read(&*remote, "", "", "aux_b").expect("on VSS"),
+            b"v_b".to_vec()
+        );
+
+        // Delivered rows must be gone from disk, or a later restart would
+        // resurrect and re-send stale values.
+        let reopened = SyncedKvStore::with_vss(Arc::clone(&local), Arc::clone(&remote));
+        assert_eq!(
+            reopened.pending_remote_writes(),
+            0,
+            "drained entries must not survive on disk"
+        );
+    }
+
+    /// A queued removal must also survive a restart and converge on VSS.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_removal_survives_restart_and_drains() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let proxy = super::super::vss_offline_force_close::VssProxy::start();
+        let (signing_key, store_id) = generate_test_keys();
+        let remote =
+            Arc::new(VssKvStore::new(proxy.url(), store_id, signing_key).expect("vss store"));
+        let conn = create_test_sqlite();
+        let local = Arc::new(SeaOrmKvStore::from_connection(Arc::clone(&conn)));
+
+        {
+            let synced = SyncedKvStore::with_vss(Arc::clone(&local), Arc::clone(&remote));
+            synced
+                .write("", "", "aux_rm", b"v".to_vec())
+                .expect("write");
+            proxy.go_offline();
+            synced
+                .remove("", "", "aux_rm", false)
+                .expect("local remove");
+            assert_eq!(synced.pending_remote_writes(), 1);
+        }
+
+        let synced = SyncedKvStore::with_vss(
+            Arc::new(SeaOrmKvStore::from_connection(conn)),
+            Arc::clone(&remote),
+        );
+        assert_eq!(synced.pending_remote_writes(), 1);
+
+        proxy.go_online();
+        synced.drain_pending();
+        assert_eq!(synced.pending_remote_writes(), 0);
+        assert!(
+            KVStoreSync::read(&*remote, "", "", "aux_rm").is_err(),
+            "queued removal must have converged on VSS"
+        );
+        let reopened = SyncedKvStore::with_vss(Arc::clone(&local), Arc::clone(&remote));
+        assert_eq!(reopened.pending_remote_writes(), 0);
     }
 }

--- a/src/test/vss.rs
+++ b/src/test/vss.rs
@@ -976,4 +976,40 @@ mod tests {
 
         client.delete_backup().await.expect("cleanup");
     }
+
+    /// A queued (failed) replication must never overwrite a newer value that
+    /// already replicated for the same key. Field incident 2026-07: the
+    /// channel manager on VSS ended up older than the channel monitors, so a
+    /// restore force-closed the channel (`OutdatedChannelManager`).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn synced_kv_store_drain_never_regresses_newer_write() {
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let proxy = super::super::vss_offline_force_close::VssProxy::start();
+        let (signing_key, store_id) = generate_test_keys();
+        let remote =
+            Arc::new(VssKvStore::new(proxy.url(), store_id, signing_key).expect("vss store"));
+        let synced = SyncedKvStore::with_vss(
+            Arc::new(SeaOrmKvStore::from_connection(create_test_sqlite())),
+            Arc::clone(&remote),
+        );
+
+        synced.write("", "", "manager", b"v1".to_vec()).expect("v1");
+
+        proxy.go_offline();
+        synced.write("", "", "manager", b"v2".to_vec()).expect("v2 local");
+        assert_eq!(synced.pending_remote_writes(), 1, "v2 must be queued");
+
+        proxy.go_online();
+        synced.write("", "", "manager", b"v3".to_vec()).expect("v3");
+
+        assert_eq!(
+            KVStoreSync::read(&*remote, "", "", "manager").expect("remote read"),
+            b"v3".to_vec(),
+            "remote must hold the newest value; a stale queued write must not regress it"
+        );
+    }
 }

--- a/src/test/vss.rs
+++ b/src/test/vss.rs
@@ -977,10 +977,6 @@ mod tests {
         client.delete_backup().await.expect("cleanup");
     }
 
-    /// A queued (failed) replication must never overwrite a newer value that
-    /// already replicated for the same key. Field incident 2026-07: the
-    /// channel manager on VSS ended up older than the channel monitors, so a
-    /// restore force-closed the channel (`OutdatedChannelManager`).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn synced_kv_store_drain_never_regresses_newer_write() {
         if !vss_server_available() {
@@ -1000,7 +996,9 @@ mod tests {
         synced.write("", "", "manager", b"v1".to_vec()).expect("v1");
 
         proxy.go_offline();
-        synced.write("", "", "manager", b"v2".to_vec()).expect("v2 local");
+        synced
+            .write("", "", "manager", b"v2".to_vec())
+            .expect("v2 local");
         assert_eq!(synced.pending_remote_writes(), 1, "v2 must be queued");
 
         proxy.go_online();

--- a/src/test/vss.rs
+++ b/src/test/vss.rs
@@ -993,21 +993,117 @@ mod tests {
             Arc::clone(&remote),
         );
 
-        synced.write("", "", "manager", b"v1".to_vec()).expect("v1");
+        synced
+            .write("", "", "aux_state", b"v1".to_vec())
+            .expect("v1");
 
         proxy.go_offline();
         synced
-            .write("", "", "manager", b"v2".to_vec())
+            .write("", "", "aux_state", b"v2".to_vec())
             .expect("v2 local");
         assert_eq!(synced.pending_remote_writes(), 1, "v2 must be queued");
 
         proxy.go_online();
-        synced.write("", "", "manager", b"v3".to_vec()).expect("v3");
+        synced
+            .write("", "", "aux_state", b"v3".to_vec())
+            .expect("v3");
 
         assert_eq!(
-            KVStoreSync::read(&*remote, "", "", "manager").expect("remote read"),
+            KVStoreSync::read(&*remote, "", "", "aux_state").expect("remote read"),
             b"v3".to_vec(),
             "remote must hold the newest value; a stale queued write must not regress it"
+        );
+    }
+
+    /// Manager writes must be VSS-durable before completing; graph/scorer must
+    /// never reach VSS; aux keys keep best-effort replication.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn bp_router_routes_manager_remote_first() {
+        use lightning::util::persist::{
+            KVStore, NETWORK_GRAPH_PERSISTENCE_KEY, SCORER_PERSISTENCE_KEY,
+        };
+
+        if !vss_server_available() {
+            eprintln!("SKIP: VSS server not available at {VSS_URL}");
+            return;
+        }
+
+        let proxy = super::super::vss_offline_force_close::VssProxy::start();
+        let (signing_key, store_id) = generate_test_keys();
+        let remote =
+            Arc::new(VssKvStore::new(proxy.url(), store_id, signing_key).expect("vss store"));
+        let local = Arc::new(SeaOrmKvStore::from_connection(create_test_sqlite()));
+        let remote_first = Arc::new(crate::async_kv_store::RemoteFirstKvStore::new(
+            Arc::clone(&local),
+            Some(Arc::clone(&remote)),
+        ));
+        let synced = Arc::new(SyncedKvStore::with_vss(
+            Arc::clone(&local),
+            Arc::clone(&remote),
+        ));
+        let router = Arc::new(crate::async_kv_store::BpKvStoreRouter::new(
+            Arc::clone(&remote_first),
+            Arc::clone(&local),
+            synced,
+        ));
+
+        router
+            .write("", "", "manager", b"m1".to_vec())
+            .await
+            .expect("manager write");
+        assert_eq!(
+            remote.read_async("", "", "manager").await.expect("on VSS"),
+            b"m1".to_vec(),
+            "manager must be durable on VSS when the write completes"
+        );
+
+        router
+            .write("", "", NETWORK_GRAPH_PERSISTENCE_KEY, b"g1".to_vec())
+            .await
+            .expect("graph write");
+        router
+            .write("", "", SCORER_PERSISTENCE_KEY, b"s1".to_vec())
+            .await
+            .expect("scorer write");
+        assert!(
+            remote
+                .read_async("", "", NETWORK_GRAPH_PERSISTENCE_KEY)
+                .await
+                .is_err(),
+            "network graph must not replicate to VSS"
+        );
+        assert!(
+            remote
+                .read_async("", "", SCORER_PERSISTENCE_KEY)
+                .await
+                .is_err(),
+            "scorer must not replicate to VSS"
+        );
+        assert!(
+            KVStoreSync::read(&*local, "", "", NETWORK_GRAPH_PERSISTENCE_KEY).is_ok(),
+            "network graph must be stored locally"
+        );
+
+        // Manager write during an outage blocks (retry loop) instead of
+        // acking; it completes once VSS is back and lands durably.
+        proxy.go_offline();
+        let router_task = Arc::clone(&router);
+        let pending =
+            tokio::spawn(async move { router_task.write("", "", "manager", b"m2".to_vec()).await });
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        assert!(
+            !pending.is_finished(),
+            "manager write must not complete while VSS is unreachable"
+        );
+        proxy.go_online();
+        tokio::time::timeout(Duration::from_secs(30), pending)
+            .await
+            .expect("write must finish after recovery")
+            .expect("join")
+            .expect("write ok");
+        assert_eq!(
+            remote.read_async("", "", "manager").await.expect("on VSS"),
+            b"m2".to_vec(),
         );
     }
 }

--- a/src/test/vss_offline_force_close.rs
+++ b/src/test/vss_offline_force_close.rs
@@ -7,7 +7,7 @@ const VSS_SERVER_ADDR: &str = "127.0.0.1:8081";
 /// simulating a VSS outage for a single node without touching the shared
 /// service. Offline: established connections are cut and new ones are closed
 /// on accept.
-struct VssProxy {
+pub(super) struct VssProxy {
     port: u16,
     online: tokio::sync::watch::Sender<bool>,
 }
@@ -15,7 +15,7 @@ struct VssProxy {
 impl VssProxy {
     // The proxy gets a dedicated thread + runtime: the shared test runtime can
     // stall for seconds on synchronous KVStore calls and would starve it.
-    fn start() -> Self {
+    pub(super) fn start() -> Self {
         let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         std_listener.set_nonblocking(true).unwrap();
         let port = std_listener.local_addr().unwrap().port();
@@ -50,15 +50,15 @@ impl VssProxy {
         Self { port, online }
     }
 
-    fn url(&self) -> String {
+    pub(super) fn url(&self) -> String {
         format!("http://127.0.0.1:{}/vss", self.port)
     }
 
-    fn go_offline(&self) {
+    pub(super) fn go_offline(&self) {
         self.online.send(false).unwrap();
     }
 
-    fn go_online(&self) {
+    pub(super) fn go_online(&self) {
         self.online.send(true).unwrap();
     }
 }


### PR DESCRIPTION
Fixes #110.

A VSS backup could hold a channel manager older than the monitors; restoring it silently force-closed the affected channels.

## Changes

- Fix the replication retry queue overwriting newer values on VSS with stale queued ones.
- Persist the channel manager and sweeper state remote-first (same guarantees as monitors); network graph and scorer become local-only.
- Make the retry queue durable: pending replications survive restarts, drain on a 60s timer and get a bounded flush at shutdown.
- Bound the shutdown flush to 30s so a VSS outage cannot hang shutdown.
- Refuse to unlock after a restore whose manager lags a still-open monitor, instead of silently force-closing; a dedicated `--vss-accept-inconsistent-restore` flag overrides (kept separate from `--vss-allow-empty-restore` so bootstrap automation cannot pre-accept force-closes by accident).
- Network graph and scorer are now also read back from the local DB at startup, so routing data survives restarts (previously they were persisted but read from never-written files).

## Trade-offs

- During a VSS outage the node pauses event processing, including on-chain fee-bumping of pending force-closes; everything resumes when VSS recovers. VSS reachability should be monitored as a deployment requirement.
- Shutdown during an outage takes up to 30s and the next restore is refused by the guard.
- Graph and scorer no longer replicate; routing data rebuilds from gossip.

## Tests

Unit tests for the queue regression, routing and queue durability; e2e for outage-then-restore keeping the channel and shutdown-during-outage leading to a refused restore; existing VSS suites pass unchanged.
