### PR TITLE
Fail unlock with a clear error when the channel manager cannot be deserialized

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,9 @@ pub enum APIError {
     #[error("Failed to issue asset: {0}")]
     FailedIssuingAsset(String),
 
+    #[error("Failed to load channel state: {0}")]
+    FailedLoadingChannelState(String),
+
     #[error("Failed to open channel: {0}")]
     FailedOpenChannel(String),
 
@@ -523,6 +526,7 @@ impl IntoResponse for APIError {
             APIError::FailedClosingChannel(_)
             | APIError::FailedInvoiceCreation(_)
             | APIError::FailedIssuingAsset(_)
+            | APIError::FailedLoadingChannelState(_)
             | APIError::FailedOpenChannel(_)
             | APIError::FailedPayment(_)
             | APIError::FailedPeerDisconnection(_)

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -4899,7 +4899,16 @@ pub(crate) async fn start_ldk(
                     ldk_data_dir_path.clone(),
                     Arc::clone(&kv_store) as Arc<dyn KVStoreSync + Send + Sync>,
                 );
-                <(BlockHash, ChannelManager)>::read(&mut &bytes[..], read_args).unwrap()
+                match <(BlockHash, ChannelManager)>::read(&mut &bytes[..], read_args) {
+                    Ok(read) => read,
+                    Err(e) => {
+                        return Err(APIError::FailedLoadingChannelState(format!(
+                            "cannot deserialize the channel manager ({e:?}); the persisted \
+                             channel state is incomplete or incompatible, a missing channel \
+                             monitor is the most common cause (see the LDK logs)"
+                        )))
+                    }
+                }
             }
             Err(e) if e.kind() == io::ErrorKind::NotFound => {
                 // We're starting a fresh node.

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -3084,6 +3084,8 @@ mod swap_roundtrip_multihop_asset_asset;
 mod swap_roundtrip_multihop_buy;
 mod swap_roundtrip_multihop_sell;
 mod swap_roundtrip_sell;
+#[cfg(feature = "vss")]
+mod unlock_missing_monitor;
 mod unlock_request_optional_bitcoind;
 mod upload_asset_media;
 mod vanilla_payment_on_rgb_channel;

--- a/src/test/unlock_missing_monitor.rs
+++ b/src/test/unlock_missing_monitor.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/unlock_missing_monitor/";
+
+async fn delete_monitor_rows(node_test_dir: &str) -> u64 {
+    use sea_orm::{ConnectionTrait, Database, Statement};
+
+    let db = Database::connect(format!("sqlite:{node_test_dir}/rln_db?mode=rw"))
+        .await
+        .expect("open node db");
+    let res = db
+        .execute(Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "DELETE FROM kv_store WHERE primary_namespace IN ('monitors', 'monitor_updates')",
+        ))
+        .await
+        .expect("delete monitor rows");
+    res.rows_affected()
+}
+
+/// A channel manager whose channel monitors are missing from storage (e.g. an
+/// incomplete backup) must fail unlock with a clear error and leave the node
+/// serving, instead of panicking and dropping the connection.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[traced_test]
+async fn unlock_with_missing_monitor_fails_cleanly() {
+    tokio::time::timeout(
+        std::time::Duration::from_secs(300),
+        unlock_with_missing_monitor_fails_cleanly_inner(),
+    )
+    .await
+    .expect("unlock_with_missing_monitor_fails_cleanly timed out");
+}
+
+async fn unlock_with_missing_monitor_fails_cleanly_inner() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}node2");
+
+    let (node1_addr, node1_password) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    connect_peer(
+        node1_addr,
+        &node2_pubkey,
+        &format!("127.0.0.1:{NODE2_PEER_PORT}"),
+    )
+    .await;
+
+    open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(600_000),
+        Some(100_000_000),
+        None,
+        None,
+    )
+    .await;
+    wait_for_usable_channels(node1_addr, 1).await;
+
+    shutdown(&[node1_addr, node2_addr]).await;
+
+    let deleted = delete_monitor_rows(&test_dir_node1).await;
+    assert!(deleted > 0, "monitors must exist before deletion");
+
+    let node1_addr =
+        start_daemon_with_vss(&test_dir_node1, NODE1_PEER_PORT, true, None, false).await;
+
+    // Two attempts: the failure must be a clean, repeatable error, not a
+    // panicked task and a dropped connection.
+    for attempt in 1..=2 {
+        let res = reqwest::Client::new()
+            .post(format!("http://{node1_addr}/unlock"))
+            .json(&unlock_req(&node1_password))
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("attempt {attempt}: unlock must answer, got: {e}"));
+        assert_eq!(
+            res.status(),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            "attempt {attempt}"
+        );
+        let body = res.json::<APIErrorResponse>().await.unwrap();
+        assert_eq!(body.name, "FailedLoadingChannelState", "attempt {attempt}");
+        assert!(
+            body.error.contains("channel monitor"),
+            "attempt {attempt}: error must explain the cause: {}",
+            body.error
+        );
+    }
+
+    // The node must keep serving after the failed unlocks.
+    let res = reqwest::Client::new()
+        .get(format!("http://{node1_addr}/nodeinfo"))
+        .send()
+        .await
+        .expect("nodeinfo must answer");
+    assert_eq!(res.status(), reqwest::StatusCode::FORBIDDEN);
+
+    shutdown(&[node1_addr]).await;
+}


### PR DESCRIPTION
A node whose stored channel state cannot be deserialized — e.g. a restored backup containing the channel manager but missing a channel's monitor panicked in the middle of the /unlock request. The task died, the connection was dropped with no response (curl (52) Empty reply from server), and the only explanation (LDK's Missing ChannelMonitor for channel …) was buried in .ldk/logs/logs.txt.

### Fix

Replace the unwrap on the channel-manager read with a proper error: unlock now fails with 500 FailedLoadingChannelState, explaining that the persisted channel state is incomplete or incompatible and that a missing channel monitor is the most common cause (pointing to the LDK logs). The node stays up and serving, and repeated unlock attempts return the same clean error instead of a dead connection. 

No recovery is attempted, state missing a monitor genuinely cannot be loaded without risking funds; preventing such backups is already covered by #115/#120.

Test

New e2e unlock_with_missing_monitor_fails_cleanly: opens a channel, deletes only the monitor rows from the KV store, restarts, and asserts unlock answers with the clear error twice and the node keeps serving.