### PR TITLE
Fall back to IPv4 when the IPv6 dual-stack peer listener bind fails

### DIFF
--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -5238,9 +5238,13 @@ pub(crate) async fn start_ldk(
     let stop_processing = Arc::new(AtomicBool::new(false));
     let stop_listen = Arc::clone(&stop_processing);
     tokio::spawn(async move {
-        let listener = tokio::net::TcpListener::bind(format!("[::]:{listening_port}"))
-            .await
-            .expect("Failed to bind to listen port - is something else already listening on it?");
+        // Dual-stack when available; hosts with IPv6 disabled fall back to IPv4.
+        let listener = crate::utils::bind_first_available(&[
+            format!("[::]:{listening_port}"),
+            format!("0.0.0.0:{listening_port}"),
+        ])
+        .await
+        .expect("Failed to bind to listen port - is something else already listening on it?");
         loop {
             let peer_mgr = peer_manager_connection_handler.clone();
             let tcp_stream = listener.accept().await.unwrap().0;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -889,8 +889,41 @@ pub(crate) fn validate_and_parse_payment_preimage(
     Ok(preimage)
 }
 
+/// Binds the first address that accepts a listener, so an IPv6 dual-stack
+/// bind can fall back to IPv4-only on hosts without IPv6.
+pub(crate) async fn bind_first_available(
+    addrs: &[String],
+) -> std::io::Result<tokio::net::TcpListener> {
+    let mut last_err = None;
+    for addr in addrs {
+        match tokio::net::TcpListener::bind(addr).await {
+            Ok(listener) => return Ok(listener),
+            Err(e) => {
+                tracing::warn!(addr, error = %e, "listen bind failed; trying next address");
+                last_err = Some(e);
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "no addresses to bind")
+    }))
+}
+
 #[cfg(test)]
 mod utils_tests {
+    #[tokio::test]
+    async fn bind_first_available_falls_back_when_first_addr_fails() {
+        let occupied = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let taken = occupied.local_addr().unwrap().to_string();
+        let listener = super::bind_first_available(&[taken.clone(), "127.0.0.1:0".to_string()])
+            .await
+            .expect("must fall back to the second address");
+        assert_ne!(listener.local_addr().unwrap().to_string(), taken);
+
+        let err = super::bind_first_available(&[taken.clone(), taken]).await;
+        assert!(err.is_err(), "all candidates failing must surface an error");
+    }
+
     use super::validate_vss_url;
 
     #[test]


### PR DESCRIPTION
The LDK peer listener binds [::] for dual-stack listening, which panics at node startup on hosts where IPv6 is unavailable (Os error 97: Address family not supported by protocol) — currently the case on the CI runners, where it fails every e2e job, and possible on real deployments in IPv6-less containers. This PR adds a small bind_first_available helper that tries the dual-stack address first and falls back to IPv4-only (0.0.0.0) with a warning, keeping behavior unchanged on hosts with working IPv6. Includes a unit test pinning the fallback semantics; this PR's own CI run validates the fix, since the runners are the affected environment.