### PR TITLE
Settle on-chain RGB and BTC on the wasm side after channel close

### DIFF
--- a/bindings/wasm-sdk/examples/wasm-interop/manual_js_rgb_coop_close_settlement_flow.js
+++ b/bindings/wasm-sdk/examples/wasm-interop/manual_js_rgb_coop_close_settlement_flow.js
@@ -17,13 +17,12 @@
 // >= the expected in-channel amount within the settlement timeout, while passing end-to-end once
 // the wasm sweep pipeline exists.
 //
-// Steps:
-//   0. hub funds its wallet, issues NIA, opens the real RGB channel to us with push (300 RGB).
-//   1. hub → wasm RGB keysend (50 RGB) → wasm in-channel RGB = 350.
-//   2. snapshot pre-close wallet balances (on-chain RGB expected 0 — everything is in-channel).
-//   3. wasm cooperatively closes the channel; both sides negotiate the colored closing tx.
-//   4. pump chain sync + RGB work while mining; wait for the native side to settle (control),
-//      then assert the wasm side's getAssetBalance reaches the expected 350 on-chain.
+// The flow: the hub funds its wallet, issues NIA and opens the real RGB channel to us with
+// push (300 RGB); a hub → wasm RGB keysend (50 RGB) brings the wasm in-channel RGB to 350;
+// pre-close wallet balances are snapshotted (on-chain RGB expected 0 — everything is
+// in-channel); the wasm side cooperatively closes and both sides negotiate the colored closing
+// tx; finally chain sync + RGB work are pumped while mining until the native side settles
+// (control) and the wasm side's getAssetBalance reaches the expected 350 on-chain.
 //
 // Driven headlessly by run_coop_close_settlement_flow.mjs, or manually via
 // rgb_coop_close_settlement_flow.html.
@@ -59,7 +58,7 @@ const EXPECTED_HUB_RGB = ASSET_CHANNEL_AMOUNT - ASSET_PUSH_AMOUNT - RGB_KEYSEND_
 const CHANNEL_READY_TIMEOUT_MS = 240_000;
 const FUND_TIMEOUT_MS = 60_000;
 const PAYMENT_TIMEOUT_MS = 90_000;
-const RGB_FUNDING_STEP_TIMEOUT_MS = 30_000;
+const RGB_FUNDING_WORK_TIMEOUT_MS = 30_000;
 const FETCH_TIMEOUT_MS = 15_000;
 // Settlement needs: closing tx broadcast + confirm, SpendableOutputs maturity (ANTI_REORG_DELAY
 // = 6 confs), sweep broadcast + confirm, refresh. We mine continuously, so this bounds the
@@ -274,7 +273,7 @@ async function waitForUsableChannel(node, peer, gatewayUrl, walletAddress, timeo
       log(`chainSyncTick err iter=${iter}`, String(e));
     }
     try {
-      await withTimeout(node.driveRgbFundingWork(), RGB_FUNDING_STEP_TIMEOUT_MS, "driveRgbFundingWork");
+      await withTimeout(node.driveRgbFundingWork(), RGB_FUNDING_WORK_TIMEOUT_MS, "driveRgbFundingWork");
     } catch (e) {
       if (String(e).includes("timed out")) throw e;
     }
