### PR TITLE
Re-import channel consignments on restore so force-closed channel funds can be recovered

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -147,6 +147,8 @@ jobs:
         run: cargo test --features vss "test::vss_unreachable_openchannel" -- --test-threads=1
       - name: Run VSS full-restore e2e test (wipe node dir, restore from seed)
         run: cargo test --features "uniffi,test-utils,vls,vss" --test lib_sdk vss_restore -- --test-threads=1
+      - name: Run consignment re-import e2e test (restore without RGB backup)
+        run: cargo test --features "uniffi,test-utils,vls,vss" --test lib_sdk vss_consignment_reimport -- --test-threads=1
       - name: Stop regtest and VSS services
         if: always()
         run: docker compose --profile vss down -v --remove-orphans

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,7 @@ dependencies = [
 name = "lightning"
 version = "0.2.2"
 dependencies = [
+ "amplify",
  "bech32 0.11.1",
  "bincode",
  "bitcoin 0.32.102",
@@ -2802,6 +2803,7 @@ dependencies = [
  "musig2",
  "possiblyrandom 0.2.0",
  "rgb-lib",
+ "rgb-strict-encoding",
  "serde",
  "tokio",
 ]

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -38,8 +38,9 @@ use lightning::onion_message::messenger::{
     DefaultMessageRouter, OnionMessenger as LdkOnionMessenger,
 };
 use lightning::rgb_utils::{
-    get_rgb_channel_info_pending, is_channel_rgb, update_rgb_channel_amount, RgbKvStoreExt,
-    RGB_PAYMENT_INFO_INBOUND_NS, RGB_PAYMENT_INFO_OUTBOUND_NS, RGB_PRIMARY_NS,
+    deserialize_fascia, get_rgb_channel_info_pending, is_channel_rgb, update_rgb_channel_amount,
+    RgbKvStoreExt, RGB_COMMITMENT_FASCIA_NS, RGB_PAYMENT_INFO_INBOUND_NS,
+    RGB_PAYMENT_INFO_OUTBOUND_NS, RGB_PRIMARY_NS,
 };
 use lightning::rgb_utils::{RgbPaymentInfo, STATIC_BLINDING};
 use lightning::routing::gossip;
@@ -104,14 +105,13 @@ use rgb_lib::{
     Fascia, FileContent, RgbTransfer, RgbTxid, TransferStatus, WitnessOrd,
 };
 use std::collections::HashMap;
-#[cfg(feature = "vss")]
 use std::collections::HashSet;
 use std::convert::TryInto;
 use std::fs;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::net::ToSocketAddrs;
 use std::net::{SocketAddr, TcpListener};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock, Weak};
@@ -142,6 +142,13 @@ const ASSET_LINK_SWAP_AUTHORIZATION_MAX_EXPIRY_SECS: u64 = 24 * 60 * 60;
 const OUTPUT_SPENDER_TXES_KEY: &str = "output_spender_txes";
 const PSBT_NAMESPACE: &str = "psbt";
 const PENDING_FUNDING_NAMESPACE: &str = "pending_funding";
+/// Funding consignments keyed by funding txid, kept for wallet re-seeding
+/// after a restore without an RGB backup (issue #111).
+const FUNDING_CONSIGNMENT_NAMESPACE: &str = "funding_consignment";
+/// Local-only marker: absent on a freshly restored device, so the fascia
+/// replay reruns until it completes once.
+const REIMPORT_MARKER_NAMESPACE: &str = "reimport_marker";
+const REIMPORT_MARKER_KEY: &str = "fascia_replay";
 const CONFIG_INDEXER_URL: &str = "indexer_url";
 const CONFIG_BITCOIN_NETWORK: &str = "bitcoin_network";
 const CONFIG_WALLET_FINGERPRINT: &str = "wallet_fingerprint";
@@ -2376,6 +2383,13 @@ async fn handle_ldk_events(
 
                 let consignment_path =
                     unlocked_state.rgb_get_send_consignment_path(&asset_id, &funding_txid_str);
+                match fs::read(&consignment_path) {
+                    Ok(data) => unlocked_state
+                        .kv_store
+                        .write(FUNDING_CONSIGNMENT_NAMESPACE, "", &funding_txid_str, data)
+                        .unwrap(),
+                    Err(e) => tracing::error!("cannot store funding consignment: {e}"),
+                }
                 let proxy_url = TransportEndpoint::new(unlocked_state.proxy_endpoint.clone())
                     .unwrap()
                     .endpoint;
@@ -3125,6 +3139,15 @@ async fn handle_ldk_events(
                                 return Ok(());
                             }
                         };
+                    unlocked_state
+                        .kv_store
+                        .write(
+                            FUNDING_CONSIGNMENT_NAMESPACE,
+                            "",
+                            &funding_txid,
+                            consignment_data.clone(),
+                        )
+                        .unwrap();
                     let consignment =
                         RgbTransfer::load(&mut std::io::Cursor::new(consignment_data))
                             .expect("successful consignment load");
@@ -4145,6 +4168,168 @@ mod watchdog_tests {
     }
 }
 
