### PR TITLE
Channel open stuck in Opening when VSS is unreachable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -143,6 +143,8 @@ jobs:
         run: VSS=1 ./regtest.sh start
       - name: Run VSS tests (e2e against regtest + VSS server)
         run: cargo test --features vss "test::vss::tests" -- --test-threads=1
+      - name: Run VSS unreachable openchannel e2e test
+        run: cargo test --features vss "test::vss_unreachable_openchannel" -- --test-threads=1
       - name: Run VSS full-restore e2e test (wipe node dir, restore from seed)
         run: cargo test --features "uniffi,test-utils,vls,vss" --test lib_sdk vss_restore -- --test-threads=1
       - name: Stop regtest and VSS services

--- a/src/async_kv_store.rs
+++ b/src/async_kv_store.rs
@@ -59,6 +59,18 @@ impl RemoteFirstKvStore {
     pub fn stop(&self) {
         let _ = self.shutdown.send(true);
     }
+
+    /// Probes the configured VSS server. `true` when VSS is not configured or
+    /// answered (a missing probe key still proves the server responded).
+    pub async fn remote_reachable(&self) -> bool {
+        match &self.remote {
+            None => true,
+            Some(remote) => match remote.read_async("", "", "vss_health_probe").await {
+                Ok(_) => true,
+                Err(e) => e.kind() == io::ErrorKind::NotFound,
+            },
+        }
+    }
 }
 
 /// Runs `op` until it succeeds, retrying transient VSS failures with capped

--- a/src/error.rs
+++ b/src/error.rs
@@ -109,6 +109,10 @@ pub enum APIError {
     #[error("Failed to initialize VSS: {0}")]
     FailedVssInit(String),
 
+    #[cfg(feature = "vss")]
+    #[error("VSS server is unreachable")]
+    VssUnreachable,
+
     #[error("Failed to disconnect to peer: {0}")]
     FailedPeerDisconnection(String),
 
@@ -634,7 +638,7 @@ impl IntoResponse for APIError {
                 self.name(),
             ),
             #[cfg(feature = "vss")]
-            APIError::FailedVssInit(_) => (
+            APIError::FailedVssInit(_) | APIError::VssUnreachable => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 self.to_string(),
                 self.name(),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -4115,6 +4115,13 @@ pub(crate) async fn open_channel(
         let guard = state.check_unlocked().await?;
         let unlocked_state = guard.as_ref().unwrap();
 
+        // Channel persistence is remote-first: without VSS the open would
+        // accept and then stall silently, so refuse it up front.
+        #[cfg(feature = "vss")]
+        if !unlocked_state.monitor_kv_store.remote_reachable().await {
+            return Err(APIError::VssUnreachable);
+        }
+
         let is_virtual_open = match payload.virtual_open_mode.as_deref() {
             None => false,
             Some(VIRTUAL_OPEN_MODE_TRUSTED_NO_BROADCAST) => true,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2990,3 +2990,5 @@ mod virtual_channels;
 mod vss;
 #[cfg(feature = "vss")]
 mod vss_offline_force_close;
+#[cfg(feature = "vss")]
+mod vss_unreachable_openchannel;

--- a/src/test/vss_unreachable_openchannel.rs
+++ b/src/test/vss_unreachable_openchannel.rs
@@ -1,0 +1,99 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/vss_unreachable_openchannel/";
+
+/// A node whose configured VSS server is unreachable must refuse a channel
+/// open with a clear error instead of accepting it and leaving the channel
+/// silently stuck in `Opening`; once VSS is reachable again the same open
+/// must succeed.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[traced_test]
+async fn openchannel_refused_while_vss_unreachable() {
+    tokio::time::timeout(
+        std::time::Duration::from_secs(300),
+        openchannel_refused_while_vss_unreachable_inner(),
+    )
+    .await
+    .expect("openchannel_refused_while_vss_unreachable timed out");
+}
+
+async fn openchannel_refused_while_vss_unreachable_inner() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}node2");
+
+    let proxy = super::vss_offline_force_close::VssProxy::start();
+    let (node1_addr, _, _) = start_node_with_vss(
+        &test_dir_node1,
+        NODE1_PEER_PORT,
+        false,
+        &proxy.url(),
+        None,
+        false,
+    )
+    .await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    connect_peer(
+        node1_addr,
+        &node2_pubkey,
+        &format!("127.0.0.1:{NODE2_PEER_PORT}"),
+    )
+    .await;
+
+    proxy.go_offline();
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let res = open_channel_request_raw(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(600_000),
+        Some(100_000_000),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        true,
+        true,
+    )
+    .await
+    .expect_err("openchannel must be refused while VSS is unreachable");
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::SERVICE_UNAVAILABLE,
+        "VSS server is unreachable",
+        "VssUnreachable",
+    )
+    .await;
+    assert!(
+        list_channels(node1_addr).await.is_empty(),
+        "a refused open must not leave a channel behind"
+    );
+
+    // Once VSS is reachable again the same open must go through to a ready,
+    // usable channel.
+    proxy.go_online();
+    open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(600_000),
+        Some(100_000_000),
+        None,
+        None,
+    )
+    .await;
+    wait_for_usable_channels(node1_addr, 1).await;
+    wait_for_usable_channels(node2_addr, 1).await;
+
+    shutdown(&[node1_addr, node2_addr]).await;
+}


### PR DESCRIPTION
## The issue

Opening a channel while a node could not reach its configured VSS server left the channel silently stuck in "Open in progress". `/openchannel` accepted the request and returned success, but the funding flow could never run: channel state is persisted remote-first, so with VSS unreachable the persistence layer sits in its retry loop and the node is paused until VSS is back. The pause is by design, a remote-first node must not keep operating without its backup, but accepting new work it cannot complete, with no error and no signal, is not. The only workaround was restarting the node without VSS.

## The fix

`/openchannel` now probes the configured VSS server up front and refuses the request with a clear error (`503 VssUnreachable: "VSS server is unreachable"`) while VSS cannot be reached. Nothing else changes: all persistence stays remote-first, in-flight operations keep the existing retry-until-recovery behavior, and once VSS is reachable again channel opens work normally. Nodes without VSS configured are unaffected.

Verified behavior around the fix:

- With VSS reachable, mixed topologies (one node with VSS, one without) open channels fine in both directions, the bug only exists while VSS is unreachable.
- Before the fix, an open accepted during a short outage completes on its own once VSS recovers; the silent wedge persists only for as long as the outage does.
- If the *peer's* VSS is unreachable, the peer is paused and simply never answers the open, from the opener's side this is indistinguishable from an unresponsive peer, and LDK's normal unfunded-channel handling applies. That side is remote-first working as intended, not a defect.