@@ -404,10 +403,10 @@ async function runFlow(cfg, runtimeId) {
   const nativePubkey = nativeInfo.pubkey;
   log("Native hub info", { pubkey: nativePubkey });
 
-  // === STEP 0a: hub issues the asset ===
+  // === bootstrap: hub issues the asset ===
   const assetId = await nativeBootstrapRgbAsset(cfg, walletAddress);
 
-  // === STEP 0b: connect to the hub ===
+  // === bootstrap: connect to the hub ===
   await node.connectPeer(cfg.nativePeerAddr, nativePubkey);
   {
     const live = JSON.parse(node.nodePubkeyJson());
@@ -424,7 +423,7 @@ async function runFlow(cfg, runtimeId) {
     await waitForNativePeer(node, cfg.nativeMgmtUrl, myPubkeyHex, 20_000).catch(() => {});
   };
 
-  // === STEP 0c: hub opens the REAL RGB channel to us ===
+  // === bootstrap: hub opens the REAL RGB channel to us ===
   log("Requesting native hub to open a REAL RGB channel to us...", {
     assetId, assetAmount: ASSET_CHANNEL_AMOUNT, pushAssetAmount: ASSET_PUSH_AMOUNT,
   });
@@ -457,7 +456,7 @@ async function runFlow(cfg, runtimeId) {
     Number(nativeChannel.asset_local_amount) === ASSET_CHANNEL_AMOUNT - ASSET_PUSH_AMOUNT,
     `hub-side asset_local_amount should be ${ASSET_CHANNEL_AMOUNT - ASSET_PUSH_AMOUNT}, got ${nativeChannel.asset_local_amount}`,
   );
-  log("✅ STEP 0 done — REAL RGB channel open + ready on both sides", {
+  log("✅ REAL RGB channel open + ready on both sides", {
     id: rgbChannelId,
     wasm_asset_local: rgbChannel.asset_local_amount,
     hub_asset_local: nativeChannel.asset_local_amount,
@@ -465,8 +464,8 @@ async function runFlow(cfg, runtimeId) {
 
   await settleChainConvergence(node);
 
-  // === STEP 1: hub → wasm RGB keysend (makes the wasm in-channel balance ≠ the pushed amount) ===
-  log("STEP 1: hub → wasm RGB keysend...", { assetId, asset: RGB_KEYSEND_AMOUNT, amtMsat: RGB_HTLC_MSAT });
+  // === hub → wasm RGB keysend (makes the wasm in-channel balance ≠ the pushed amount) ===
+  log("hub → wasm RGB keysend...", { assetId, asset: RGB_KEYSEND_AMOUNT, amtMsat: RGB_HTLC_MSAT });
   const hubKeysend = await nativePost(cfg.nativeMgmtUrl, "/keysend", {
     dest_pubkey: myPubkeyHex,
     amt_msat: RGB_HTLC_MSAT,
@@ -476,14 +475,14 @@ async function runFlow(cfg, runtimeId) {
   const hubKeysendSettled = await waitNativePaymentSettled(
     node, cfg, hubKeysend.payment_hash, "hub→wasm RGB keysend", PAYMENT_TIMEOUT_MS,
   );
-  log("✅ STEP 1 done — hub→wasm RGB keysend settled", hubKeysendSettled);
+  log("✅ hub→wasm RGB keysend settled", hubKeysendSettled);
 
-  // === STEP 2: pre-close snapshot ===
+  // === pre-close snapshot ===
   await settleChainConvergence(node, 4);
   const preCloseChannel = node.listChannelsValue().find((c) => c.channel_id === rgbChannelId);
   const preCloseWasmRgb = assetBalanceOrZero(wallet, assetId);
   const preCloseWasmBtc = wallet.getBtcBalanceValue();
-  log("STEP 2: pre-close snapshot", {
+  log("pre-close snapshot", {
     channel_asset_local: preCloseChannel?.asset_local_amount,
     channel_asset_remote: preCloseChannel?.asset_remote_amount,
     wasm_onchain_rgb: preCloseWasmRgb,
@@ -494,8 +493,8 @@ async function runFlow(cfg, runtimeId) {
     `wasm in-channel RGB should be ${EXPECTED_WASM_RGB} before close, got ${preCloseChannel?.asset_local_amount}`,
   );
 
-  // === STEP 3: WASM side cooperatively closes the channel ===
-  log("STEP 3: wasm initiates cooperative close...", { channel: rgbChannelId.slice(0, 16) });
+  // === WASM side cooperatively closes the channel ===
+  log("wasm initiates cooperative close...", { channel: rgbChannelId.slice(0, 16) });
   node.closeChannelWithOptions(rgbChannelId, nativePubkey, false);
   // Pump until both sides agree the channel is gone (shutdown + closing_signed negotiation
   // rides the normal peer pump; the colored closing tx needs process_pending_rgb_transactions,
@@ -515,12 +514,12 @@ async function runFlow(cfg, runtimeId) {
     assert(closedOnNative, "channel still listed on the native side after cooperative close");
   }
   await mineBlocks(cfg.gatewayUrl, walletAddress, 3);
-  log("✅ STEP 3 done — cooperative close negotiated, closing tx mined");
+  log("✅ cooperative close negotiated, closing tx mined");
 
-  // === STEP 4: settlement — mine + pump until BOTH sides recover their RGB on-chain ===
+  // === settlement — mine + pump until BOTH sides recover their RGB on-chain ===
   // Native side first (control: proves the closing tx really is colored and the infra works —
   // the native SpendableOutputs → RgbOutputSpender pipeline settles automatically).
-  log("STEP 4: waiting for on-chain RGB settlement (native control first, then wasm)...", {
+  log("waiting for on-chain RGB settlement (native control first, then wasm)...", {
     expected_hub: EXPECTED_HUB_RGB, expected_wasm: EXPECTED_WASM_RGB,
   });
   let nativeSettled = null;

--- a/bindings/wasm-sdk/examples/wasm-interop/manual_js_rgb_coop_close_settlement_flow.js
+++ b/bindings/wasm-sdk/examples/wasm-interop/manual_js_rgb_coop_close_settlement_flow.js
@@ -1,0 +1,633 @@
+// Repro / regression flow for: "On-chain RGB balance does not settle on the WASM side after
+// channel close" (hackmd bug report).
+//
+// A native hub opens a REAL, on-chain-funded, anchors RGB channel to the wasm node with
+// push_asset_amount (seeding the wasm side's in-channel RGB), one RGB keysend lands hub→wasm to
+// make the wasm balance distinct from the pushed amount, and then the WASM side cooperatively
+// closes the channel. After the colored closing transaction confirms:
+//
+//   - the NATIVE side recovers its RGB share on-chain automatically (SpendableOutputs →
+//     OutputSweeper → RgbOutputSpender colored sweep) — used here as the infra control;
+//   - the WASM side, on the bug, never settles: ChainMonitor events are never drained, there is
+//     no Event::SpendableOutputs handler, and no sweep pipeline exists, so
+//     wallet.getAssetBalance stays 0 forever even though the closing tx is colored and the
+//     transfer info is recorded.
+//
+// The flow fails with a REPRO marker if the wasm side's on-chain RGB balance does not become
+// >= the expected in-channel amount within the settlement timeout, while passing end-to-end once
+// the wasm sweep pipeline exists.
+//
+// Steps:
+//   0. hub funds its wallet, issues NIA, opens the real RGB channel to us with push (300 RGB).
+//   1. hub → wasm RGB keysend (50 RGB) → wasm in-channel RGB = 350.
+//   2. snapshot pre-close wallet balances (on-chain RGB expected 0 — everything is in-channel).
+//   3. wasm cooperatively closes the channel; both sides negotiate the colored closing tx.
+//   4. pump chain sync + RGB work while mining; wait for the native side to settle (control),
+//      then assert the wasm side's getAssetBalance reaches the expected 350 on-chain.
+//
+// Driven headlessly by run_coop_close_settlement_flow.mjs, or manually via
+// rgb_coop_close_settlement_flow.html.
+
+import init, {
+  RlnWasmNode,
+  RlnWasmSdk,
+  RlnWasmWallet,
+  rgbGenerateKeysValue,
+} from "../../pkg/rln_wasm_sdk.js";
+
+const DEFAULTS = {
+  nodeProxyUrl: "ws://127.0.0.1:3001",
+  esploraUrl: "http://127.0.0.1:3002",
+  rgbProxyUrl: "http://127.0.0.1:3001/rgb/json-rpc",
+  gatewayUrl: "http://127.0.0.1:3001",
+  nativePeerAddr: "127.0.0.1:9802",
+  nativeMgmtUrl: "http://127.0.0.1:3101",
+};
+
+const CHANNEL_CAPACITY_SAT = 1_000_000;
+const CHANNEL_PUSH_MSAT = 500_000_000; // 500k sat of BTC pushed to the wasm side
+const COLORED_UTXO_SIZE_SAT = CHANNEL_CAPACITY_SAT + 100_000;
+const ASSET_TOTAL_ISSUE = 2000; // NIA minted on the hub
+const ASSET_CHANNEL_AMOUNT = 600; // RGB committed into the channel on open
+const ASSET_PUSH_AMOUNT = 300; // RGB pushed to the wasm side on open (hub keeps 300)
+const RGB_KEYSEND_AMOUNT = 50; // hub → wasm keysend; wasm expects 350 on-chain after close
+const RGB_HTLC_MSAT = 3_000_000; // RGB-LN minimum BTC carried per HTLC
+
+const EXPECTED_WASM_RGB = ASSET_PUSH_AMOUNT + RGB_KEYSEND_AMOUNT; // 350
+const EXPECTED_HUB_RGB = ASSET_CHANNEL_AMOUNT - ASSET_PUSH_AMOUNT - RGB_KEYSEND_AMOUNT; // 250
+
+const CHANNEL_READY_TIMEOUT_MS = 240_000;
+const FUND_TIMEOUT_MS = 60_000;
+const PAYMENT_TIMEOUT_MS = 90_000;
+const RGB_FUNDING_STEP_TIMEOUT_MS = 30_000;
+const FETCH_TIMEOUT_MS = 15_000;
+// Settlement needs: closing tx broadcast + confirm, SpendableOutputs maturity (ANTI_REORG_DELAY
+// = 6 confs), sweep broadcast + confirm, refresh. We mine continuously, so this bounds the
+// whole tail of the flow.
+const SETTLEMENT_TIMEOUT_MS = Number(240_000);
+
+// ---------------------------------------------------------------------------
+// helpers (shared shape with manual_js_rgb_e2e_full_flow.js)
+// ---------------------------------------------------------------------------
+
+function safeJson(v) {
+  return JSON.stringify(v, (_k, x) => (typeof x === "bigint" ? x.toString() : x), 2);
+}
+
+function log(message, data) {
+  const out = document.getElementById("out");
+  const line = `${message}${data === undefined ? "" : `: ${safeJson(data)}`}`;
+  if (out) {
+    const pre = document.createElement("pre");
+    pre.textContent = line;
+    out.appendChild(pre);
+  }
+  console.log(`[e2e] ${line}`);
+}
+
+function readParam(name, fallback) {
+  const v = new URLSearchParams(window.location.search).get(name);
+  return v && v.trim() ? v.trim() : fallback;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withTimeout(promise, timeoutMs, label) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(`ASSERTION FAILED: ${msg}`);
+}
+
+async function mineBlocks(gatewayUrl, address, count) {
+  try {
+    const resp = await fetch(`${gatewayUrl}/dev/regtest/fund`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ address, amount_btc: 0.0001, mine_blocks: count }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!resp.ok) log(`mineBlocks HTTP ${resp.status}`, await resp.text().catch(() => ""));
+  } catch (e) {
+    log("mineBlocks error", String(e));
+  }
+}
+
+async function nativeGet(nativeMgmtUrl, path) {
+  const resp = await fetch(`${nativeMgmtUrl}${path}`, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!resp.ok) throw new Error(`${path} failed: ${resp.status} ${await resp.text().catch(() => "")}`);
+  return resp.json();
+}
+
+async function nativePost(nativeMgmtUrl, path, body, timeoutMs = FETCH_TIMEOUT_MS) {
+  const resp = await fetch(`${nativeMgmtUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const text = await resp.text().catch(() => "");
+  if (!resp.ok) throw new Error(`${path} failed: ${resp.status} ${text.slice(0, 300)}`);
+  return text ? JSON.parse(text) : {};
+}
+
+async function withRetry(fn, attempts, onRetry) {
+  let lastErr;
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastErr = e;
+      log(`attempt ${i}/${attempts} failed`, String(e));
+      if (i < attempts && onRetry) await onRetry();
+    }
+  }
+  throw lastErr;
+}
+
+async function fundAddress(gatewayUrl, address, amountBtc, mineBlocksCount) {
+  const resp = await fetch(`${gatewayUrl}/dev/regtest/fund`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ address, amount_btc: amountBtc, mine_blocks: mineBlocksCount }),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!resp.ok) throw new Error(`fund ${address} failed: ${resp.status} ${await resp.text().catch(() => "")}`);
+}
+
+// Wait until the native hub's on-chain wallet actually sees at least `minSat` of vanilla funds.
+async function waitNativeFunds(cfg, minSat, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const bal = await nativePost(cfg.nativeMgmtUrl, "/btcbalance", { skip_sync: false }).catch(() => null);
+    const spendable = Number(bal?.vanilla?.spendable ?? 0);
+    if (spendable >= minSat) return bal;
+    await sleep(2000);
+  }
+  throw new Error(`native hub wallet did not see ${minSat} sat within ${timeoutMs}ms`);
+}
+
+// Bootstrap the native hub as the RGB issuer: fund its wallet, create colored UTXOs, issue NIA.
+async function nativeBootstrapRgbAsset(cfg, walletAddress) {
+  const { address: nativeAddr } = await nativePost(cfg.nativeMgmtUrl, "/address", {});
+  log("Native hub wallet address", { nativeAddr });
+  await fundAddress(cfg.gatewayUrl, nativeAddr, 1, 6);
+  await waitNativeFunds(cfg, COLORED_UTXO_SIZE_SAT * 5 + 1_000_000);
+  await nativePost(cfg.nativeMgmtUrl, "/refreshtransfers", { asset_id: null, filter: [], skip_sync: false }).catch(() => {});
+
+  await withRetry(
+    () => nativePost(cfg.nativeMgmtUrl, "/createutxos", {
+      up_to: false, num: 5, size: COLORED_UTXO_SIZE_SAT, fee_rate: 1, skip_sync: false,
+    }),
+    5,
+    () => sleep(3000),
+  );
+  await mineBlocks(cfg.gatewayUrl, walletAddress, 3);
+  await nativePost(cfg.nativeMgmtUrl, "/refreshtransfers", { asset_id: null, filter: [], skip_sync: false }).catch(() => {});
+
+  const issued = await nativePost(cfg.nativeMgmtUrl, "/issueassetnia", {
+    ticker: "CLS", name: "Coop Close Settlement Repro", precision: 0, amounts: [ASSET_TOTAL_ISSUE],
+  });
+  const assetId = issued.asset.asset_id;
+  log("Native hub issued NIA asset", { assetId });
+  await mineBlocks(cfg.gatewayUrl, walletAddress, 3);
+  await nativePost(cfg.nativeMgmtUrl, "/refreshtransfers", { asset_id: null, filter: [], skip_sync: false }).catch(() => {});
+  return assetId;
+}
+
+function wasmPeerView(node) {
+  try {
+    return JSON.parse(node.listPeersJson()).map((p) => ({ pk: (p.pubkey || "").slice(0, 12), started: p.started }));
+  } catch (_e) {
+    return "n/a";
+  }
+}
+
+async function waitForNativePeer(node, nativeMgmtUrl, wasmPubkeyHex, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let iter = 0;
+  while (Date.now() < deadline) {
+    await node.chainSyncTickValue().catch(() => {});
+    let nativePeers = [];
+    try {
+      const resp = await fetch(`${nativeMgmtUrl}/listpeers`, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+      if (resp.ok) nativePeers = (await resp.json()).peers || [];
+    } catch (_e) {
+      /* keep polling */
+    }
+    if (nativePeers.some((p) => p.pubkey === wasmPubkeyHex)) return true;
+    if (iter % 4 === 0) {
+      log(`waitForNativePeer[${iter}]`, {
+        wasmSees: wasmPeerView(node),
+        lspSees: nativePeers.map((p) => (p.pubkey || "").slice(0, 12)),
+      });
+    }
+    iter++;
+    await sleep(500);
+  }
+  throw new Error(`native hub did not see us (${wasmPubkeyHex.slice(0, 12)}) as a peer within ${timeoutMs}ms`);
+}
+
+async function fundWallet(gatewayUrl, wallet, online, address) {
+  log("Funding wasm wallet on-chain...", { address });
+  const resp = await fetch(`${gatewayUrl}/dev/regtest/fund`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ address, amount_btc: 1, mine_blocks: 6 }),
+  });
+  if (!resp.ok) throw new Error(`fund request failed: ${resp.status} ${await resp.text().catch(() => "")}`);
+  const deadline = Date.now() + FUND_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await wallet.syncOnline(online);
+    const bal = wallet.getBtcBalanceValue();
+    if (Number(bal?.vanilla?.spendable ?? 0) >= 50_000_000) {
+      log("Wallet funded", bal);
+      return;
+    }
+    await sleep(2000);
+  }
+  throw new Error("wallet not funded within timeout");
+}
+
+// Drive the wasm node (chain sync + RGB funding work) and mine periodically until the REAL RGB
+// channel to `peer` is usable on the wasm side.
+async function waitForUsableChannel(node, peer, gatewayUrl, walletAddress, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let iter = 0;
+  while (Date.now() < deadline) {
+    try {
+      await node.chainSyncTickValue();
+    } catch (e) {
+      log(`chainSyncTick err iter=${iter}`, String(e));
+    }
+    try {
+      await withTimeout(node.driveRgbFundingWork(), RGB_FUNDING_STEP_TIMEOUT_MS, "driveRgbFundingWork");
+    } catch (e) {
+      if (String(e).includes("timed out")) throw e;
+    }
+    const found = node
+      .listChannelsValue()
+      .find((c) => c.peer_pubkey === peer && c.is_usable);
+    if (found) return found;
+    if (iter % 3 === 2) await mineBlocks(gatewayUrl, walletAddress, 3);
+    if (iter % 5 === 0) {
+      log("waiting for the real RGB channel to become usable", node.listChannelsValue().map((c) => ({ id: c.channel_id.slice(0, 12), asset: !!c.asset_id, status: c.status, usable: c.is_usable })));
+    }
+    await sleep(2000);
+    iter++;
+  }
+  throw new Error(`real RGB channel to ${peer.slice(0, 12)} not usable within ${timeoutMs}ms`);
+}
+
+// Wait until the native hub reports the channel to us as ready.
+async function waitForNativeChannelReady(nativeMgmtUrl, wasmPubkeyHex, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { channels = [] } = await nativeGet(nativeMgmtUrl, "/listchannels").catch(() => ({}));
+    const ch = channels.find((c) => c.peer_pubkey === wasmPubkeyHex && c.asset_id);
+    if (ch && ch.ready) return ch;
+    await sleep(1500);
+  }
+  throw new Error(`native hub channel to us not ready within ${timeoutMs}ms`);
+}
+
+// getAssetBalance throws "Asset ... not found" while the wallet has never seen the asset
+// on-chain (an inbound hub-funded channel keeps all RGB in-channel until close settlement) —
+// treat that as an all-zero balance.
+function assetBalanceOrZero(wallet, assetId) {
+  try {
+    return wallet.getAssetBalanceValue(assetId);
+  } catch (_e) {
+    return { settled: 0, future: 0, spendable: 0, unknown_asset: true };
+  }
+}
+
+async function settleChainConvergence(node, rounds = 6, gapMs = 900) {
+  for (let i = 0; i < rounds; i++) {
+    try {
+      await node.chainSyncTickValue();
+    } catch (_e) {
+      /* non-fatal */
+    }
+    await sleep(gapMs);
+  }
+}
+
+async function pumpOnce(node) {
+  try {
+    await node.driveRgbFundingWork();
+  } catch (_e) { /* non-fatal */ }
+  try {
+    await node.chainSyncTickValue();
+  } catch (_e) { /* non-fatal */ }
+  try {
+    await node.driveRgbFundingWork();
+  } catch (_e) { /* non-fatal */ }
+}
+
+// Poll the native hub's view of an outbound payment until Succeeded.
+async function waitNativePaymentSettled(node, cfg, paymentHash, label, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await pumpOnce(node);
+    const { payments = [] } = await nativeGet(cfg.nativeMgmtUrl, "/listpayments").catch(() => ({}));
+    const p = payments.find((x) => x.payment_hash === paymentHash);
+    const status = String(p?.status ?? "").toLowerCase();
+    if (status === "succeeded") return p;
+    if (status === "failed") throw new Error(`${label}: native payment ${paymentHash.slice(0, 16)} FAILED`);
+    await sleep(750);
+  }
+  throw new Error(`${label}: native payment ${paymentHash.slice(0, 16)} did not settle within ${timeoutMs}ms`);
+}
+
+// ---------------------------------------------------------------------------
+// the flow
+// ---------------------------------------------------------------------------
+
+async function runFlow(cfg, runtimeId) {
+  await init();
+  log("WASM initialized", { runtimeId, flow: "rgb-coop-close-settlement" });
+
+  const keys = rgbGenerateKeysValue("regtest");
+  const sdkPassword = "rgb-coop-close-settlement";
+  const sdk = new RlnWasmSdk();
+  await sdk.initValue(sdkPassword, keys.mnemonic);
+  await sdk.unlock(JSON.stringify({ password: sdkPassword }));
+  log("SDK initialized + unlocked");
+
+  const node = RlnWasmNode.newWithNodeRuntimeId(cfg.nodeProxyUrl, runtimeId, "Regtest");
+  const myPubkey = JSON.parse(node.nodePubkeyJson());
+  let myPubkeyHex =
+    (typeof myPubkey === "string" ? myPubkey : myPubkey?.pubkey ?? myPubkey?.node_pubkey) || "";
+  assert(myPubkeyHex, "could not determine wasm node pubkey");
+  log("WASM node created", myPubkey);
+
+  const wallet = await RlnWasmWallet.create(
+    JSON.stringify({
+      data_dir: `/tmp/rln_wasm_coop_close_${runtimeId}`,
+      bitcoin_network: "Regtest",
+      database_type: "Sqlite",
+      max_allocations_per_utxo: 5,
+      account_xpub_vanilla: keys.account_xpub_vanilla,
+      account_xpub_colored: keys.account_xpub_colored,
+      mnemonic: keys.mnemonic,
+      master_fingerprint: keys.master_fingerprint,
+      vanilla_keychain: null,
+      supported_schemas: ["Nia"],
+    })
+  );
+  // The sweep's witness_receive + post_consignment resolve their transport endpoint from the
+  // wallet's RGB proxy transport config — configure it exactly like a production app would.
+  wallet.setRgbProxyTransport(cfg.rgbProxyUrl, null, null);
+  const online = await wallet.goOnlineValue(true, cfg.esploraUrl);
+  node.attachWallet(wallet);
+  const walletAddress = wallet.getAddress();
+  log("Wallet online + attached", { walletAddress });
+
+  await fundWallet(cfg.gatewayUrl, wallet, online, walletAddress);
+  node.chainSyncStartValue(cfg.esploraUrl, 3_600_000);
+
+  const nativeInfo = await nativeGet(cfg.nativeMgmtUrl, "/nodeinfo");
+  const nativePubkey = nativeInfo.pubkey;
+  log("Native hub info", { pubkey: nativePubkey });
+
+  // === STEP 0a: hub issues the asset ===
+  const assetId = await nativeBootstrapRgbAsset(cfg, walletAddress);
+
+  // === STEP 0b: connect to the hub ===
+  await node.connectPeer(cfg.nativePeerAddr, nativePubkey);
+  {
+    const live = JSON.parse(node.nodePubkeyJson());
+    const liveHex = (typeof live === "string" ? live : live?.pubkey ?? live?.node_pubkey) || "";
+    if (liveHex && liveHex !== myPubkeyHex) {
+      log("on-wire pubkey refreshed after connect", { initial: myPubkeyHex.slice(0, 16), live: liveHex.slice(0, 16) });
+      myPubkeyHex = liveHex;
+    }
+  }
+  await waitForNativePeer(node, cfg.nativeMgmtUrl, myPubkeyHex, 60_000);
+  log("✅ connected to the hub; it reports us as a peer");
+  const reconnectAndWaitForPeer = async () => {
+    await node.connectPeer(cfg.nativePeerAddr, nativePubkey).catch(() => {});
+    await waitForNativePeer(node, cfg.nativeMgmtUrl, myPubkeyHex, 20_000).catch(() => {});
+  };
+
+  // === STEP 0c: hub opens the REAL RGB channel to us ===
+  log("Requesting native hub to open a REAL RGB channel to us...", {
+    assetId, assetAmount: ASSET_CHANNEL_AMOUNT, pushAssetAmount: ASSET_PUSH_AMOUNT,
+  });
+  const openRes = await withRetry(
+    () =>
+      nativePost(cfg.nativeMgmtUrl, "/openchannel", {
+        peer_pubkey_and_opt_addr: `${myPubkeyHex}@127.0.0.1:9735`,
+        capacity_sat: CHANNEL_CAPACITY_SAT,
+        push_msat: CHANNEL_PUSH_MSAT,
+        asset_id: assetId,
+        asset_amount: ASSET_CHANNEL_AMOUNT,
+        push_asset_amount: ASSET_PUSH_AMOUNT,
+        public: false,
+        with_anchors: true, // RGB channels require anchors
+        fee_base_msat: null,
+        fee_proportional_millionths: null,
+        temporary_channel_id: null,
+        // NO virtual_open_mode: this is a real, on-chain-funded, broadcast channel.
+      }, 30_000),
+    5,
+    reconnectAndWaitForPeer,
+  );
+  log("Native hub /openchannel accepted", openRes);
+
+  const rgbChannel = await waitForUsableChannel(node, nativePubkey, cfg.gatewayUrl, walletAddress, CHANNEL_READY_TIMEOUT_MS);
+  const rgbChannelId = rgbChannel.channel_id;
+  assert(rgbChannel.is_usable === true, "real RGB channel did not become usable on the wasm side");
+  const nativeChannel = await waitForNativeChannelReady(cfg.nativeMgmtUrl, myPubkeyHex, 60_000);
+  assert(
+    Number(nativeChannel.asset_local_amount) === ASSET_CHANNEL_AMOUNT - ASSET_PUSH_AMOUNT,
+    `hub-side asset_local_amount should be ${ASSET_CHANNEL_AMOUNT - ASSET_PUSH_AMOUNT}, got ${nativeChannel.asset_local_amount}`,
+  );
+  log("✅ STEP 0 done — REAL RGB channel open + ready on both sides", {
+    id: rgbChannelId,
+    wasm_asset_local: rgbChannel.asset_local_amount,
+    hub_asset_local: nativeChannel.asset_local_amount,
+  });
+
+  await settleChainConvergence(node);
+
+  // === STEP 1: hub → wasm RGB keysend (makes the wasm in-channel balance ≠ the pushed amount) ===
+  log("STEP 1: hub → wasm RGB keysend...", { assetId, asset: RGB_KEYSEND_AMOUNT, amtMsat: RGB_HTLC_MSAT });
+  const hubKeysend = await nativePost(cfg.nativeMgmtUrl, "/keysend", {
+    dest_pubkey: myPubkeyHex,
+    amt_msat: RGB_HTLC_MSAT,
+    asset_id: assetId,
+    asset_amount: RGB_KEYSEND_AMOUNT,
+  }, 30_000);
+  const hubKeysendSettled = await waitNativePaymentSettled(
+    node, cfg, hubKeysend.payment_hash, "hub→wasm RGB keysend", PAYMENT_TIMEOUT_MS,
+  );
+  log("✅ STEP 1 done — hub→wasm RGB keysend settled", hubKeysendSettled);
+
+  // === STEP 2: pre-close snapshot ===
+  await settleChainConvergence(node, 4);
+  const preCloseChannel = node.listChannelsValue().find((c) => c.channel_id === rgbChannelId);
+  const preCloseWasmRgb = assetBalanceOrZero(wallet, assetId);
+  const preCloseWasmBtc = wallet.getBtcBalanceValue();
+  log("STEP 2: pre-close snapshot", {
+    channel_asset_local: preCloseChannel?.asset_local_amount,
+    channel_asset_remote: preCloseChannel?.asset_remote_amount,
+    wasm_onchain_rgb: preCloseWasmRgb,
+    wasm_onchain_btc_vanilla_spendable: preCloseWasmBtc?.vanilla?.spendable,
+  });
+  assert(
+    Number(preCloseChannel?.asset_local_amount ?? 0) === EXPECTED_WASM_RGB,
+    `wasm in-channel RGB should be ${EXPECTED_WASM_RGB} before close, got ${preCloseChannel?.asset_local_amount}`,
+  );
+
+  // === STEP 3: WASM side cooperatively closes the channel ===
+  log("STEP 3: wasm initiates cooperative close...", { channel: rgbChannelId.slice(0, 16) });
+  node.closeChannelWithOptions(rgbChannelId, nativePubkey, false);
+  // Pump until both sides agree the channel is gone (shutdown + closing_signed negotiation
+  // rides the normal peer pump; the colored closing tx needs process_pending_rgb_transactions,
+  // which driveRgbFundingWork flushes).
+  {
+    const deadline = Date.now() + 120_000;
+    let closedOnWasm = false;
+    let closedOnNative = false;
+    while (Date.now() < deadline && !(closedOnWasm && closedOnNative)) {
+      await pumpOnce(node);
+      closedOnWasm = !node.listChannelsValue().some((c) => c.channel_id === rgbChannelId);
+      const { channels = [] } = await nativeGet(cfg.nativeMgmtUrl, "/listchannels").catch(() => ({}));
+      closedOnNative = !channels.some((c) => c.peer_pubkey === myPubkeyHex && c.asset_id);
+      await sleep(1000);
+    }
+    assert(closedOnWasm, "channel still listed on the wasm side after cooperative close");
+    assert(closedOnNative, "channel still listed on the native side after cooperative close");
+  }
+  await mineBlocks(cfg.gatewayUrl, walletAddress, 3);
+  log("✅ STEP 3 done — cooperative close negotiated, closing tx mined");
+
+  // === STEP 4: settlement — mine + pump until BOTH sides recover their RGB on-chain ===
+  // Native side first (control: proves the closing tx really is colored and the infra works —
+  // the native SpendableOutputs → RgbOutputSpender pipeline settles automatically).
+  log("STEP 4: waiting for on-chain RGB settlement (native control first, then wasm)...", {
+    expected_hub: EXPECTED_HUB_RGB, expected_wasm: EXPECTED_WASM_RGB,
+  });
+  let nativeSettled = null;
+  let wasmSettled = null;
+  const deadline = Date.now() + SETTLEMENT_TIMEOUT_MS;
+  let iter = 0;
+  while (Date.now() < deadline && !(nativeSettled && wasmSettled)) {
+    // Keep blocks flowing: closing-tx maturity (ANTI_REORG_DELAY=6) and sweep confirmations.
+    await mineBlocks(cfg.gatewayUrl, walletAddress, 2);
+    await pumpOnce(node);
+
+    if (!nativeSettled) {
+      await nativePost(cfg.nativeMgmtUrl, "/refreshtransfers", { asset_id: null, filter: [], skip_sync: false }).catch(() => {});
+      const bal = await nativePost(cfg.nativeMgmtUrl, "/assetbalance", { asset_id: assetId }).catch(() => null);
+      const total = Number(bal?.settled ?? 0) + Number(bal?.future ?? 0);
+      if (iter % 4 === 0) log(`  [native control] on-chain RGB`, bal);
+      if (total >= EXPECTED_HUB_RGB) {
+        nativeSettled = bal;
+        log("✅ native control settled its RGB share on-chain", bal);
+      }
+    }
+
+    if (!wasmSettled) {
+      await wallet.refreshValue(online, null, [], false).catch((e) => {
+        if (iter % 4 === 0) log("  wasm refresh error (non-fatal)", String(e));
+      });
+      const bal = assetBalanceOrZero(wallet, assetId);
+      const total = Number(bal?.settled ?? 0) + Number(bal?.future ?? 0);
+      if (iter % 4 === 0) log(`  [wasm] on-chain RGB`, bal);
+      if (total >= EXPECTED_WASM_RGB) {
+        wasmSettled = bal;
+        log("✅ wasm side settled its RGB share on-chain", bal);
+      }
+    }
+
+    iter++;
+    await sleep(2000);
+  }
+
+  if (!nativeSettled) {
+    throw new Error(
+      `native control did not settle ${EXPECTED_HUB_RGB} RGB on-chain within ${SETTLEMENT_TIMEOUT_MS}ms — infra problem, not the wasm bug`,
+    );
+  }
+  if (!wasmSettled) {
+    const bal = assetBalanceOrZero(wallet, assetId);
+    throw new Error(
+      `REPRO: wasm on-chain RGB balance did not settle after cooperative close — ` +
+      `expected >= ${EXPECTED_WASM_RGB}, getAssetBalance=${safeJson(bal)} while the native side ` +
+      `recovered ${EXPECTED_HUB_RGB}. This is the "On-chain RGB balance does not settle on the ` +
+      `WASM side after channel close" bug (no ChainMonitor drain / SpendableOutputs handler / sweep pipeline).`,
+    );
+  }
+
+  const postCloseWasmBtc = wallet.getBtcBalanceValue();
+  log("post-close wasm BTC balance", {
+    vanilla_spendable: postCloseWasmBtc?.vanilla?.spendable,
+    colored_spendable: postCloseWasmBtc?.colored?.spendable,
+  });
+
+  const result = {
+    ok: true,
+    flow: "rgb-coop-close-settlement",
+    runtimeId,
+    assetId,
+    rgbChannelId,
+    wasmOnchainRgb: wasmSettled,
+    nativeOnchainRgb: nativeSettled,
+  };
+  log("=== COOP-CLOSE RGB SETTLEMENT FLOW COMPLETE ===", result);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// entrypoint
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const out = document.getElementById("out");
+  if (out) out.innerHTML = "";
+  const cfg = {
+    nodeProxyUrl: readParam("nodeProxyUrl", DEFAULTS.nodeProxyUrl),
+    esploraUrl: readParam("esploraUrl", DEFAULTS.esploraUrl),
+    rgbProxyUrl: readParam("rgbProxyUrl", DEFAULTS.rgbProxyUrl),
+    gatewayUrl: readParam("gatewayUrl", DEFAULTS.gatewayUrl),
+    nativePeerAddr: readParam("nativePeerAddr", DEFAULTS.nativePeerAddr),
+    nativeMgmtUrl: readParam("nativeMgmtUrl", DEFAULTS.nativeMgmtUrl),
+  };
+  const runtimeId = readParam("runtimeId", `coop-close-${Math.random().toString(16).slice(2)}`);
+  log("Config", { ...cfg, runtimeId });
+
+  try {
+    const result = await runFlow(cfg, runtimeId);
+    window.__E2E_RESULT = result;
+    window.__E2E_DONE = true;
+    log("*** COOP-CLOSE RGB SETTLEMENT E2E SUCCESS ***");
+  } catch (err) {
+    const failure = { ok: false, runtimeId, error: String(err && err.stack ? err.stack : err) };
+    window.__E2E_RESULT = failure;
+    window.__E2E_DONE = true;
+    log("*** COOP-CLOSE RGB SETTLEMENT E2E FAILED ***", failure);
+  }
+}
+
+if (new URLSearchParams(window.location.search).has("autorun")) {
+  main();
+} else {
+  const btn = document.getElementById("run");
+  if (btn) btn.addEventListener("click", () => main());
+}

--- a/bindings/wasm-sdk/examples/wasm-interop/rgb_coop_close_settlement_flow.html
+++ b/bindings/wasm-sdk/examples/wasm-interop/rgb_coop_close_settlement_flow.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RLN WASM — Coop-Close RGB Settlement Repro</title>
+    <style>
+      body { font-family: ui-monospace, Menlo, Consolas, monospace; margin: 1.5rem; }
+      button { padding: 0.5rem 0.9rem; font-size: 1rem; }
+      #out { border: 1px solid #bbb; padding: 0.8rem; margin-top: 1rem; max-height: 80vh; overflow: auto; }
+      pre { margin: 0.3rem 0; white-space: pre-wrap; }
+      .hint { color: #666; font-size: 0.85em; }
+    </style>
+  </head>
+  <body>
+    <h1>Cooperative Close — On-Chain RGB Settlement on the WASM Side</h1>
+    <p class="hint">
+      The native hub opens a <strong>real, on-chain-funded, anchors</strong> RGB channel to this
+      wasm node with <code>push_asset_amount</code>, one RGB keysend lands hub→wasm, then the wasm
+      side <strong>cooperatively closes</strong> the channel. The flow then asserts that the wasm
+      side's RGB share of the colored closing transaction settles into the on-chain wallet
+      (<code>getAssetBalance</code> &gt; 0) — the bug under test is that it stays 0 forever because
+      the wasm backend never drains <code>ChainMonitor</code> events, never handles
+      <code>SpendableOutputs</code>, and has no colored sweep pipeline. Requires
+      compose.wasm-infra.yaml infra, the wasm-proxy-gateway (dev-http), and a fresh native
+      <code>rgb-lightning-node</code> (peer 9802, REST 3101). Driven headlessly by
+      <code>run_coop_close_settlement_flow.mjs</code> (auto-runs when <code>?autorun</code> is
+      present).
+    </p>
+    <button id="run">Run Settlement Flow</button>
+    <div id="out"></div>
+    <script type="module" src="./manual_js_rgb_coop_close_settlement_flow.js"></script>
+  </body>
+</html>

--- a/bindings/wasm-sdk/examples/wasm-interop/run_coop_close_settlement_flow.mjs
+++ b/bindings/wasm-sdk/examples/wasm-interop/run_coop_close_settlement_flow.mjs
@@ -80,8 +80,8 @@ async function main() {
   const browser = await puppeteer.launch({
     executablePath: CHROME,
     headless: true,
-    // STEP 4 keeps the page's JS busy with long wallet refresh calls; the default 180s
-    // protocol timeout can kill the final __E2E_RESULT evaluate on an unsettled (repro) run.
+    // The settlement wait keeps the page's JS busy with long wallet refresh calls; the default
+    // 180s protocol timeout can kill the final __E2E_RESULT evaluate on an unsettled (repro) run.
     protocolTimeout: 300_000,
     userDataDir,
     args: [

--- a/bindings/wasm-sdk/examples/wasm-interop/run_coop_close_settlement_flow.mjs
+++ b/bindings/wasm-sdk/examples/wasm-interop/run_coop_close_settlement_flow.mjs
@@ -1,0 +1,139 @@
+// Headless driver for the cooperative-close RGB settlement flow
+// (manual_js_rgb_coop_close_settlement_flow.js).
+//
+// Same harness shape as run_e2e_full_flow.mjs: static server over the repo root + system Chrome
+// via puppeteer-core. Single phase. The console filter additionally surfaces close / sweep /
+// SpendableOutputs lines, because the behaviour under test is post-close on-chain settlement.
+//
+// Prereqs: compose.wasm-infra.yaml infra, wasm-proxy-gateway (dev-http) on 3001, a FRESH native
+// rgb-lightning-node on 9802/3101, and the wasm pkg built:
+//   cd bindings/wasm-sdk && wasm-pack build --target web --dev --out-dir pkg
+//
+// Usage:
+//   node bindings/wasm-sdk/examples/wasm-interop/run_coop_close_settlement_flow.mjs
+
+import http from "node:http";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+const PAGE_PATH = "/bindings/wasm-sdk/examples/wasm-interop/rgb_coop_close_settlement_flow.html";
+
+const PUPPETEER_DIR = process.env.E2E_PUPPETEER || "/tmp/e2e-driver/node_modules/puppeteer-core";
+const CHROME = process.env.PUPPETEER_EXECUTABLE_PATH || "/usr/bin/google-chrome";
+const RUN_TIMEOUT_MS = Number(process.env.E2E_RUN_TIMEOUT_MS || 900_000);
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".json": "application/json; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+};
+
+function startStaticServer(root) {
+  const server = http.createServer((req, res) => {
+    try {
+      const urlPath = decodeURIComponent(new URL(req.url, "http://x").pathname);
+      const filePath = path.join(root, urlPath);
+      if (!filePath.startsWith(root) || !fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+        res.writeHead(404);
+        res.end("not found");
+        return;
+      }
+      const ext = path.extname(filePath).toLowerCase();
+      res.writeHead(200, {
+        "content-type": MIME[ext] || "application/octet-stream",
+        "cache-control": "no-store",
+      });
+      fs.createReadStream(filePath).pipe(res);
+    } catch (e) {
+      res.writeHead(500);
+      res.end(String(e));
+    }
+  });
+  const port = Number(process.env.E2E_STATIC_PORT || 0);
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => resolve({ server, port: server.address().port }));
+  });
+}
+
+async function loadPuppeteer() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(PUPPETEER_DIR, "package.json"), "utf8"));
+  const rel = pkg.exports?.["."]?.import || pkg.module || pkg.main;
+  const entry = pathToFileURL(path.join(PUPPETEER_DIR, rel)).href;
+  return (await import(entry)).default;
+}
+
+async function main() {
+  const { server, port } = await startStaticServer(REPO_ROOT);
+  const baseUrl = `http://127.0.0.1:${port}`;
+  console.log(`static server: ${baseUrl} (root=${REPO_ROOT})`);
+
+  const puppeteer = await loadPuppeteer();
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "e2e-chrome-"));
+  const browser = await puppeteer.launch({
+    executablePath: CHROME,
+    headless: true,
+    // STEP 4 keeps the page's JS busy with long wallet refresh calls; the default 180s
+    // protocol timeout can kill the final __E2E_RESULT evaluate on an unsettled (repro) run.
+    protocolTimeout: 300_000,
+    userDataDir,
+    args: [
+      "--no-sandbox",
+      "--disable-dev-shm-usage",
+      "--disable-gpu",
+      "--disable-web-security",
+      "--disable-features=IsolateOrigins,site-per-process",
+    ],
+  });
+
+  let exitCode = 0;
+  try {
+    const page = await browser.newPage();
+    page.on("console", (msg) => {
+      const t = msg.text();
+      if (t.startsWith("[e2e]")) {
+        console.log(t);
+      } else if (
+        // The behaviour under test: always surface close/sweep/spendable-output lines.
+        /SpendableOutputs|sweep|ChannelClosed|force.?clos|ProcessingError|closed due to|height-only best block/i.test(t)
+      ) {
+        console.log(`[wasm!] ${t.slice(0, 400)}`);
+      } else if (
+        process.env.E2E_VERBOSE &&
+        /rgb|witness|consignment|transfer/i.test(t)
+      ) {
+        console.log(`[wasm] ${t.slice(0, 280)}`);
+      }
+    });
+    page.on("pageerror", (err) => console.log(`[pageerror] ${err}`));
+
+    const runtimeId = `coop-close-${Date.now().toString(16)}`;
+    const url = `${baseUrl}${PAGE_PATH}?autorun=1&runtimeId=${encodeURIComponent(runtimeId)}`;
+    console.log(`\n=== navigating ===\n${url}`);
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 60_000 });
+    await page.waitForFunction("window.__E2E_DONE === true", { timeout: RUN_TIMEOUT_MS, polling: 500 });
+    const result = await page.evaluate("window.__E2E_RESULT");
+
+    console.log("\n--- RESULT ---");
+    console.log(JSON.stringify(result, null, 2));
+    if (!result || !result.ok) throw new Error("coop-close RGB settlement flow failed");
+
+    console.log("\n✅✅✅ COOP-CLOSE RGB SETTLEMENT FLOW PASSED ✅✅✅");
+  } catch (e) {
+    console.error(`\n❌ FLOW FAILED: ${e}`);
+    exitCode = 1;
+  } finally {
+    await browser.close().catch(() => {});
+    server.close();
+  }
+  process.exit(exitCode);
+}
+
+main();

--- a/bindings/wasm-sdk/examples/wasm-interop/run_e2e_full_flow.mjs
+++ b/bindings/wasm-sdk/examples/wasm-interop/run_e2e_full_flow.mjs
@@ -117,6 +117,10 @@ async function main() {
       const t = msg.text();
       if (t.startsWith("[e2e]")) {
         console.log(t);
+      } else if (t.includes("height-only best block")) {
+        // Height-only chain sync (fresh wallet, no monitors yet): surfaced so runs can verify
+        // the ChannelManager's best block advances before the first channel exists.
+        console.log(`[wasm] ${t.slice(0, 200)}`);
       } else if (
         process.env.E2E_VERBOSE &&
         // Narrow filter: the router's path-finding decision lines, plus HTLC-handling failures

--- a/bindings/wasm-sdk/src/ldk_live_backend.rs
+++ b/bindings/wasm-sdk/src/ldk_live_backend.rs
@@ -17,7 +17,7 @@ use lightning::bitcoin::block::Header;
 use lightning::bitcoin::consensus::deserialize;
 use lightning::bitcoin::hash_types::Txid;
 use lightning::chain::chaininterface::{
-    BroadcasterInterface, FeeEstimator, FEERATE_FLOOR_SATS_PER_KW,
+    BroadcasterInterface, ConfirmationTarget, FeeEstimator, FEERATE_FLOOR_SATS_PER_KW,
 };
 use lightning::chain::chainmonitor;
 use lightning::chain::Confirm;
@@ -36,6 +36,7 @@ use lightning::onion_message::messenger::DefaultMessageRouter;
 use lightning::rgb_utils::{
     update_rgb_channel_amount, write_rgb_payment_info_file, ContractId, RgbInfo, RgbKvStoreExt,
     RgbPaymentInfo, RGB_PAYMENT_INFO_INBOUND_NS, RGB_PAYMENT_INFO_OUTBOUND_NS, RGB_PRIMARY_NS,
+    RGB_TRANSFER_INFO_NS,
 };
 use lightning::routing::gossip::NetworkGraph;
 use lightning::routing::router::{DefaultRouter, PaymentParameters, RouteParameters};
@@ -43,14 +44,17 @@ use lightning::routing::scoring::{
     ProbabilisticScorer, ProbabilisticScoringDecayParameters, ProbabilisticScoringFeeParameters,
 };
 use lightning::sign::KeysManager;
-use lightning::sign::{EntropySource, InMemorySigner, NodeSigner, Recipient};
+use lightning::sign::{
+    EntropySource, InMemorySigner, NodeSigner, OutputSpender, Recipient,
+    SpendableOutputDescriptor,
+};
 use lightning::types::payment::{PaymentHash, PaymentPreimage};
 use lightning::util::config::UserConfig;
 use lightning::util::errors::APIError;
 use lightning::util::logger::{Logger, Record};
 use lightning::util::persist::KVStoreSync;
 use lightning::util::persist::MonitorName;
-use lightning::util::ser::{ReadableArgs, Writeable};
+use lightning::util::ser::{Readable, ReadableArgs, Writeable};
 use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
 use secp256k1::PublicKey as SecpPublicKey;
 use wasm_bindgen::prelude::JsValue;
@@ -211,6 +215,61 @@ enum PendingRgbFundingWork {
     ProcessPendingTransactions,
 }
 
+/// One queued post-close sweep: the serialized `SpendableOutputDescriptor`s from a single
+/// `Event::SpendableOutputs`. Persisted durably (the event fires exactly once per output set,
+/// so dropping an item would strand the funds) and drained by the drive tick, which builds and
+/// broadcasts the sweep transaction — colored when the closing tx carries an RGB allocation
+/// (the wasm equivalent of the native `RgbOutputSpender`), vanilla BTC otherwise.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct PendingSweepWork {
+    descriptors_hex: Vec<String>,
+    channel_id: Option<String>,
+}
+
+/// Durable state for the post-close sweep pipeline: the queue of unprocessed
+/// `SpendableOutputs` descriptor sets plus, per processed set, the finished sweep tx (keyed by
+/// a hash of the descriptor set) so a replayed event or a retry after a crash rebroadcasts the
+/// SAME transaction instead of building a conflicting double-spend.
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+struct PersistedSweepState {
+    pending: Vec<PendingSweepWork>,
+    swept: HashMap<String, String>,
+}
+
+fn sweep_state_storage_key(runtime_key: &str) -> String {
+    format!("rln:wasm:ldk-sweeps:{runtime_key}")
+}
+
+/// Stable identity of a descriptor set, used as the idempotency key for built sweep txs.
+fn sweep_descriptors_key(descriptors_hex: &[String]) -> String {
+    let joined = descriptors_hex.join(",");
+    <Sha256 as bitcoin_hashes::Hash>::hash(joined.as_bytes()).to_string()
+}
+
+/// RGB transport-endpoint form (`rpc://` / `rpcs://`) of a proxy URL. `witness_receive`
+/// validates its transport endpoints as `RgbTransport` strings, while the proxy client (and
+/// `post_consignment`) use the plain `http(s)://` URL — the SDK stores the latter.
+fn rgb_transport_endpoint_from_http(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("https://") {
+        format!("rpcs://{rest}")
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        format!("rpc://{rest}")
+    } else {
+        url.to_string()
+    }
+}
+
+/// Plain `http(s)://` form of a proxy URL that may have been configured in `rpc://` form.
+fn http_endpoint_from_any(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("rpcs://") {
+        format!("https://{rest}")
+    } else if let Some(rest) = url.strip_prefix("rpc://") {
+        format!("http://{rest}")
+    } else {
+        url.to_string()
+    }
+}
+
 pub trait LdkLiveBackend {
     fn new_outbound_connection(&self, peer_pubkey: &str) -> Result<String, JsValue>;
     fn read_event(&self, payload_hex: &str) -> Result<(), JsValue>;
@@ -341,6 +400,15 @@ pub trait LdkLiveBackend {
     }
 
     fn chain_relevant_txids(&self) -> Result<Vec<String>, JsValue> {
+        Ok(Vec::new())
+    }
+
+    /// Outputs the chain monitor asked the `Filter` to watch for SPENDS, as
+    /// `(funding txid, vout)`. The chain sync driver checks these against the indexer's
+    /// outspend endpoint — that is how a closing/commitment tx (which the monitor has never
+    /// seen and therefore cannot list in `chain_relevant_txids`) gets discovered and fed back
+    /// via `chain_apply_confirmed_tx`, eventually maturing into `Event::SpendableOutputs`.
+    fn chain_watched_outputs(&self) -> Result<Vec<(String, u32)>, JsValue> {
         Ok(Vec::new())
     }
 
@@ -559,6 +627,10 @@ pub struct WasmLdkLiveBackend {
     /// Channel ids the live `ChannelManager` reported closed via `Event::ChannelClosed`, pending
     /// propagation to the runtime channel view (drained by `take_closed_live_channels`).
     closed_channels: RefCell<Vec<String>>,
+    /// Post-close sweep work queued from `Event::SpendableOutputs` (drained by the drive tick).
+    pending_sweep_work: RefCell<VecDeque<PendingSweepWork>>,
+    /// Built sweep txs keyed by descriptor-set hash (see `PersistedSweepState::swept`).
+    sweep_txes: RefCell<HashMap<String, String>>,
     object_graph: RefCell<Option<LdkObjectGraph>>,
 }
 
@@ -668,6 +740,11 @@ struct FixedFeeEstimator;
 // counterparty reading that estimate rejects a channel opened at the protocol floor (253 sat/kw)
 // with "Peer's feerate much too low". So we must open at a realistic feerate, not the floor.
 const REGTEST_CHANNEL_FEERATE_SATS_PER_KW: u32 = 5000;
+
+// Sat value of each colored output on a post-close sweep tx (the RGB allocation rides on it;
+// the BTC value only needs to clear the dust floor). Matches the native node's default
+// `dust_limit_msat / 1000` used by `RgbOutputSpender`.
+const SWEEP_COLORED_OUTPUT_SAT: u64 = 546;
 
 // Per-channel handshake parameters for non-virtual opens, matching native `open_channel`.
 const OPEN_CHANNEL_HTLC_MIN_MSAT: u64 = 3_000_000;
@@ -1357,6 +1434,14 @@ fn load_scorer_snapshot(
 
 impl WasmLdkLiveBackend {
     fn new(runtime_key: String, node_seed32: Option<[u8; 32]>) -> Self {
+        // Restore the durable sweep state: `Event::SpendableOutputs` fires exactly once per
+        // output set, so pending items must survive a reload or the closing outputs strand.
+        let sweep_state: PersistedSweepState = browser_persistent_state_store()
+            .get(&sweep_state_storage_key(&runtime_key))
+            .ok()
+            .flatten()
+            .and_then(|raw| serde_json::from_str(&raw).ok())
+            .unwrap_or_default();
         Self {
             runtime_key,
             node_seed32,
@@ -1377,7 +1462,20 @@ impl WasmLdkLiveBackend {
             hodl_claim_deadlines: RefCell::new(HashMap::new()),
             async_recipient_preimages: RefCell::new(HashMap::new()),
             closed_channels: RefCell::new(Vec::new()),
+            pending_sweep_work: RefCell::new(sweep_state.pending.into()),
+            sweep_txes: RefCell::new(sweep_state.swept),
             object_graph: RefCell::new(None),
+        }
+    }
+
+    fn persist_sweep_state(&self) {
+        let state = PersistedSweepState {
+            pending: self.pending_sweep_work.borrow().iter().cloned().collect(),
+            swept: self.sweep_txes.borrow().clone(),
+        };
+        if let Ok(raw) = serde_json::to_string(&state) {
+            let _ = browser_persistent_state_store()
+                .set(&sweep_state_storage_key(&self.runtime_key), &raw);
         }
     }
 
@@ -1638,6 +1736,15 @@ impl WasmLdkLiveBackend {
             collected_events.borrow_mut().push(event);
             Ok::<(), ReplayEvent>(())
         });
+        // The ChainMonitor is its own `EventsProvider`: post-close `Event::SpendableOutputs`
+        // (matured closing/commitment outputs) surfaces ONLY here, never via the
+        // ChannelManager. Without this drain the wasm side never observes its closing
+        // outputs, so neither the BTC nor the RGB share of a closed channel ever settles
+        // on-chain (native counterpart: `Event::SpendableOutputs` in `src/ldk.rs`).
+        g.chain_monitor.process_pending_events(&|event: Event| {
+            collected_events.borrow_mut().push(event);
+            Ok::<(), ReplayEvent>(())
+        });
         for event in collected_events.into_inner().into_iter() {
             self.handle_ldk_event_sync(g, event);
         }
@@ -1772,6 +1879,29 @@ impl WasmLdkLiveBackend {
                     "[rln-wasm-sdk ldk-live] ChannelClosed channel_id={id_hex}"
                 ));
                 self.closed_channels.borrow_mut().push(id_hex);
+            }
+            // ---- Matured post-close outputs: queue the sweep (native: OutputSweeper +
+            // RgbOutputSpender). The descriptors are persisted immediately — this event fires
+            // exactly once, and losing it would strand the closing outputs (both the BTC and
+            // any RGB allocation riding on the colored closing tx).
+            Event::SpendableOutputs {
+                outputs,
+                channel_id,
+            } => {
+                let descriptors_hex: Vec<String> =
+                    outputs.iter().map(|d| hex::encode(d.encode())).collect();
+                ldk_live_debug(&format!(
+                    "[rln-wasm-sdk sweep] SpendableOutputs: {} descriptor(s), channel={:?}",
+                    descriptors_hex.len(),
+                    channel_id.map(|c| format!("{c}")),
+                ));
+                self.pending_sweep_work
+                    .borrow_mut()
+                    .push_back(PendingSweepWork {
+                        descriptors_hex,
+                        channel_id: channel_id.map(|c| format!("{c}")),
+                    });
+                self.persist_sweep_state();
             }
             // ---- Real payment lifecycle (outbound, this node is the payer) ----
             Event::PaymentSent {
@@ -2881,6 +3011,22 @@ impl LdkLiveBackend for WasmLdkLiveBackend {
         })
     }
 
+    fn chain_watched_outputs(&self) -> Result<Vec<(String, u32)>, JsValue> {
+        self.with_graph(|g| {
+            Ok(g.chain_source
+                .watched_outputs
+                .borrow()
+                .iter()
+                .map(|output| {
+                    (
+                        output.outpoint.txid.to_string(),
+                        u32::from(output.outpoint.index),
+                    )
+                })
+                .collect())
+        })
+    }
+
     fn chain_apply_best_block(&self, height: u32, header_hex: &str) -> Result<(), JsValue> {
         let header_bytes =
             hex::decode(header_hex).map_err(|e| JsValue::from_str(&format!("header hex: {e}")))?;
@@ -3790,6 +3936,374 @@ impl WasmLdkLiveBackend {
                 .map_err(|e| {
                     JsValue::from_str(&format!("RGB pending transactions failed: {e:?}"))
                 })?;
+        }
+        // Phase G: post-close sweeps (SpendableOutputs → colored/vanilla sweep tx). Drain
+        // events first: after a close there may be no peer traffic left, so the frame-driven
+        // `process_events` path can stop running — without this drain a matured
+        // `Event::SpendableOutputs` would sit in the ChainMonitor forever. Errors defer the
+        // item to the next drive tick (e.g. closing tx not confirmed yet) and never fail the
+        // funding pipeline.
+        {
+            let graph = this.object_graph.borrow();
+            if let Some(g) = graph.as_ref() {
+                this.ingest_funding_generation_ready_events(g);
+            }
+        }
+        Self::drive_sweep_work(&this).await;
+        Ok(())
+    }
+
+    /// Drains the post-close sweep queue. Each item is one `Event::SpendableOutputs`
+    /// descriptor set; a failed item is re-queued at the front and retried on the next drive
+    /// tick (the dominant "failure" is simply the closing tx not yet confirmed / indexed).
+    async fn drive_sweep_work(this: &Rc<Self>) {
+        loop {
+            let item = this.pending_sweep_work.borrow_mut().pop_front();
+            let Some(item) = item else { break };
+            match Self::process_sweep_item(this, &item).await {
+                Ok(()) => {
+                    this.persist_sweep_state();
+                }
+                Err(e) => {
+                    ldk_live_debug(&format!(
+                        "[rln-wasm-sdk sweep] deferring sweep to next drive tick: {e}"
+                    ));
+                    this.pending_sweep_work.borrow_mut().push_front(item);
+                    this.persist_sweep_state();
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Builds, colors (when the closing tx carries RGB), signs and broadcasts the sweep
+    /// transaction for one descriptor set — the wasm equivalent of the native
+    /// `RgbOutputSpender::spend_spendable_outputs` (`src/ldk.rs`).
+    ///
+    /// RGB flow per colored closing txid: `update_witnesses` (register the confirmed closing
+    /// tx as a settled RGB witness) → `witness_receive` (allocate a wallet-owned receive slot)
+    /// → `create_spendable_outputs_psbt` + `color_psbt_and_consume` (move the allocation onto
+    /// the sweep output) → sign/broadcast → `post_consignment` (so the wallet's refresh can
+    /// accept the transfer and credit `getAssetBalance`).
+    async fn process_sweep_item(this: &Rc<Self>, item: &PendingSweepWork) -> Result<(), String> {
+        let mut descriptors: Vec<SpendableOutputDescriptor> = Vec::new();
+        for descriptor_hex in &item.descriptors_hex {
+            let bytes =
+                hex::decode(descriptor_hex).map_err(|e| format!("descriptor hex: {e}"))?;
+            let mut cursor = std::io::Cursor::new(bytes);
+            descriptors.push(
+                SpendableOutputDescriptor::read(&mut cursor)
+                    .map_err(|e| format!("descriptor decode: {e:?}"))?,
+            );
+        }
+        if descriptors.is_empty() {
+            return Ok(());
+        }
+
+        let (keys_manager, broadcaster, rgb_kv_store, fee_estimator) = {
+            let graph = this.object_graph.borrow();
+            let g = graph
+                .as_ref()
+                .ok_or_else(|| "LDK object graph not initialized".to_string())?;
+            (
+                Arc::clone(&g.keys_manager),
+                Arc::clone(&g.broadcaster),
+                Arc::clone(&g.rgb_kv_store),
+                Arc::clone(&g.fee_estimator),
+            )
+        };
+
+        // Idempotency: a replayed event / retry after a crash must rebroadcast the SAME tx
+        // rather than build a conflicting double-spend of the closing outputs.
+        let sweep_key = sweep_descriptors_key(&item.descriptors_hex);
+        if let Some(tx_hex) = this.sweep_txes.borrow().get(&sweep_key).cloned() {
+            let tx_bytes = hex::decode(&tx_hex).map_err(|e| format!("sweep tx hex: {e}"))?;
+            let tx: bitcoin::Transaction =
+                deserialize(&tx_bytes).map_err(|e| format!("sweep tx decode: {e}"))?;
+            broadcaster.broadcast_transactions(&[&tx]);
+            return Ok(());
+        }
+
+        let wallet_rc = RGB_WALLET_REGISTRY
+            .with(|reg| reg.borrow().get(&this.runtime_key).cloned())
+            .ok_or_else(|| "no RGB wallet attached".to_string())?;
+        const WALLET_BUSY: &str = "RGB wallet is busy; retrying sweep on next drive tick";
+        let busy = |_: std::cell::BorrowError| WALLET_BUSY.to_string();
+        let busy_mut = |_: std::cell::BorrowMutError| WALLET_BUSY.to_string();
+
+        let change_script = {
+            let mut wallet = wallet_rc.try_borrow_mut().map_err(busy_mut)?;
+            let address = wallet
+                .get_address()
+                .map_err(|e| format!("sweep change address: {e}"))?;
+            address
+                .parse::<bitcoin::Address<bitcoin::address::NetworkUnchecked>>()
+                .map_err(|e| format!("sweep change address parse: {e}"))?
+                .assume_checked()
+                .script_pubkey()
+        };
+        let fee_rate =
+            fee_estimator.get_est_sat_per_1000_weight(ConfirmationTarget::OutputSpendingFee);
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+
+        // Partition the descriptor set: which closing txids carry an RGB allocation
+        // (recorded by the fork's `color_closing`/`color_commitment` under
+        // RGB_TRANSFER_INFO_NS)? Everything else sweeps as vanilla BTC.
+        let mut txouts: Vec<bitcoin::TxOut> = Vec::new();
+        // contract id (string) → (colored vout, total rgb amount, recipient id)
+        let mut asset_info: HashMap<String, (u32, u64, String)> = HashMap::new();
+        let mut vanilla_descriptor = true;
+        let mut next_colored_vout: u32 = 0;
+        let mut proxy_endpoint: Option<String> = None;
+
+        for descriptor in &descriptors {
+            let outpoint = match descriptor {
+                SpendableOutputDescriptor::StaticPaymentOutput(d) => d.outpoint,
+                SpendableOutputDescriptor::DelayedPaymentOutput(d) => d.outpoint,
+                SpendableOutputDescriptor::StaticOutput { outpoint, .. } => *outpoint,
+            };
+            let txid_str = outpoint.txid.to_string();
+            if rgb_kv_store
+                .read(RGB_PRIMARY_NS, RGB_TRANSFER_INFO_NS, &txid_str)
+                .is_err()
+            {
+                continue;
+            }
+            let transfer_info = rgb_kv_store
+                .read_rgb_transfer_info(&txid_str)
+                .map_err(|e| format!("read_rgb_transfer_info({txid_str}): {e}"))?;
+            if transfer_info.rgb_amount == 0 {
+                continue;
+            }
+            vanilla_descriptor = false;
+
+            let endpoint = match proxy_endpoint.clone() {
+                Some(endpoint) => endpoint,
+                None => {
+                    let idb_key = wallet_rc.try_borrow().map_err(busy)?.idb_key();
+                    let endpoint = crate::effective_rgb_proxy_endpoint_for_wallet_key(&idb_key)
+                        .ok_or_else(|| {
+                            "no RGB proxy transport configured; cannot sweep colored output"
+                                .to_string()
+                        })?;
+                    proxy_endpoint = Some(endpoint.clone());
+                    endpoint
+                }
+            };
+
+            let online = wallet_rc
+                .try_borrow()
+                .map_err(busy)?
+                .get_online()
+                .ok_or_else(|| "RGB wallet is not online".to_string())?;
+
+            // The closing tx must be confirmed before rgb-lib will accept it as a witness.
+            let closing_height = {
+                let wallet = wallet_rc.try_borrow().map_err(busy)?;
+                wallet
+                    .get_tx_height(online.clone(), txid_str.clone())
+                    .await
+                    .map_err(|e| format!("get_tx_height({txid_str}): {e}"))?
+            };
+            let Some(closing_height) = closing_height else {
+                return Err(format!("closing tx {txid_str} not confirmed yet"));
+            };
+            let rgb_txid = txid_str
+                .parse::<rgb_lib_wasm::RgbTxid>()
+                .map_err(|_| format!("invalid rgb txid {txid_str}"))?;
+            let update_res = {
+                let mut wallet = wallet_rc.try_borrow_mut().map_err(busy_mut)?;
+                wallet
+                    .update_witnesses(online.clone(), closing_height, vec![rgb_txid])
+                    .await
+                    .map_err(|e| format!("update_witnesses({txid_str}): {e}"))?
+            };
+            // Only the closing tx witness (force-listed and pre-fetched above) gates the
+            // sweep. The stock's update pass also re-resolves OTHER tentative witnesses —
+            // e.g. never-broadcast commitment transfers of the channel being closed — which
+            // the wasm pre-fetch resolver cannot resolve and reports as failed. Those are
+            // irrelevant to (and would otherwise permanently defer) this sweep.
+            if update_res
+                .failed
+                .keys()
+                .any(|failed_txid| failed_txid.to_string() == txid_str)
+            {
+                return Err(format!(
+                    "update_witnesses failed for closing tx {txid_str}: {:?}",
+                    update_res.failed
+                ));
+            }
+            if !update_res.failed.is_empty() {
+                ldk_live_debug(&format!(
+                    "[rln-wasm-sdk sweep] update_witnesses reported unrelated unresolved witnesses (ignored): {:?}",
+                    update_res.failed
+                ));
+            }
+
+            let contract_id_str = transfer_info.contract_id.to_string();
+            let mut new_asset = false;
+            let recipient_id =
+                if let Some((_, _, recipient_id)) = asset_info.get(&contract_id_str) {
+                    recipient_id.clone()
+                } else {
+                    new_asset = true;
+                    let receive_data = {
+                        let mut wallet = wallet_rc.try_borrow_mut().map_err(busy_mut)?;
+                        wallet
+                            .witness_receive(
+                                None,
+                                rgb_lib_wasm::Assignment::Any,
+                                None,
+                                vec![rgb_transport_endpoint_from_http(&endpoint)],
+                                0,
+                            )
+                            .map_err(|e| format!("witness_receive: {e}"))?
+                    };
+                    let script = rgb_lib_wasm::utils::script_buf_from_recipient_id(
+                        receive_data.recipient_id.clone(),
+                    )
+                    .map_err(|e| format!("sweep recipient id: {e}"))?
+                    .ok_or_else(|| "sweep recipient id has no script".to_string())?;
+                    txouts.push(bitcoin::TxOut {
+                        value: bitcoin::Amount::from_sat(SWEEP_COLORED_OUTPUT_SAT),
+                        script_pubkey: bitcoin::ScriptBuf::from_bytes(script.to_bytes()),
+                    });
+                    receive_data.recipient_id
+                };
+
+            asset_info
+                .entry(contract_id_str)
+                .and_modify(|(_, amount, _)| *amount += transfer_info.rgb_amount)
+                .or_insert_with(|| {
+                    (next_colored_vout, transfer_info.rgb_amount, recipient_id)
+                });
+            if new_asset {
+                next_colored_vout += 1;
+            }
+        }
+
+        let descriptor_refs: Vec<&SpendableOutputDescriptor> = descriptors.iter().collect();
+
+        if vanilla_descriptor {
+            let tx = keys_manager
+                .spend_spendable_outputs(
+                    &descriptor_refs,
+                    txouts,
+                    change_script,
+                    fee_rate,
+                    None,
+                    &secp,
+                )
+                .map_err(|_| "vanilla sweep tx build failed".to_string())?;
+            broadcaster.broadcast_transactions(&[&tx]);
+            let txid = tx.compute_txid().to_string();
+            ldk_live_debug(&format!("[rln-wasm-sdk sweep] vanilla sweep broadcast {txid}"));
+            this.sweep_txes
+                .borrow_mut()
+                .insert(sweep_key, bitcoin::consensus::encode::serialize_hex(&tx));
+            return Ok(());
+        }
+
+        // ---- colored sweep (mirrors native `RgbOutputSpender`) ----
+        let (psbt, _expected_max_weight) =
+            SpendableOutputDescriptor::create_spendable_outputs_psbt(
+                &secp,
+                &descriptor_refs,
+                txouts,
+                change_script,
+                fee_rate,
+                None,
+            )
+            .map_err(|_| "failed to build sweep PSBT".to_string())?;
+
+        let mut asset_info_map = HashMap::new();
+        for (contract_id_str, (vout, amount, _)) in asset_info.clone() {
+            let contract_id = contract_id_str
+                .parse::<rgb_lib_wasm::ContractId>()
+                .map_err(|_| format!("invalid contract id {contract_id_str}"))?;
+            asset_info_map.insert(
+                contract_id,
+                rgb_lib_wasm::wallet::rust_only::AssetColoringInfo {
+                    output_map: HashMap::from_iter([(vout, amount)]),
+                    static_blinding: None,
+                },
+            );
+        }
+        let coloring_info = rgb_lib_wasm::wallet::rust_only::ColoringInfo {
+            asset_info_map,
+            static_blinding: None,
+            nonce: None,
+        };
+
+        let mut rgb_psbt = psbt
+            .to_string()
+            .parse::<rgb_lib_wasm::bitcoin::Psbt>()
+            .map_err(|e| format!("sweep PSBT roundtrip: {e}"))?;
+        let consignments = {
+            let wallet = wallet_rc.try_borrow().map_err(busy)?;
+            wallet
+                .color_psbt_and_consume(&mut rgb_psbt, coloring_info)
+                .await
+                .map_err(|e| format!("color_psbt_and_consume: {e}"))?
+        };
+
+        let psbt = rgb_psbt
+            .to_string()
+            .parse::<bitcoin::Psbt>()
+            .map_err(|e| format!("colored sweep PSBT roundtrip: {e}"))?;
+        let psbt = keys_manager
+            .sign_spendable_outputs_psbt(&descriptor_refs, psbt, &secp)
+            .map_err(|_| "failed to sign sweep PSBT".to_string())?;
+        let spending_tx = match psbt.extract_tx() {
+            Ok(tx) => tx,
+            Err(bitcoin::psbt::ExtractTxError::MissingInputValue { tx }) => tx,
+            Err(e) => return Err(format!("sweep tx extract: {e}")),
+        };
+        let sweep_txid = spending_tx.compute_txid().to_string();
+
+        // Post each consignment BEFORE broadcasting (native order): a broadcast sweep whose
+        // consignment never reached the proxy could not be accepted by the receiving side.
+        let proxy_endpoint = http_endpoint_from_any(
+            &proxy_endpoint.ok_or_else(|| "missing sweep proxy endpoint".to_string())?,
+        );
+        for consignment in consignments {
+            use rgb_lib_wasm::{ConsignmentExt, FileContent};
+            let contract_id_str = consignment.contract_id().to_string();
+            let (mut vout, _, recipient_id) = asset_info
+                .get(&contract_id_str)
+                .cloned()
+                .ok_or_else(|| format!("no asset info for contract {contract_id_str}"))?;
+            vout += 1;
+            let mut consignment_bytes = Vec::new();
+            consignment
+                .save(&mut consignment_bytes)
+                .map_err(|e| format!("consignment serialize: {e}"))?;
+            let wallet = wallet_rc.try_borrow().map_err(busy)?;
+            wallet
+                .post_consignment(
+                    &proxy_endpoint,
+                    recipient_id,
+                    &consignment_bytes,
+                    sweep_txid.clone(),
+                    Some(vout),
+                )
+                .await
+                .map_err(|e| format!("post_consignment: {e}"))?;
+        }
+
+        broadcaster.broadcast_transactions(&[&spending_tx]);
+        ldk_live_debug(&format!("[rln-wasm-sdk sweep] colored sweep broadcast {sweep_txid}"));
+        this.sweep_txes.borrow_mut().insert(
+            sweep_key,
+            bitcoin::consensus::encode::serialize_hex(&spending_tx),
+        );
+
+        // Best-effort refresh so the incoming sweep transfer is pulled from the proxy and the
+        // on-chain RGB balance credits without waiting for an app-driven refresh.
+        if let Ok(mut wallet) = wallet_rc.try_borrow_mut() {
+            if let Some(online) = wallet.get_online() {
+                let _ = wallet.refresh(online, None, vec![], false).await;
+            }
         }
         Ok(())
     }

--- a/bindings/wasm-sdk/src/ldk_live_backend.rs
+++ b/bindings/wasm-sdk/src/ldk_live_backend.rs
@@ -45,8 +45,7 @@ use lightning::routing::scoring::{
 };
 use lightning::sign::KeysManager;
 use lightning::sign::{
-    EntropySource, InMemorySigner, NodeSigner, OutputSpender, Recipient,
-    SpendableOutputDescriptor,
+    EntropySource, InMemorySigner, NodeSigner, OutputSpender, Recipient, SpendableOutputDescriptor,
 };
 use lightning::types::payment::{PaymentHash, PaymentPreimage};
 use lightning::util::config::UserConfig;
@@ -3937,12 +3936,7 @@ impl WasmLdkLiveBackend {
                     JsValue::from_str(&format!("RGB pending transactions failed: {e:?}"))
                 })?;
         }
-        // Phase G: post-close sweeps (SpendableOutputs → colored/vanilla sweep tx). Drain
-        // events first: after a close there may be no peer traffic left, so the frame-driven
-        // `process_events` path can stop running — without this drain a matured
-        // `Event::SpendableOutputs` would sit in the ChainMonitor forever. Errors defer the
-        // item to the next drive tick (e.g. closing tx not confirmed yet) and never fail the
-        // funding pipeline.
+
         {
             let graph = this.object_graph.borrow();
             if let Some(g) = graph.as_ref() {
@@ -3988,8 +3982,7 @@ impl WasmLdkLiveBackend {
     async fn process_sweep_item(this: &Rc<Self>, item: &PendingSweepWork) -> Result<(), String> {
         let mut descriptors: Vec<SpendableOutputDescriptor> = Vec::new();
         for descriptor_hex in &item.descriptors_hex {
-            let bytes =
-                hex::decode(descriptor_hex).map_err(|e| format!("descriptor hex: {e}"))?;
+            let bytes = hex::decode(descriptor_hex).map_err(|e| format!("descriptor hex: {e}"))?;
             let mut cursor = std::io::Cursor::new(bytes);
             descriptors.push(
                 SpendableOutputDescriptor::read(&mut cursor)
@@ -4142,41 +4135,39 @@ impl WasmLdkLiveBackend {
 
             let contract_id_str = transfer_info.contract_id.to_string();
             let mut new_asset = false;
-            let recipient_id =
-                if let Some((_, _, recipient_id)) = asset_info.get(&contract_id_str) {
-                    recipient_id.clone()
-                } else {
-                    new_asset = true;
-                    let receive_data = {
-                        let mut wallet = wallet_rc.try_borrow_mut().map_err(busy_mut)?;
-                        wallet
-                            .witness_receive(
-                                None,
-                                rgb_lib_wasm::Assignment::Any,
-                                None,
-                                vec![rgb_transport_endpoint_from_http(&endpoint)],
-                                0,
-                            )
-                            .map_err(|e| format!("witness_receive: {e}"))?
-                    };
-                    let script = rgb_lib_wasm::utils::script_buf_from_recipient_id(
-                        receive_data.recipient_id.clone(),
-                    )
-                    .map_err(|e| format!("sweep recipient id: {e}"))?
-                    .ok_or_else(|| "sweep recipient id has no script".to_string())?;
-                    txouts.push(bitcoin::TxOut {
-                        value: bitcoin::Amount::from_sat(SWEEP_COLORED_OUTPUT_SAT),
-                        script_pubkey: bitcoin::ScriptBuf::from_bytes(script.to_bytes()),
-                    });
-                    receive_data.recipient_id
+            let recipient_id = if let Some((_, _, recipient_id)) = asset_info.get(&contract_id_str)
+            {
+                recipient_id.clone()
+            } else {
+                new_asset = true;
+                let receive_data = {
+                    let mut wallet = wallet_rc.try_borrow_mut().map_err(busy_mut)?;
+                    wallet
+                        .witness_receive(
+                            None,
+                            rgb_lib_wasm::Assignment::Any,
+                            None,
+                            vec![rgb_transport_endpoint_from_http(&endpoint)],
+                            0,
+                        )
+                        .map_err(|e| format!("witness_receive: {e}"))?
                 };
+                let script = rgb_lib_wasm::utils::script_buf_from_recipient_id(
+                    receive_data.recipient_id.clone(),
+                )
+                .map_err(|e| format!("sweep recipient id: {e}"))?
+                .ok_or_else(|| "sweep recipient id has no script".to_string())?;
+                txouts.push(bitcoin::TxOut {
+                    value: bitcoin::Amount::from_sat(SWEEP_COLORED_OUTPUT_SAT),
+                    script_pubkey: bitcoin::ScriptBuf::from_bytes(script.to_bytes()),
+                });
+                receive_data.recipient_id
+            };
 
             asset_info
                 .entry(contract_id_str)
                 .and_modify(|(_, amount, _)| *amount += transfer_info.rgb_amount)
-                .or_insert_with(|| {
-                    (next_colored_vout, transfer_info.rgb_amount, recipient_id)
-                });
+                .or_insert_with(|| (next_colored_vout, transfer_info.rgb_amount, recipient_id));
             if new_asset {
                 next_colored_vout += 1;
             }
@@ -4197,7 +4188,9 @@ impl WasmLdkLiveBackend {
                 .map_err(|_| "vanilla sweep tx build failed".to_string())?;
             broadcaster.broadcast_transactions(&[&tx]);
             let txid = tx.compute_txid().to_string();
-            ldk_live_debug(&format!("[rln-wasm-sdk sweep] vanilla sweep broadcast {txid}"));
+            ldk_live_debug(&format!(
+                "[rln-wasm-sdk sweep] vanilla sweep broadcast {txid}"
+            ));
             this.sweep_txes
                 .borrow_mut()
                 .insert(sweep_key, bitcoin::consensus::encode::serialize_hex(&tx));
@@ -4292,7 +4285,9 @@ impl WasmLdkLiveBackend {
         }
 
         broadcaster.broadcast_transactions(&[&spending_tx]);
-        ldk_live_debug(&format!("[rln-wasm-sdk sweep] colored sweep broadcast {sweep_txid}"));
+        ldk_live_debug(&format!(
+            "[rln-wasm-sdk sweep] colored sweep broadcast {sweep_txid}"
+        ));
         this.sweep_txes.borrow_mut().insert(
             sweep_key,
             bitcoin::consensus::encode::serialize_hex(&spending_tx),

--- a/bindings/wasm-sdk/src/ldk_runtime.rs
+++ b/bindings/wasm-sdk/src/ldk_runtime.rs
@@ -491,6 +491,12 @@ pub trait LdkRuntimeManager {
         Ok(Vec::new())
     }
 
+    /// `(funding txid, vout)` pairs the chain monitor watches for spends; see
+    /// `LdkLiveBackend::chain_watched_outputs`.
+    fn chain_watched_outputs(&self) -> Result<Vec<(String, u32)>, JsValue> {
+        Ok(Vec::new())
+    }
+
     fn chain_apply_best_block(&self, _height: u32, _header_hex: &str) -> Result<(), JsValue> {
         Ok(())
     }
@@ -1168,6 +1174,11 @@ impl LdkRuntimeManager for WasmNativeRuntimeManager {
     fn chain_relevant_txids(&self) -> Result<Vec<String>, JsValue> {
         let backend = self.ensure_live_backend()?;
         backend.chain_relevant_txids()
+    }
+
+    fn chain_watched_outputs(&self) -> Result<Vec<(String, u32)>, JsValue> {
+        let backend = self.ensure_live_backend()?;
+        backend.chain_watched_outputs()
     }
 
     fn chain_apply_best_block(&self, height: u32, header_hex: &str) -> Result<(), JsValue> {

--- a/bindings/wasm-sdk/src/lib.rs
+++ b/bindings/wasm-sdk/src/lib.rs
@@ -527,6 +527,27 @@ fn wallet_rgb_proxy_transport_get(idb_key: &str) -> Option<RlnWasmRgbProxyTransp
     Some(config)
 }
 
+/// The effective RGB proxy endpoint (with auth query params applied) for a wallet, resolved
+/// from its registered proxy-transport config or the SDK default. Used by the live backend's
+/// post-close sweep, which needs a transport endpoint for `witness_receive` and a proxy URL for
+/// `post_consignment` outside any facade call. `None` when no transport has been configured.
+pub(crate) fn effective_rgb_proxy_endpoint_for_wallet_key(idb_key: &str) -> Option<String> {
+    let config = wallet_rgb_proxy_transport_get(idb_key).or_else(sdk_default_rgb_proxy_transport)?;
+    match (&config.auth_token, &config.node_id) {
+        (Some(token), Some(node_id)) => {
+            let separator = if config.endpoint.contains('?') { '&' } else { '?' };
+            Some(format!(
+                "{}{}auth_token={}&node_id={}",
+                config.endpoint,
+                separator,
+                urlencoding::encode(token),
+                urlencoding::encode(node_id),
+            ))
+        }
+        _ => Some(config.endpoint.clone()),
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
 fn local_storage_get_item(key: &str) -> Result<Option<String>, JsValue> {
     let Some(window) = web_sys::window() else {

--- a/bindings/wasm-sdk/src/ln_node.rs
+++ b/bindings/wasm-sdk/src/ln_node.rs
@@ -4093,6 +4093,15 @@ async fn fetch_tx_status(indexer_url: &str, txid: &str) -> Result<Option<(u32, S
         .send()
         .await
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    // Esplora deployments differ on unknown txids: some answer 200 {"confirmed":false},
+    // others 404. A relevant txid the indexer has never seen is NORMAL here — a trusted
+    // virtual channel's funding tx is intentionally never broadcast, yet its monitor still
+    // registers it with the `Filter`. Treating the 404 as an error would abort the whole
+    // chain-sync tick before `chain_apply_best_block`, permanently freezing the wallet's
+    // best-block height (frozen-height CLTV failures, e.g. PaymentClaimBuffer).
+    if response.status() == 404 {
+        return Ok(None);
+    }
     if !response.ok() {
         return Err(JsValue::from_str(&format!(
             "tx status query failed with status {}",
@@ -4139,6 +4148,11 @@ async fn fetch_outspend_txid(
         .send()
         .await
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    // Unknown funding txid (e.g. a never-broadcast virtual channel funding): treat as
+    // unspent rather than an error, mirroring `fetch_tx_status`.
+    if response.status() == 404 {
+        return Ok(None);
+    }
     if !response.ok() {
         return Err(JsValue::from_str(&format!(
             "outspend query failed with status {}",

--- a/bindings/wasm-sdk/src/ln_node.rs
+++ b/bindings/wasm-sdk/src/ln_node.rs
@@ -4125,6 +4125,60 @@ async fn fetch_tx_status(indexer_url: &str, txid: &str) -> Result<Option<(u32, S
     Ok(Some((height, block_hash)))
 }
 
+/// Esplora: `GET /tx/:txid/outspend/:vout` → whether (and by which tx) an output is spent.
+/// Returns the spender txid only once the spend itself is CONFIRMED — an unconfirmed spend
+/// cannot be fed to LDK's `transactions_confirmed` anyway.
+#[cfg(target_arch = "wasm32")]
+async fn fetch_outspend_txid(
+    indexer_url: &str,
+    txid: &str,
+    vout: u32,
+) -> Result<Option<String>, JsValue> {
+    let url = format!("{indexer_url}/tx/{txid}/outspend/{vout}");
+    let response = Request::get(&url)
+        .send()
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    if !response.ok() {
+        return Err(JsValue::from_str(&format!(
+            "outspend query failed with status {}",
+            response.status()
+        )));
+    }
+    let value: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let spent = value
+        .get("spent")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if !spent {
+        return Ok(None);
+    }
+    let confirmed = value
+        .get("status")
+        .and_then(|s| s.get("confirmed"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if !confirmed {
+        return Ok(None);
+    }
+    Ok(value
+        .get("txid")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string()))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn fetch_outspend_txid(
+    _indexer_url: &str,
+    _txid: &str,
+    _vout: u32,
+) -> Result<Option<String>, JsValue> {
+    Err(JsValue::from_str(sdk_contracts::ERR_CHAIN_SYNC_WASM32_ONLY))
+}
+
 /// Esplora: `GET /block/:hash/txids` returns the ordered txid list for the block.
 /// LDK's `transactions_confirmed` requires the transaction's index within that list (coinbase is 0).
 #[cfg(target_arch = "wasm32")]
@@ -6001,8 +6055,49 @@ async fn apply_chain_sync_to_live_ldk(
         return Ok(());
     }
 
-    let relevant = ldk_runtime.chain_relevant_txids()?;
+    let mut relevant = ldk_runtime.chain_relevant_txids()?;
+    // Watched-output spend detection: the monitor watches its funding outpoints via the
+    // `Filter`, but the tx that SPENDS one (closing/commitment tx) is unknown to it until we
+    // feed it in — `chain_relevant_txids` can never list it. Ask the indexer who spent each
+    // watched outpoint and treat any confirmed spender as a relevant tx; applying it via
+    // `chain_apply_confirmed_tx` below lets the monitor resolve the close and (after maturity)
+    // emit `Event::SpendableOutputs`, which drives the post-close sweep.
+    let watched_outputs = ldk_runtime.chain_watched_outputs()?;
+    let max_outspends = 64usize;
+    for (txid, vout) in watched_outputs.into_iter().take(max_outspends) {
+        match fetch_outspend_txid(&indexer_url, &txid, vout).await {
+            Ok(Some(spender_txid)) => {
+                if !relevant.contains(&spender_txid) {
+                    relevant.push(spender_txid);
+                }
+            }
+            Ok(None) => {}
+            Err(e) => {
+                wasm_debug(&format!(
+                    "[rln-wasm-sdk chain-sync] outspend lookup failed for {txid}:{vout}: {e:?}"
+                ));
+            }
+        }
+    }
     if relevant.is_empty() {
+        // Height-only sync. A wallet with no monitors and no watched txids (fresh node before
+        // its first channel, restored wallet with zero channels, virtual-channel onboarding
+        // window) previously returned early here on EVERY tick, freezing the ChannelManager's
+        // best block at the network genesis. Outbound route CLTVs were then computed from that
+        // frozen height and rejected by peers at the real chain height ("cltv expiry too
+        // soon" — compensating would need an ever-growing CLTV delta), and the hodl-HTLC
+        // deadline fail-back (driven inside chain_apply_best_block) could never fire. Apply
+        // the tip unconditionally; tolerate a missing LDK object graph (e.g. wallet attached
+        // but LDK not started yet) instead of failing the whole chain-sync tick.
+        let tip_header_hex = fetch_block_header_hex_by_height(&indexer_url, tip_height).await?;
+        match ldk_runtime.chain_apply_best_block(tip_height, &tip_header_hex) {
+            Ok(()) => wasm_debug(&format!(
+                "[rln-wasm-sdk chain-sync] height-only best block applied height={tip_height}"
+            )),
+            Err(e) => wasm_debug(&format!(
+                "[rln-wasm-sdk chain-sync] height-only best block skipped (backend not ready): {e:?}"
+            )),
+        }
         return Ok(());
     }
 


### PR DESCRIPTION
# Settle on-chain RGB and BTC on the wasm side after channel close

Fixes the reported bug: after a cooperative close of an RGB channel, the native node recovers
its RGB allocation on-chain but the wasm SDK side stays at `getAssetBalance = 0` forever, even
though the closing tx is colored and the transfer info is recorded.

## Root causes (all four were needed)

1. **ChainMonitor events were never drained** — `Event::SpendableOutputs` is emitted only by the
   `ChainMonitor`'s `EventsProvider`, never by the `ChannelManager`, and the wasm backend only
   drained the latter. The drain now also runs from the drive tick, since peer traffic can stop
   entirely after a close.
2. **No `SpendableOutputs` handler** — the event fell into the catch-all arm and was discarded.
   It now serializes the descriptors and queues durable sweep work (the event fires exactly
   once; losing it would strand the funds across a reload).
3. **No sweep pipeline** — the wasm equivalent of the native `RgbOutputSpender` now runs in the
   drive tick: transfer-info lookup by closing txid → `update_witnesses` → `witness_receive` →
   sweep PSBT + `color_psbt_and_consume` → sign → post consignment → broadcast → refresh, with
   an idempotency map so retries rebroadcast the same tx instead of double-spending. Non-RGB
   closes sweep as vanilla BTC via `KeysManager::spend_spendable_outputs`. (LDK's `OutputSweeper`
   can't be reused: its `OutputSpender` trait is sync while rgb-lib-wasm's calls are async.)
4. **No funding-spend detection** — the chain sync only looked up known txids, so the monitor
   never saw the closing tx confirm and never emitted `SpendableOutputs` at all. The driver now
   checks each `Filter`-watched outpoint via esplora `/tx/:txid/outspend/:vout` and feeds
   confirmed spenders into `transactions_confirmed`, mirroring what `lightning-transaction-sync`
   does for the native node.

## Also fixed: frozen best-block height on channel-less wallets

`apply_chain_sync_to_live_ldk` returned early when there were no relevant txids, so a wallet
with no monitors yet (fresh node, virtual-channel onboarding window, restored zero-channel
wallet) never received `best_block_updated` and stayed at genesis height — outbound route CLTVs
computed from height 0 were rejected by real-height peers, and the hodl-HTLC deadline fail-back
could never fire. The tip is now applied even with no relevant txids, tolerating a
not-yet-started LDK graph.

## Reproduction & verification

New e2e: `bindings/wasm-sdk/examples/wasm-interop/run_coop_close_settlement_flow.mjs` — a native
hub opens a real anchors RGB channel to the wasm node with pushed RGB, one keysend lands, the
wasm side coop-closes, then the flow asserts BOTH sides settle on-chain (the native side acts as
the infra control).

- Before the fix: native settles its 250 RGB, wasm stays at 0 (reproduces the report).
- After the fix: full pass — wasm broadcasts a colored sweep and credits all 350 RGB.
- Regression: the virtual-channel full flow (`run_e2e_full_flow.mjs`) passes run + verify, and
  logs `height-only best block applied height=N` during the pre-channel window.