+/// Re-seed the RGB wallet with funding consignments the wallet doesn't know,
+/// so a wallet restored without an RGB backup can color force-close sweeps
+/// (issue #111). Failures are logged, never fatal: unlock must proceed.
+async fn reimport_funding_consignments(
+    rgb_wallet_wrapper: &Arc<RgbLibWalletWrapper>,
+    kv_store: &Arc<SyncedKvStore>,
+    proxy_endpoint: &str,
+    ldk_data_dir: &Path,
+) {
+    let mark_replay_done = || {
+        let _ =
+            kv_store.write_local_only(REIMPORT_MARKER_NAMESPACE, "", REIMPORT_MARKER_KEY, vec![1]);
+    };
+    let replay_pending = kv_store
+        .read(REIMPORT_MARKER_NAMESPACE, "", REIMPORT_MARKER_KEY)
+        .is_err();
+    let txids = match kv_store.list(FUNDING_CONSIGNMENT_NAMESPACE, "") {
+        Ok(keys) => keys,
+        Err(e) => {
+            tracing::error!("cannot list stored funding consignments: {e}");
+            return;
+        }
+    };
+    if txids.is_empty() {
+        mark_replay_done();
+        return;
+    }
+    let known: HashSet<String> = match rgb_wallet_wrapper.list_assets(vec![]) {
+        Ok(assets) => assets
+            .nia
+            .unwrap_or_default()
+            .into_iter()
+            .map(|a| a.asset_id)
+            .chain(
+                assets
+                    .cfa
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|a| a.asset_id),
+            )
+            .chain(
+                assets
+                    .uda
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|a| a.asset_id),
+            )
+            .chain(
+                assets
+                    .ifa
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|a| a.asset_id),
+            )
+            .collect(),
+        Err(e) => {
+            tracing::error!("cannot list assets before consignment re-import: {e}");
+            return;
+        }
+    };
+    let mut imported_any = false;
+    for txid in txids {
+        let data = match kv_store.read(FUNDING_CONSIGNMENT_NAMESPACE, "", &txid) {
+            Ok(data) => data,
+            Err(e) => {
+                tracing::error!("cannot read stored funding consignment for {txid}: {e}");
+                continue;
+            }
+        };
+        let consignment = match RgbTransfer::load(&mut std::io::Cursor::new(&data)) {
+            Ok(consignment) => consignment,
+            Err(e) => {
+                tracing::error!("cannot load stored funding consignment for {txid}: {e}");
+                continue;
+            }
+        };
+        if known.contains(&consignment.contract_id().to_string()) {
+            continue;
+        }
+        let wrapper = Arc::clone(rgb_wallet_wrapper);
+        let txid_copy = txid.clone();
+        let proxy_endpoint = proxy_endpoint.to_string();
+        let consignment_path = ldk_data_dir.join(format!("reimport_consignment_{txid}"));
+        // Re-post our stored copy so the proxy can serve it, then accept it
+        // like the funding-time acceptor flow does: this consumes the
+        // consignment into the RGB runtime, which save_new_asset requires.
+        let res = tokio::task::spawn_blocking(move || -> Result<(), String> {
+            fs::write(&consignment_path, &data).map_err(|e| e.to_string())?;
+            let proxy_url = TransportEndpoint::new(proxy_endpoint.clone())
+                .map_err(|e| e.to_string())?
+                .endpoint;
+            if let Err(e) = wrapper.post_consignment(
+                &proxy_url,
+                txid_copy.clone(),
+                &consignment_path,
+                txid_copy.clone(),
+                None,
+            ) {
+                tracing::debug!("re-posting funding consignment for {txid_copy}: {e}");
+            }
+            let _ = fs::remove_file(&consignment_path);
+            let (consignment, _) = wrapper
+                .accept_transfer(txid_copy.clone(), 1, &proxy_endpoint, STATIC_BLINDING)
+                .map_err(|e| e.to_string())?;
+            match wrapper.save_new_asset(consignment, txid_copy) {
+                Ok(()) => Ok(()),
+                Err(e) if e.to_string().contains("UNIQUE constraint failed") => Ok(()),
+                Err(e) => Err(e.to_string()),
+            }
+        })
+        .await;
+        match res {
+            Ok(Ok(())) => {
+                imported_any = true;
+                tracing::info!("re-imported funding consignment for {txid}");
+            }
+            Ok(Err(e)) => tracing::error!("cannot re-import funding consignment for {txid}: {e}"),
+            Err(e) => tracing::error!("funding consignment re-import task failed for {txid}: {e}"),
+        }
+    }
+
+    // The runtime also needs the funding->commitment transitions to color
+    // force-close sweeps; re-consume the stored latest fascia of each channel.
+    if !imported_any && !replay_pending {
+        return;
+    }
+    let fascia_keys = match kv_store.list(RGB_PRIMARY_NS, RGB_COMMITMENT_FASCIA_NS) {
+        Ok(keys) => keys,
+        Err(e) => {
+            tracing::error!("cannot list stored commitment fascias: {e}");
+            return;
+        }
+    };
+    for key in fascia_keys {
+        let data = match kv_store.read(RGB_PRIMARY_NS, RGB_COMMITMENT_FASCIA_NS, &key) {
+            Ok(data) => data,
+            Err(e) => {
+                tracing::error!("cannot read stored commitment fascia {key}: {e}");
+                continue;
+            }
+        };
+        let fascia = match deserialize_fascia(data) {
+            Ok(fascia) => fascia,
+            Err(e) => {
+                tracing::error!("cannot deserialize stored commitment fascia {key}: {e}");
+                continue;
+            }
+        };
+        let wrapper = Arc::clone(rgb_wallet_wrapper);
+        match tokio::task::spawn_blocking(move || {
+            wrapper.consume_fascia(fascia, Some(WitnessOrd::Ignored))
+        })
+        .await
+        {
+            Ok(Ok(())) => tracing::info!("re-consumed commitment fascia {key}"),
+            Ok(Err(e)) => tracing::error!("cannot re-consume commitment fascia {key}: {e}"),
+            Err(e) => tracing::error!("commitment fascia re-consume task failed for {key}: {e}"),
+        }
+    }
+    mark_replay_done();
+}
+
 pub(crate) async fn start_ldk(
     app_state: Arc<AppState>,
     key_source: NodeKeySource,
@@ -4959,6 +5144,14 @@ pub(crate) async fn start_ldk(
         Arc::new(Mutex::new(rgb_wallet)),
         rgb_online,
     ));
+
+    reimport_funding_consignments(
+        &rgb_wallet_wrapper,
+        &kv_store,
+        proxy_endpoint,
+        &ldk_data_dir,
+    )
+    .await;
 
     // Initialize the OutputSweeper.
     let txes: OutputSpenderTxes = match kv_store.read("", "", OUTPUT_SPENDER_TXES_KEY) {

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -875,6 +875,22 @@ impl RgbLibWalletWrapper {
             .list_unspents(online, settled_only, skip_sync)
     }
 
+    pub(crate) fn accept_transfer(
+        &self,
+        txid: String,
+        vout: u32,
+        proxy_endpoint: &str,
+        blinding: u64,
+    ) -> Result<(RgbTransfer, Vec<Assignment>), RgbLibError> {
+        let consignment_endpoint = RgbTransport::from_str(proxy_endpoint).map_err(|e| {
+            RgbLibError::InvalidTransportEndpoint {
+                details: e.to_string(),
+            }
+        })?;
+        self.get_rgb_wallet()
+            .accept_transfer(txid, vout, consignment_endpoint, blinding)
+    }
+
     pub(crate) fn post_consignment<P: AsRef<Path>>(
         &self,
         proxy_url: &str,

--- a/src/synced_kv_store.rs
+++ b/src/synced_kv_store.rs
@@ -236,6 +236,19 @@ impl SyncedKvStore {
         Ok(restored)
     }
 
+    /// Local-only write; the row is never replicated, so a wipe-and-restore
+    /// intentionally loses it.
+    pub(crate) fn write_local_only(
+        &self,
+        primary_namespace: &str,
+        secondary_namespace: &str,
+        key: &str,
+        buf: Vec<u8>,
+    ) -> Result<(), io::Error> {
+        self.local
+            .write(primary_namespace, secondary_namespace, key, buf)
+    }
+
     /// Local-only removal; lets the restore guard discard a restored key.
     #[cfg(feature = "vss")]
     pub(crate) fn remove_local_only(

--- a/src/test/lib_sdk/mod.rs
+++ b/src/test/lib_sdk/mod.rs
@@ -17,6 +17,8 @@ mod send_receive;
 mod swap_roundtrip_buy;
 mod vanilla_payment_on_rgb_channel;
 #[cfg(feature = "vss")]
+mod vss_consignment_reimport;
+#[cfg(feature = "vss")]
 mod vss_manager_lag;
 #[cfg(feature = "vss")]
 mod vss_restore;

--- a/src/test/lib_sdk/vss_consignment_reimport.rs
+++ b/src/test/lib_sdk/vss_consignment_reimport.rs
@@ -1,0 +1,252 @@
+//! Issue #111: a node restored from VSS without an RGB wallet backup must
+//! still recover the funds of force-closed channels — vanilla and colored —
+//! by re-importing the channel consignment kept in the replicated KV data.
+//! Requires the regtest stack (`./regtest.sh start`) and the VSS server
+//! (`docker compose --profile vss up -d`).
+
+use crate::helpers::*;
+use crate::vss_manager_lag::{vss_server_available, ManagerFilterProxy};
+use serial_test::serial;
+use std::{fs, time::Duration};
+
+const NODE_A_PORT_OFFSET: u16 = 150;
+const NODE_B_PORT_OFFSET: u16 = 150;
+const PASSWORD_A: &str = "nodeApass";
+const PASSWORD_B: &str = "nodeBpass";
+const CHANNEL_ASSET_AMOUNT: u64 = 600;
+const ASSET_SEND_A_TO_B: u64 = 150;
+const ASSET_SEND_B_TO_A: u64 = 50;
+// The recovery must reflect the latest commitment, not the funding split.
+const NODE_A_FINAL_ASSET_AMOUNT: u64 = CHANNEL_ASSET_AMOUNT - ASSET_SEND_A_TO_B + ASSET_SEND_B_TO_A;
+const NODE_B_FINAL_ASSET_AMOUNT: u64 = ASSET_SEND_A_TO_B - ASSET_SEND_B_TO_A;
+
+fn spendable_sats(node: &SdkNode) -> u64 {
+    let balance = node.btc_balance(false).expect("btc_balance");
+    balance.vanilla.spendable + balance.colored.spendable
+}
+
+#[test]
+#[serial]
+fn restored_node_recovers_force_closed_channel_funds() {
+    ensure_regtest_available();
+    if !vss_server_available() {
+        eprintln!("SKIP: VSS server not available");
+        return;
+    }
+
+    let test_dir = test_dir("vss_consignment_reimport");
+    if test_dir.exists() {
+        fs::remove_dir_all(&test_dir).expect("clean previous test dir");
+    }
+    fs::create_dir_all(&test_dir).expect("create test dir");
+    let node_a_dir = test_dir.join("node_a");
+    let node_b_dir = test_dir.join("node_b");
+
+    let proxy = ManagerFilterProxy::start();
+
+    // Phase 1: build the incomplete backup through the product path — the
+    // node replicates normally except that no RGB backup ever reaches VSS.
+    let node_a = make_node_with_vss(
+        &node_a_dir,
+        NODE_A_DAEMON_PORT + NODE_A_PORT_OFFSET,
+        NODE_A_PEER_PORT + NODE_A_PORT_OFFSET,
+        &proxy.url(),
+    );
+    let node_b = make_node(
+        &node_b_dir,
+        NODE_B_DAEMON_PORT + NODE_B_PORT_OFFSET,
+        NODE_B_PEER_PORT + NODE_B_PORT_OFFSET,
+    );
+
+    let mnemonic_a = node_a
+        .init(PASSWORD_A.to_string(), None)
+        .expect("node A init");
+    node_b
+        .init(PASSWORD_B.to_string(), None)
+        .expect("node B init");
+    node_a
+        .unlock(unlock_request(PASSWORD_A))
+        .expect("node A initial unlock");
+    node_b
+        .unlock(unlock_request(PASSWORD_B))
+        .expect("node B initial unlock");
+
+    proxy.block_rgb_backup_writes();
+
+    fund_and_create_utxos(&node_a, "node A");
+    fund_and_create_utxos(&node_b, "node B");
+
+    let asset = node_a
+        .issueassetnia(SdkIssueAssetNiaRequest {
+            amounts: vec![1_000],
+            ticker: "USDT".to_string(),
+            name: "Tether".to_string(),
+            precision: 0,
+        })
+        .expect("node A issueassetnia");
+    let asset_id = asset.asset_id;
+
+    let node_a_pubkey = node_a.node_info().expect("node A node_info").pubkey;
+    let node_b_pubkey = node_b.node_info().expect("node B node_info").pubkey;
+    let peer_uri = format!(
+        "{node_b_pubkey}@127.0.0.1:{}",
+        NODE_B_PEER_PORT + NODE_B_PORT_OFFSET
+    );
+    node_a
+        .connectpeer(peer_uri.clone())
+        .expect("node A connectpeer");
+
+    let open_channel = node_a
+        .openchannel(SdkOpenChannelRequest {
+            peer_pubkey_and_opt_addr: peer_uri.clone(),
+            capacity_sat: OPEN_CHANNEL_CAPACITY_SAT,
+            // Push some msat so node B can pay the return keysend over the
+            // channel reserve.
+            push_msat: PAYMENT_MSAT,
+            public: true,
+            with_anchors: true,
+            fee_base_msat: None,
+            fee_proportional_millionths: None,
+            temporary_channel_id: None,
+            asset_id: Some(asset_id),
+            asset_amount: Some(CHANNEL_ASSET_AMOUNT),
+            push_asset_amount: None,
+            virtual_open_mode: None,
+        })
+        .expect("node A openchannel colored");
+    wait_for_channel_funding_tx(&node_a, &node_b, &asset_id, Duration::from_secs(120));
+    mine(OPEN_CHANNEL_CONFIRM_BLOCKS);
+    wait_for_usable_channel(&node_a, &node_b, &asset_id, Duration::from_secs(300));
+    let _colored_channel_id = node_a
+        .get_channel_id(open_channel.temporary_channel_id)
+        .expect("node A get_channel_id");
+
+    // A second, vanilla channel: its force-close sweep must also recover.
+    node_a
+        .openchannel(SdkOpenChannelRequest {
+            peer_pubkey_and_opt_addr: peer_uri.clone(),
+            capacity_sat: OPEN_CHANNEL_CAPACITY_SAT,
+            push_msat: 0,
+            public: true,
+            with_anchors: true,
+            fee_base_msat: None,
+            fee_proportional_millionths: None,
+            temporary_channel_id: None,
+            asset_id: None,
+            asset_amount: None,
+            push_asset_amount: None,
+            virtual_open_mode: None,
+        })
+        .expect("node A openchannel vanilla");
+    mine(OPEN_CHANNEL_CONFIRM_BLOCKS);
+    wait_for_usable_channel_counts(&[(&node_a, 2), (&node_b, 2)], Duration::from_secs(300));
+
+    // Several settled payments so the stored fascia is overwritten across
+    // commitment updates and the restore recovers the latest balance split.
+    keysend(
+        &node_a,
+        node_b_pubkey,
+        None,
+        Some(&asset_id),
+        Some(ASSET_SEND_A_TO_B),
+    );
+    keysend(
+        &node_b,
+        node_a_pubkey,
+        None,
+        Some(&asset_id),
+        Some(ASSET_SEND_B_TO_A),
+    );
+    std::thread::sleep(Duration::from_secs(5));
+
+    // Phase 2: graceful shutdown, device wiped, restore from VSS + seed.
+    node_a.shutdown();
+    drop(node_a);
+    proxy.allow_all();
+    fs::remove_dir_all(&node_a_dir).expect("wipe node A storage");
+
+    let node_a = make_node_with_vss(
+        &node_a_dir,
+        NODE_A_DAEMON_PORT + NODE_A_PORT_OFFSET,
+        NODE_A_PEER_PORT + NODE_A_PORT_OFFSET,
+        &proxy.url(),
+    );
+    let mnemonic_returned = node_a
+        .init(PASSWORD_A.to_string(), Some(mnemonic_a.clone()))
+        .expect("node A re-init");
+    assert_eq!(mnemonic_returned, mnemonic_a);
+    node_a
+        .vss_clear_fence(SdkVssClearFenceRequest {
+            password: PASSWORD_A.to_string(),
+        })
+        .expect("node A vss_clear_fence");
+    node_a
+        .unlock(unlock_request(PASSWORD_A))
+        .expect("node A unlock after restore");
+
+    // Phase 3: right after unlock the wallet must know the channel asset
+    // again, re-imported from the consignment in the replicated KV data.
+    let assets = node_a
+        .list_assets(vec![])
+        .expect("node A list_assets")
+        .nia
+        .unwrap_or_default();
+    assert!(
+        assets.iter().any(|a| a.asset_id == asset_id),
+        "restored node must re-import the channel asset from the stored consignment"
+    );
+
+    node_a
+        .connectpeer(peer_uri)
+        .expect("node A connectpeer after restore");
+    wait_for_usable_channels(&node_a, 2, Duration::from_secs(120));
+    let btc_at_restore = spendable_sats(&node_a);
+
+    // Phase 4: force-close both channels; the sweeps must return the BTC of
+    // both to_self outputs and make the channel's asset amount spendable.
+    let channels = node_a.list_channels().expect("node A list_channels");
+    assert_eq!(channels.len(), 2);
+    for channel in channels {
+        close_channel_with_force(&node_a, channel.channel_id, node_b_pubkey, true);
+    }
+
+    let mut btc_recovered = false;
+    let mut assets_recovered = false;
+    for _ in 0..40 {
+        mine(10);
+        std::thread::sleep(Duration::from_secs(3));
+        let _ = node_a.refreshtransfers(SdkRefreshTransfersRequest { skip_sync: false });
+        // > 120k sat proves both ~97k to_self outputs (vanilla and colored)
+        // were swept; either alone cannot reach it.
+        if !btc_recovered && spendable_sats(&node_a) > btc_at_restore + 120_000 {
+            btc_recovered = true;
+        }
+        if !assets_recovered
+            && asset_balance_spendable(&node_a, &asset_id) >= NODE_A_FINAL_ASSET_AMOUNT
+        {
+            assets_recovered = true;
+        }
+        if btc_recovered && assets_recovered {
+            break;
+        }
+    }
+    assert!(
+        btc_recovered,
+        "the force-closed channels' BTC (vanilla and colored) must return to the spendable balance"
+    );
+    assert!(
+        assets_recovered,
+        "the channel's asset amount must become spendable again"
+    );
+
+    // The intact counterparty must also claim its latest-state amount.
+    wait_for_balance(
+        &node_b,
+        &asset_id,
+        NODE_B_FINAL_ASSET_AMOUNT,
+        Duration::from_secs(120),
+    );
+
+    node_a.shutdown();
+    node_b.shutdown();
+}

--- a/src/test/lib_sdk/vss_manager_lag.rs
+++ b/src/test/lib_sdk/vss_manager_lag.rs
@@ -17,39 +17,45 @@ const PASSWORD_A: &str = "nodeApass";
 const PASSWORD_B: &str = "nodeBpass";
 const MANAGER_VSS_KEY: &[u8] = b"_/_/manager";
 
-fn vss_server_available() -> bool {
+pub(crate) fn vss_server_available() -> bool {
     std::net::TcpStream::connect_timeout(&VSS_SERVER_ADDR.parse().unwrap(), Duration::from_secs(2))
         .is_ok()
 }
 
-/// VSS proxy that can reject channel-manager-key writes, passing all else through.
-struct ManagerFilterProxy {
+/// VSS proxy that can reject channel-manager-key and/or RGB-backup writes,
+/// passing all else through.
+pub(crate) struct ManagerFilterProxy {
     port: u16,
-    filter: Arc<AtomicBool>,
+    filter_manager: Arc<AtomicBool>,
+    filter_rgb_backup: Arc<AtomicBool>,
     blocked: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl ManagerFilterProxy {
-    fn start() -> Self {
+    pub(crate) fn start() -> Self {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
-        let filter = Arc::new(AtomicBool::new(false));
+        let filter_manager = Arc::new(AtomicBool::new(false));
+        let filter_rgb_backup = Arc::new(AtomicBool::new(false));
         let blocked = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-        let flag = Arc::clone(&filter);
+        let manager_flag = Arc::clone(&filter_manager);
+        let rgb_flag = Arc::clone(&filter_rgb_backup);
         let hits = Arc::clone(&blocked);
         std::thread::spawn(move || {
             for conn in listener.incoming() {
                 let Ok(stream) = conn else { break };
-                let flag = Arc::clone(&flag);
+                let manager_flag = Arc::clone(&manager_flag);
+                let rgb_flag = Arc::clone(&rgb_flag);
                 let hits = Arc::clone(&hits);
                 std::thread::spawn(move || {
-                    let _ = handle_conn(stream, flag, hits);
+                    let _ = handle_conn(stream, manager_flag, rgb_flag, hits);
                 });
             }
         });
         Self {
             port,
-            filter,
+            filter_manager,
+            filter_rgb_backup,
             blocked,
         }
     }
@@ -58,16 +64,21 @@ impl ManagerFilterProxy {
         self.blocked.load(Ordering::SeqCst)
     }
 
-    fn url(&self) -> String {
+    pub(crate) fn url(&self) -> String {
         format!("http://127.0.0.1:{}/vss", self.port)
     }
 
-    fn block_manager_writes(&self) {
-        self.filter.store(true, Ordering::SeqCst);
+    pub(crate) fn block_manager_writes(&self) {
+        self.filter_manager.store(true, Ordering::SeqCst);
     }
 
-    fn allow_all(&self) {
-        self.filter.store(false, Ordering::SeqCst);
+    pub(crate) fn block_rgb_backup_writes(&self) {
+        self.filter_rgb_backup.store(true, Ordering::SeqCst);
+    }
+
+    pub(crate) fn allow_all(&self) {
+        self.filter_manager.store(false, Ordering::SeqCst);
+        self.filter_rgb_backup.store(false, Ordering::SeqCst);
     }
 }
 
@@ -106,9 +117,14 @@ fn read_http_request(
     Ok(Some((head, body)))
 }
 
+fn body_contains(body: &[u8], needle: &[u8]) -> bool {
+    body.windows(needle.len()).any(|w| w == needle)
+}
+
 fn handle_conn(
     mut client: std::net::TcpStream,
-    filter: Arc<AtomicBool>,
+    filter_manager: Arc<AtomicBool>,
+    filter_rgb_backup: Arc<AtomicBool>,
     blocked: Arc<std::sync::atomic::AtomicUsize>,
 ) -> std::io::Result<()> {
     while let Some((head, body)) = read_http_request(&mut client)? {
@@ -117,10 +133,10 @@ fn handle_conn(
             .lines()
             .next()
             .is_some_and(|l| l.contains("putObject"));
-        let has_manager_key = body
-            .windows(MANAGER_VSS_KEY.len())
-            .any(|w| w == MANAGER_VSS_KEY);
-        if filter.load(Ordering::SeqCst) && is_put && has_manager_key {
+        let is_blocked = is_put
+            && ((filter_manager.load(Ordering::SeqCst) && body_contains(&body, MANAGER_VSS_KEY))
+                || (filter_rgb_backup.load(Ordering::SeqCst) && body_contains(&body, b"backup/")));
+        if is_blocked {
             blocked.fetch_add(1, Ordering::SeqCst);
             client.write_all(
                 b"HTTP/1.1 502 Bad Gateway\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",


### PR DESCRIPTION
A node restored from VSS and seed without an RGB wallet backup (or with one that predates a channel) gets its channels back but has no memory of the assets on them. When such a channel force-closes, the sweeper cannot color the spend of the colored commitment output, so both the BTC and the assets in it stay parked on-chain indefinitely.

The fix persists the two artifacts a restored wallet needs, in the already-replicated KV store: the channel funding consignment (now kept permanently by both funder and acceptor) and the latest commitment transition (stored by the rust-lightning side, see UTEXO-Protocol/rust-lightning#29). At unlock, any stored consignment whose asset the wallet does not know is re-imported through the same validation path used at funding time, and the commitment transitions are re-consumed, after which force-close sweeps work as on an intact wallet. Failures in this path are logged and skipped so unlock is never blocked.

The new e2e builds the incomplete backup through the product path, wipes and restores the node, force-closes one colored and one vanilla channel, and requires the asset to be listed right after unlock, the BTC of both sweeps to return, and the channel's asset amount to become spendable again. 

Not covered (follow-ups): claims of HTLCs that were in flight at the close, and justice sweeps of revoked commitments after a restore.

Fixes #111