### PR TITLE
Add BOLT11 description to invoice creation, decode and payment APIs

### DIFF
--- a/bindings/c-ffi/src/json_types.rs
+++ b/bindings/c-ffi/src/json_types.rs
@@ -608,6 +608,7 @@ pub(crate) struct JsonPayment {
     pub updated_at: u64,
     pub payee_pubkey: String,
     pub preimage: Option<String>,
+    pub description: Option<String>,
     pub description_hash: Option<String>,
 }
 
@@ -624,6 +625,7 @@ impl From<Payment> for JsonPayment {
             updated_at: p.updated_at,
             payee_pubkey: fmt_pubkey(&p.payee_pubkey),
             preimage: p.preimage,
+            description: p.description,
             description_hash: p.description_hash,
         }
     }
@@ -640,6 +642,8 @@ pub(crate) struct JsonLnInvoiceRequest {
     pub asset_amount: Option<u64>,
     #[serde(default)]
     pub payment_hash: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
     #[serde(default)]
     pub description_hash: Option<String>,
     // APay outbound flow (added by upstream PR #29). Wallets register a batch of
@@ -661,6 +665,7 @@ impl TryFrom<JsonLnInvoiceRequest> for LnInvoiceRequest {
             asset_id: j.asset_id.map(|s| parse_contract_id(&s)).transpose()?,
             asset_amount: j.asset_amount,
             payment_hash: j.payment_hash.map(|s| parse_payment_hash(&s)).transpose()?,
+            description: j.description,
             description_hash: j.description_hash,
             min_final_cltv_expiry_delta: j.min_final_cltv_expiry_delta,
         })

--- a/bindings/rgb_lightning_node.udl
+++ b/bindings/rgb_lightning_node.udl
@@ -222,6 +222,7 @@ dictionary Payment {
     u64 updated_at;
     PublicKey payee_pubkey;
     string? preimage;
+    string? description;
     string? description_hash;
 };
 
@@ -548,6 +549,7 @@ dictionary LnInvoiceRequest {
     ContractId? asset_id;
     u64? asset_amount;
     PaymentHash? payment_hash;
+    string? description = null;
     string? description_hash;
     u16? min_final_cltv_expiry_delta;
 };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -859,7 +859,8 @@ paths:
       summary: Get a LN invoice
       description: >-
         Get a LN invoice to receive a payment. Provide `payment_hash` to create a HODL invoice.
-        Provide `description_hash` to include an out-of-band BOLT11 description hash.
+        Provide `description` to include a BOLT11 description, or `description_hash` to include
+        an out-of-band BOLT11 description hash (mutually exclusive).
         Provide `min_final_cltv_expiry_delta` to request an explicit inbound final CLTV policy.
       requestBody:
         content:
@@ -2203,6 +2204,11 @@ components:
             - integer
             - 'null'
           example: 42
+        description:
+          type:
+            - string
+            - 'null'
+          example: 1 cup of coffee
         description_hash:
           type:
             - string
@@ -3053,9 +3059,13 @@ components:
           type: string
           description: Optional. When provided, the invoice is created as HODL.
           example: 3febfae1e68b190c15461f4c2a3290f9af1dae63fd7d620d2bd61601869026cd
+        description:
+          type: string
+          description: Optional. When provided, the invoice includes a BOLT11 description. Mutually exclusive with description_hash.
+          example: 1 cup of coffee
         description_hash:
           type: string
-          description: Optional. When provided, the invoice includes a BOLT11 description hash.
+          description: Optional. When provided, the invoice includes a BOLT11 description hash. Mutually exclusive with description.
           example: 5ca5d81b482b4015e7b14df7a27fe0a38c226273604ffd3b008b752571811938
         min_final_cltv_expiry_delta:
           type: integer
@@ -3352,6 +3362,12 @@ components:
         preimage:
           type: string
           example: 89d28bd306aa9bb906fd0ac31092d04c37c919a171b343083167e2a3cdc60578
+        description:
+          type:
+            - string
+            - 'null'
+          description: BOLT11 description (the d tag), if present
+          example: 1 cup of coffee
         description_hash:
           type:
             - string

--- a/src/asset_link.rs
+++ b/src/asset_link.rs
@@ -43,8 +43,8 @@ use crate::{
     ldk::{clear_rgb_payment_pending, write_rgb_payment_info_file, PaymentInfo},
     rgb::get_rgb_channel_info_optional,
     utils::{
-        description_hash_from_invoice, get_current_timestamp, get_route, hex_str,
-        new_jsonrpc_request_id, UnlockedAppState,
+        description_from_invoice, description_hash_from_invoice, get_current_timestamp, get_route,
+        hex_str, new_jsonrpc_request_id, UnlockedAppState,
     },
 };
 
@@ -797,6 +797,7 @@ pub(crate) async fn send_linked_asset_payment(
             expires_at: None,
             claim_deadline_height: None,
             invoice_type: None,
+            description: description_from_invoice(invoice),
             description_hash: description_hash_from_invoice(invoice),
             payment_idx: None,
             async_hash_index: None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -176,6 +176,9 @@ pub enum APIError {
     #[error("Invalid right outpoint: {0}")]
     InvalidRightOutpoint(String),
 
+    #[error("Invalid description: {0}")]
+    InvalidDescription(String),
+
     #[error("Invalid description hash: {0}")]
     InvalidDescriptionHash(String),
 
@@ -554,6 +557,7 @@ impl IntoResponse for APIError {
             | APIError::InvalidChannelID
             | APIError::InvalidContractLink(_)
             | APIError::InvalidRightOutpoint(_)
+            | APIError::InvalidDescription(_)
             | APIError::InvalidDescriptionHash(_)
             | APIError::InvalidDetails(_)
             | APIError::InvalidEstimationBlocks

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -173,11 +173,12 @@ use crate::signer::{
 };
 use crate::swap::{SwapData, SwapInfo};
 use crate::utils::{
-    check_port_is_available, connect_peer_if_necessary, description_hash_from_invoice,
-    do_connect_peer, get_current_timestamp, get_max_local_rgb_amount, hex_str,
-    validate_and_parse_payment_hash, validate_and_parse_payment_preimage, AppState, StaticState,
-    UnlockedAppState, ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST, ELECTRUM_URL_SIGNET,
-    ELECTRUM_URL_TESTNET, ELECTRUM_URL_TESTNET4, PROXY_ENDPOINT_LOCAL, PROXY_ENDPOINT_PUBLIC,
+    check_port_is_available, connect_peer_if_necessary, description_from_invoice,
+    description_hash_from_invoice, do_connect_peer, get_current_timestamp,
+    get_max_local_rgb_amount, hex_str, validate_and_parse_payment_hash,
+    validate_and_parse_payment_preimage, AppState, StaticState, UnlockedAppState,
+    ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST, ELECTRUM_URL_SIGNET, ELECTRUM_URL_TESTNET,
+    ELECTRUM_URL_TESTNET4, PROXY_ENDPOINT_LOCAL, PROXY_ENDPOINT_PUBLIC,
 };
 
 const VIRTUAL_CHANNEL_DOMAIN_SEPARATOR: &[u8] = b"rln_virtual_channels_v0";
@@ -283,6 +284,7 @@ pub(crate) struct PaymentInfo {
     pub(crate) expires_at: Option<u64>,
     pub(crate) claim_deadline_height: Option<u32>,
     pub(crate) invoice_type: Option<InvoiceType>,
+    pub(crate) description: Option<String>,
     pub(crate) description_hash: Option<[u8; 32]>,
     pub(crate) payment_idx: Option<u64>,
     pub(crate) async_hash_index: Option<u64>,
@@ -304,6 +306,8 @@ impl_writeable_tlv_based!(PaymentInfo, {
     (22, payment_idx, option),
     (24, async_hash_index, option),
     (26, async_host_node_id, option),
+    // odd type so older binaries skip the field instead of failing the whole read
+    (29, description, option),
 });
 
 pub(crate) struct InboundPaymentInfoStorage {
@@ -724,6 +728,7 @@ impl UnlockedAppState {
                     expires_at: None,
                     claim_deadline_height,
                     invoice_type,
+                    description: None,
                     description_hash: None,
                     payment_idx: None,
                     async_hash_index: None,
@@ -1566,6 +1571,7 @@ impl AsyncOrderInvoiceProvider for AsyncOrderRecipientInvoiceProvider {
                 invoice_type: Some(InvoiceType::Hodl {
                     async_payment_recipient: true,
                 }),
+                description: description_from_invoice(&invoice),
                 description_hash: description_hash_from_invoice(&invoice),
                 payment_idx: None,
                 async_hash_index: self.external_signer_mode.then_some(hash_index),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -35,7 +35,7 @@ use lightning::{
     util::config::{ChannelHandshakeConfig, ChannelHandshakeLimits, UserConfig},
     util::{errors::APIError as LDKAPIError, IS_SWAP_SCID},
 };
-use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description, PaymentSecret};
+use lightning_invoice::{Bolt11Invoice, PaymentSecret};
 use regex::Regex;
 use rgb_lib::utils::recipient_id_from_script_buf;
 use rgb_lib::{
@@ -95,11 +95,11 @@ use crate::signer::read_key_source_file;
 use crate::swap::{SwapData, SwapInfo, SwapString};
 use crate::utils::{
     check_already_initialized, check_channel_id, check_password_strength, check_password_validity,
-    description_hash_from_invoice, encrypt_and_save_mnemonic, get_max_local_rgb_amount, get_route,
-    hex_str, hex_str_to_compressed_pubkey, hex_str_to_vec, is_external_signer_mode_configured,
-    new_jsonrpc_request_id, open_database_pool, validate_and_parse_description_hash,
-    validate_and_parse_payment_hash, validate_and_parse_payment_preimage, UnlockedAppState,
-    UserOnionMessageContents,
+    description_from_invoice, description_hash_from_invoice, encrypt_and_save_mnemonic,
+    get_max_local_rgb_amount, get_route, hex_str, hex_str_to_compressed_pubkey, hex_str_to_vec,
+    is_external_signer_mode_configured, new_jsonrpc_request_id, open_database_pool,
+    parse_invoice_description, validate_and_parse_payment_hash,
+    validate_and_parse_payment_preimage, UnlockedAppState, UserOnionMessageContents,
 };
 use crate::{
     backup::{do_backup, restore_backup},
@@ -533,6 +533,7 @@ pub(crate) struct DecodeLNInvoiceResponse {
     pub(crate) timestamp: u64,
     pub(crate) asset_id: Option<String>,
     pub(crate) asset_amount: Option<u64>,
+    pub(crate) description: Option<String>,
     pub(crate) description_hash: Option<String>,
     pub(crate) payment_hash: String,
     pub(crate) payment_secret: String,
@@ -928,6 +929,7 @@ pub(crate) struct LNInvoiceRequest {
     pub(crate) asset_id: Option<String>,
     pub(crate) asset_amount: Option<u64>,
     pub(crate) payment_hash: Option<String>,
+    pub(crate) description: Option<String>,
     pub(crate) description_hash: Option<String>,
     pub(crate) min_final_cltv_expiry_delta: Option<u16>,
 }
@@ -1065,6 +1067,7 @@ pub(crate) struct Payment {
     pub(crate) updated_at: u64,
     pub(crate) payee_pubkey: String,
     pub(crate) preimage: Option<String>,
+    pub(crate) description: Option<String>,
     pub(crate) description_hash: Option<String>,
 }
 
@@ -2357,6 +2360,7 @@ pub(crate) async fn decode_ln_invoice(
         timestamp: invoice.duration_since_epoch().as_secs(),
         asset_id: invoice.rgb_contract_id().map(|c| c.to_string()),
         asset_amount: invoice.rgb_amount(),
+        description: description_from_invoice(&invoice),
         description_hash: match invoice.description() {
             lightning_invoice::Bolt11InvoiceDescriptionRef::Hash(hash) => {
                 Some(hex_str(&hash.0.to_byte_array()))
@@ -2566,6 +2570,7 @@ pub(crate) async fn get_payment(
                             updated_at: payment_info.updated_at,
                             payee_pubkey: payment_info.payee_pubkey.to_string(),
                             preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                            description: payment_info.description.clone(),
                             description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
                         },
                     }));
@@ -2596,6 +2601,7 @@ pub(crate) async fn get_payment(
                             updated_at: payment_info.updated_at,
                             payee_pubkey: payment_info.payee_pubkey.to_string(),
                             preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                            description: payment_info.description.clone(),
                             description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
                         },
                     }));
@@ -3011,6 +3017,7 @@ pub(crate) async fn keysend(
                 expires_at: None,
                 invoice_type: None,
                 payee_pubkey: dest_pubkey,
+                description: None,
                 description_hash: None,
                 payment_idx: None,
                 async_hash_index: None,
@@ -3273,6 +3280,7 @@ pub(crate) async fn list_payments(
                 updated_at: payment_info.updated_at,
                 payee_pubkey: payment_info.payee_pubkey.to_string(),
                 preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                description: payment_info.description.clone(),
                 description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
             },
         ));
@@ -3302,6 +3310,7 @@ pub(crate) async fn list_payments(
                 updated_at: payment_info.updated_at,
                 payee_pubkey: payment_info.payee_pubkey.to_string(),
                 preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                description: payment_info.description.clone(),
                 description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
             },
         ));
@@ -3645,12 +3654,10 @@ pub(crate) async fn ln_invoice(
             }
             None => None,
         };
-        let description = match &payload.description_hash {
-            Some(description_hash) => Bolt11InvoiceDescription::Hash(
-                validate_and_parse_description_hash(description_hash)?,
-            ),
-            None => Bolt11InvoiceDescription::Direct(Description::empty()),
-        };
+        let description = parse_invoice_description(
+            payload.description.as_deref(),
+            payload.description_hash.as_deref(),
+        )?;
 
         let invoice_params = Bolt11InvoiceParameters {
             amount_msats: payload.amt_msat,
@@ -3693,6 +3700,7 @@ pub(crate) async fn ln_invoice(
                 expires_at: Some(created_at + payload.expiry_sec as u64),
                 claim_deadline_height: None,
                 invoice_type: Some(invoice_type),
+                description: description_from_invoice(&invoice),
                 description_hash: description_hash_from_invoice(&invoice),
                 payment_idx: None,
                 async_hash_index: None,
@@ -4829,6 +4837,7 @@ pub(crate) async fn send_payment(
                     expires_at: None,
                     claim_deadline_height: None,
                     invoice_type: None,
+                    description: None,
                     description_hash: None,
                     payment_idx: None,
                     async_hash_index: None,
@@ -4983,6 +4992,7 @@ pub(crate) async fn send_payment(
                     expires_at: None,
                     claim_deadline_height: None,
                     invoice_type: None,
+                    description: description_from_invoice(&invoice),
                     description_hash: description_hash_from_invoice(&invoice),
                     payment_idx: None,
                     async_hash_index: None,

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -27,10 +27,10 @@ use crate::signer::{
 use crate::swap::{SwapData, SwapInfo, SwapString};
 use crate::utils::{
     check_already_initialized, check_channel_id, check_password_strength, check_password_validity,
-    connect_peer_if_necessary, description_hash_from_invoice, encrypt_and_save_mnemonic,
-    get_current_timestamp, get_max_local_rgb_amount, get_route, hex_str,
+    connect_peer_if_necessary, description_from_invoice, description_hash_from_invoice,
+    encrypt_and_save_mnemonic, get_current_timestamp, get_max_local_rgb_amount, get_route, hex_str,
     hex_str_to_compressed_pubkey, hex_str_to_vec, is_external_signer_mode_configured,
-    new_jsonrpc_request_id, parse_peer_info, validate_and_parse_description_hash,
+    new_jsonrpc_request_id, parse_invoice_description, parse_peer_info,
     validate_and_parse_payment_hash, validate_and_parse_payment_preimage, AppState,
     UserOnionMessageContents,
 };
@@ -582,6 +582,7 @@ pub(crate) struct PaymentData {
     pub(crate) updated_at: u64,
     pub(crate) payee_pubkey: String,
     pub(crate) preimage: Option<String>,
+    pub(crate) description: Option<String>,
     pub(crate) description_hash: Option<String>,
 }
 
@@ -2610,6 +2611,7 @@ pub(crate) async fn keysend(
             payee_pubkey: dest_pubkey,
             expires_at: None,
             invoice_type: None,
+            description: None,
             description_hash: None,
             payment_idx: None,
             async_hash_index: None,
@@ -3149,6 +3151,7 @@ pub(crate) async fn send_payment(
                     .ok_or(APIError::InvalidInvoice(s!("missing signing pubkey")))?,
                 expires_at: None,
                 invoice_type: None,
+                description: None,
                 description_hash: None,
                 payment_idx: None,
                 async_hash_index: None,
@@ -3254,6 +3257,7 @@ pub(crate) async fn send_payment(
                 payee_pubkey: invoice.get_payee_pub_key(),
                 expires_at: None,
                 invoice_type: None,
+                description: description_from_invoice(&invoice),
                 description_hash: description_hash_from_invoice(&invoice),
                 payment_idx: None,
                 async_hash_index: None,
@@ -3789,6 +3793,7 @@ pub(crate) async fn create_ln_invoice(
     asset_id: Option<String>,
     asset_amount: Option<u64>,
     payment_hash: Option<String>,
+    description: Option<String>,
     description_hash: Option<String>,
     min_final_cltv_expiry_delta: Option<u16>,
 ) -> Result<LnInvoiceData, APIError> {
@@ -3827,12 +3832,8 @@ pub(crate) async fn create_ln_invoice(
         }
         None => None,
     };
-    let description = match description_hash {
-        Some(description_hash) => {
-            Bolt11InvoiceDescription::Hash(validate_and_parse_description_hash(&description_hash)?)
-        }
-        None => Bolt11InvoiceDescription::Direct(Description::empty()),
-    };
+    let description =
+        parse_invoice_description(description.as_deref(), description_hash.as_deref())?;
 
     let invoice_params = Bolt11InvoiceParameters {
         amount_msats: amt_msat,
@@ -3877,6 +3878,7 @@ pub(crate) async fn create_ln_invoice(
             payee_pubkey: unlocked_state.runtime_node_id(),
             expires_at: Some(created_at + expiry_sec as u64),
             invoice_type: Some(invoice_type),
+            description: description_from_invoice(&invoice),
             description_hash: description_hash_from_invoice(&invoice),
             payment_idx: None,
             async_hash_index: None,
@@ -3924,6 +3926,7 @@ pub(crate) async fn list_payments(state: Arc<AppState>) -> Result<Vec<PaymentDat
             updated_at: payment_info.updated_at,
             payee_pubkey: payment_info.payee_pubkey.to_string(),
             preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+            description: payment_info.description.clone(),
             description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
         });
     }
@@ -3949,6 +3952,7 @@ pub(crate) async fn list_payments(state: Arc<AppState>) -> Result<Vec<PaymentDat
             updated_at: payment_info.updated_at,
             payee_pubkey: payment_info.payee_pubkey.to_string(),
             preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+            description: payment_info.description.clone(),
             description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
         });
     }
@@ -3995,6 +3999,7 @@ pub(crate) async fn get_payment(
                         updated_at: payment_info.updated_at,
                         payee_pubkey: payment_info.payee_pubkey.to_string(),
                         preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                        description: payment_info.description.clone(),
                         description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
                     });
                 }
@@ -4023,6 +4028,7 @@ pub(crate) async fn get_payment(
                         updated_at: payment_info.updated_at,
                         payee_pubkey: payment_info.payee_pubkey.to_string(),
                         preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
+                        description: payment_info.description.clone(),
                         description_hash: payment_info.description_hash.map(|h| hex_str(&h)),
                     });
                 }

--- a/src/test/hodl_invoice.rs
+++ b/src/test/hodl_invoice.rs
@@ -541,6 +541,7 @@ async fn claim_hodl_invoice_btc_rgb() {
         asset_id: None,
         asset_amount: None,
         payment_hash: Some(payment_hash.clone()),
+        description: None,
         description_hash: None,
         min_final_cltv_expiry_delta: None,
     };

--- a/src/test/invoice.rs
+++ b/src/test/invoice.rs
@@ -24,6 +24,7 @@ async fn invoice() {
         asset_id: Some(asset_id.clone()),
         asset_amount: Some(1),
         payment_hash: None,
+        description: None,
         description_hash: None,
         min_final_cltv_expiry_delta: None,
     };
@@ -42,6 +43,7 @@ async fn invoice() {
         asset_id: Some(asset_id.clone()),
         asset_amount: Some(1),
         payment_hash: None,
+        description: None,
         description_hash: None,
         min_final_cltv_expiry_delta: None,
     };
@@ -60,6 +62,7 @@ async fn invoice() {
         asset_id: None,
         asset_amount: None,
         payment_hash: None,
+        description: None,
         description_hash: None,
         min_final_cltv_expiry_delta: None,
     };
@@ -93,6 +96,7 @@ async fn description_hash_invoice() {
         asset_id: None,
         asset_amount: None,
         payment_hash: None,
+        description: None,
         description_hash: Some(description_hash.0.to_string()),
         min_final_cltv_expiry_delta: Some(inbound_min_final_cltv),
     };
@@ -134,6 +138,7 @@ async fn invalid_description_hash_invoice() {
         asset_id: None,
         asset_amount: None,
         payment_hash: None,
+        description: None,
         description_hash: Some("not-a-valid-description-hash".to_string()),
         min_final_cltv_expiry_delta: None,
     };
@@ -149,6 +154,125 @@ async fn invalid_description_hash_invoice() {
         reqwest::StatusCode::BAD_REQUEST,
         "Invalid description hash: not-a-valid-description-hash",
         "InvalidDescriptionHash",
+    )
+    .await;
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn description_invoice() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}description/node1");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+
+    let description = "1 cup of coffee";
+    let payload = LNInvoiceRequest {
+        amt_msat: None,
+        expiry_sec: 900,
+        asset_id: None,
+        asset_amount: None,
+        payment_hash: None,
+        description: Some(description.to_string()),
+        description_hash: None,
+        min_final_cltv_expiry_delta: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/lninvoice"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap()
+        .json::<LNInvoiceResponse>()
+        .await
+        .unwrap();
+
+    let invoice = Bolt11Invoice::from_str(&res.invoice).unwrap();
+    assert!(matches!(
+        invoice.description(),
+        lightning_invoice::Bolt11InvoiceDescriptionRef::Direct(d) if d.to_string() == description
+    ));
+
+    let decoded = decode_ln_invoice(node1_addr, &res.invoice).await;
+    assert_eq!(decoded.description.as_deref(), Some(description));
+    assert_eq!(decoded.description_hash, None);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn description_and_description_hash_invoice() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}description_and_hash/node1");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+
+    let payload = LNInvoiceRequest {
+        amt_msat: None,
+        expiry_sec: 900,
+        asset_id: None,
+        asset_amount: None,
+        payment_hash: None,
+        description: Some(s!("a description")),
+        description_hash: Some(s!(
+            "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+        )),
+        min_final_cltv_expiry_delta: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/lninvoice"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::BAD_REQUEST,
+        "Invalid request: cannot provide both description and description_hash",
+        "InvalidRequest",
+    )
+    .await;
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn invalid_description_invoice() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}invalid_description/node1");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+
+    let payload = LNInvoiceRequest {
+        amt_msat: None,
+        expiry_sec: 900,
+        asset_id: None,
+        asset_amount: None,
+        payment_hash: None,
+        description: Some("a".repeat(640)),
+        description_hash: None,
+        min_final_cltv_expiry_delta: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/lninvoice"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::BAD_REQUEST,
+        "Invalid description",
+        "InvalidDescription",
     )
     .await;
 }
@@ -190,6 +314,7 @@ async fn zero_amount_invoice() {
         asset_id: None,
         asset_amount: None,
         payment_hash: None,
+        description: None,
         description_hash: None,
         min_final_cltv_expiry_delta: None,
     };
@@ -279,6 +404,7 @@ async fn zero_amount_invoice() {
         asset_id: Some(asset_id.clone()),
         asset_amount: None,
         payment_hash: None,
+        description: None,
         description_hash: None,
         min_final_cltv_expiry_delta: None,
     };
@@ -304,6 +430,7 @@ async fn zero_amount_invoice() {
         asset_id: Some(asset_id.clone()),
         asset_amount: Some(50),
         payment_hash: None,
+        description: None,
         description_hash: None,
         min_final_cltv_expiry_delta: None,
     };

--- a/src/test/lib_core.rs
+++ b/src/test/lib_core.rs
@@ -61,6 +61,7 @@ fn locked_state_does_not_bypass_unlock_guards() {
         asset_id: None,
         asset_amount: None,
         payment_hash: None,
+        description: None,
         description_hash: None,
         min_final_cltv_expiry_delta: None,
     });

--- a/src/test/lib_sdk/close_coop_vanilla.rs
+++ b/src/test/lib_sdk/close_coop_vanilla.rs
@@ -195,6 +195,7 @@ fn run_close_coop_vanilla(name: &str, port_offset: u16, with_anchors: bool) {
                 asset_id: None,
                 asset_amount: None,
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })

--- a/src/test/lib_sdk/external_signer.rs
+++ b/src/test/lib_sdk/external_signer.rs
@@ -670,6 +670,7 @@ fn rgb_native_external_signer_mixed_one_hop_payment_quick() {
                 asset_id: Some(asset_id.clone()),
                 asset_amount: Some(PAY_ASSET),
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })
@@ -813,6 +814,7 @@ fn rgb_native_external_signer_mixed_one_hop_payment_roundtrip() {
                 asset_id: Some(asset_id.clone()),
                 asset_amount: Some(PAY_ASSET),
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })
@@ -836,6 +838,7 @@ fn rgb_native_external_signer_mixed_one_hop_payment_roundtrip() {
                 asset_id: Some(asset_id.clone()),
                 asset_amount: Some(PAY_ASSET),
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })
@@ -980,6 +983,7 @@ fn rgb_native_external_signer_mixed_one_hop_payment_coop_close_settles_to_chain(
                 asset_id: Some(asset_id.clone()),
                 asset_amount: Some(PAY_ASSET),
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })
@@ -1117,6 +1121,7 @@ fn external_signer_virtual_channel_survives_restart() {
                 asset_id: None,
                 asset_amount: None,
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })

--- a/src/test/lib_sdk/invoice.rs
+++ b/src/test/lib_sdk/invoice.rs
@@ -32,6 +32,7 @@ fn description_hash_survives_sdk_path() {
                 asset_id: None,
                 asset_amount: None,
                 payment_hash: None,
+                description: None,
                 description_hash: Some(description_hash.0.to_string()),
                 min_final_cltv_expiry_delta: None,
             })
@@ -41,6 +42,82 @@ fn description_hash_survives_sdk_path() {
         assert!(matches!(
             invoice.description(),
             Bolt11InvoiceDescriptionRef::Hash(hash) if *hash == description_hash
+        ));
+    }));
+
+    node.shutdown();
+    result.unwrap();
+}
+
+#[test]
+#[serial]
+fn description_survives_sdk_path() {
+    ensure_regtest_available();
+
+    let test_dir = test_dir("sdk_invoice_description");
+    if test_dir.exists() {
+        fs::remove_dir_all(&test_dir).expect("remove previous lib_sdk invoice test dir");
+    }
+    fs::create_dir_all(&test_dir).expect("create lib_sdk invoice test dir");
+    let node_dir = test_dir.join("node");
+
+    let node = make_node(&node_dir, NODE_A_DAEMON_PORT + 100, NODE_A_PEER_PORT + 100);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        node.init("nodeApass".to_string(), None).expect("node init");
+        node.unlock(unlock_request("nodeApass"))
+            .expect("node unlock");
+
+        let description = "1 cup of coffee";
+        let invoice = node
+            .ln_invoice(LnInvoiceRequest {
+                amt_msat: None,
+                expiry_sec: 900,
+                asset_id: None,
+                asset_amount: None,
+                payment_hash: None,
+                description: Some(description.to_string()),
+                description_hash: None,
+                min_final_cltv_expiry_delta: None,
+            })
+            .expect("node ln_invoice with description")
+            .invoice;
+
+        assert!(matches!(
+            invoice.description(),
+            Bolt11InvoiceDescriptionRef::Direct(d) if d.to_string() == description
+        ));
+
+        let too_long = node.ln_invoice(LnInvoiceRequest {
+            amt_msat: None,
+            expiry_sec: 900,
+            asset_id: None,
+            asset_amount: None,
+            payment_hash: None,
+            description: Some("a".repeat(640)),
+            description_hash: None,
+            min_final_cltv_expiry_delta: None,
+        });
+        assert!(matches!(
+            too_long,
+            Err(rgb_lightning_node::RlnError::InvalidRequest(_))
+        ));
+
+        let both = node.ln_invoice(LnInvoiceRequest {
+            amt_msat: None,
+            expiry_sec: 900,
+            asset_id: None,
+            asset_amount: None,
+            payment_hash: None,
+            description: Some(description.to_string()),
+            description_hash: Some(
+                "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff".to_string(),
+            ),
+            min_final_cltv_expiry_delta: None,
+        });
+        assert!(matches!(
+            both,
+            Err(rgb_lightning_node::RlnError::InvalidRequest(_))
         ));
     }));
 

--- a/src/test/lib_sdk/multi_hop.rs
+++ b/src/test/lib_sdk/multi_hop.rs
@@ -242,6 +242,7 @@ fn multi_hop() {
                 asset_id: Some(asset_id.clone()),
                 asset_amount: Some(50),
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })

--- a/src/test/lib_sdk/payment.rs
+++ b/src/test/lib_sdk/payment.rs
@@ -171,6 +171,7 @@ fn success() {
                 asset_id: Some(asset_id.clone()),
                 asset_amount: Some(asset_amount),
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })
@@ -238,6 +239,7 @@ fn success() {
                 asset_id: Some(asset_id.clone()),
                 asset_amount: Some(asset_amount),
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })
@@ -274,6 +276,7 @@ fn success() {
                 asset_id: Some(asset_id.clone()),
                 asset_amount: Some(asset_amount),
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })
@@ -308,6 +311,7 @@ fn success() {
                 asset_id: Some(asset_id.clone()),
                 asset_amount: Some(asset_amount),
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })

--- a/src/test/lib_sdk/restart.rs
+++ b/src/test/lib_sdk/restart.rs
@@ -158,6 +158,7 @@ fn restart() {
                 asset_id: Some(asset_id.clone()),
                 asset_amount: Some(100),
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })

--- a/src/test/lib_sdk/vanilla_payment_on_rgb_channel.rs
+++ b/src/test/lib_sdk/vanilla_payment_on_rgb_channel.rs
@@ -102,6 +102,7 @@ fn vanilla_payment_on_rgb_channel() {
                 asset_id: None,
                 asset_amount: None,
                 payment_hash: None,
+                description: None,
                 description_hash: None,
                 min_final_cltv_expiry_delta: None,
             })

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1644,7 +1644,38 @@ async fn ln_invoice_with_description_hash(
         asset_id: None,
         asset_amount: None,
         payment_hash: None,
+        description: None,
         description_hash: description_hash.map(|s| s.to_string()),
+        min_final_cltv_expiry_delta: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/lninvoice"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<LNInvoiceResponse>()
+        .await
+        .unwrap()
+}
+
+async fn ln_invoice_with_description(
+    node_address: SocketAddr,
+    amt_msat: Option<u64>,
+    expiry_sec: u32,
+    description: Option<&str>,
+) -> LNInvoiceResponse {
+    println!("generating invoice with description {description:?} for node {node_address}");
+    let payload = LNInvoiceRequest {
+        amt_msat: Some(amt_msat.unwrap_or(HTLC_MIN_MSAT)),
+        expiry_sec,
+        asset_id: None,
+        asset_amount: None,
+        payment_hash: None,
+        description: description.map(|s| s.to_string()),
+        description_hash: None,
         min_final_cltv_expiry_delta: None,
     };
     let res = reqwest::Client::new()
@@ -1700,6 +1731,7 @@ async fn ln_invoice_with_type(
         asset_id: asset_id.map(|a| a.to_string()),
         asset_amount,
         payment_hash,
+        description: None,
         description_hash: None,
         min_final_cltv_expiry_delta: None,
     };

--- a/src/test/payment.rs
+++ b/src/test/payment.rs
@@ -495,6 +495,86 @@ async fn description_hash() {
 #[serial_test::serial]
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[traced_test]
+async fn description() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}description/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(600_000),
+        Some(300_000_000),
+        None,
+        None,
+    )
+    .await;
+
+    let desc = "1 cup of coffee";
+
+    // Invoice WITH a description.
+    let invoice = ln_invoice_with_description(node2_addr, Some(3_000_000), 900, Some(desc))
+        .await
+        .invoice;
+    let decoded = decode_ln_invoice(node1_addr, &invoice).await;
+    assert_eq!(decoded.description.as_deref(), Some(desc));
+    assert_eq!(decoded.description_hash, None);
+    send_payment(node1_addr, invoice.clone()).await;
+
+    let out = get_payment(node1_addr, &decoded.payment_hash, PaymentType::Outbound).await;
+    assert_eq!(out.description.as_deref(), Some(desc));
+    let inb = get_payment(
+        node2_addr,
+        &decoded.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
+    assert_eq!(inb.description.as_deref(), Some(desc));
+
+    let listed = list_payments(node2_addr)
+        .await
+        .into_iter()
+        .find(|p| p.payment_hash == decoded.payment_hash)
+        .unwrap();
+    assert_eq!(listed.description.as_deref(), Some(desc));
+
+    // Invoice WITHOUT a description.
+    let invoice2 = ln_invoice(node2_addr, Some(3_000_000), None, None, 900)
+        .await
+        .invoice;
+    let decoded2 = decode_ln_invoice(node1_addr, &invoice2).await;
+    assert_eq!(decoded2.description, None);
+    send_payment(node1_addr, invoice2.clone()).await;
+    let out2 = get_payment(node1_addr, &decoded2.payment_hash, PaymentType::Outbound).await;
+    assert_eq!(out2.description, None);
+
+    // The description must survive a restart (persisted PaymentInfo round-trip).
+    shutdown(&[node1_addr, node2_addr]).await;
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, true).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, true).await;
+    let out = get_payment(node1_addr, &decoded.payment_hash, PaymentType::Outbound).await;
+    assert_eq!(out.description.as_deref(), Some(desc));
+    let inb = get_payment(
+        node2_addr,
+        &decoded.payment_hash,
+        PaymentType::InboundAutoClaim,
+    )
+    .await;
+    assert_eq!(inb.description.as_deref(), Some(desc));
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
 async fn pagination() {
     initialize();
 

--- a/src/test/virtual_channels.rs
+++ b/src/test/virtual_channels.rs
@@ -1460,6 +1460,7 @@ async fn virtual_one_sat_htlc_routes_both_directions() {
         asset_id: Some(issued_asset_id.clone()),
         asset_amount: Some(1),
         payment_hash: None,
+        description: None,
         description_hash: None,
         min_final_cltv_expiry_delta: None,
     };

--- a/src/uniffi_api/mod.rs
+++ b/src/uniffi_api/mod.rs
@@ -200,6 +200,7 @@ fn map_payment_data(data: crate::sdk::PaymentData) -> Result<Payment, RlnError> 
         updated_at: data.updated_at,
         payee_pubkey,
         preimage: data.preimage,
+        description: data.description,
         description_hash: data.description_hash,
     })
 }
@@ -1444,6 +1445,7 @@ impl SdkNode {
         let state = self.handle.app_state();
         let asset_id = request.asset_id.map(|a| a.to_string());
         let payment_hash = request.payment_hash.map(|h| h.0.as_hex().to_string());
+        let description = request.description;
         let description_hash = request.description_hash;
         let min_final_cltv_expiry_delta = request.min_final_cltv_expiry_delta;
         let data = block_on_sdk(sdk::create_ln_invoice(
@@ -1453,6 +1455,7 @@ impl SdkNode {
             asset_id,
             request.asset_amount,
             payment_hash,
+            description,
             description_hash,
             min_final_cltv_expiry_delta,
         ))?;

--- a/src/uniffi_api/state.rs
+++ b/src/uniffi_api/state.rs
@@ -186,6 +186,7 @@ pub(crate) fn map_api_error(err: APIError) -> RlnError {
         | APIError::InvalidChannelID
         | APIError::InvalidContractLink(_)
         | APIError::InvalidRightOutpoint(_)
+        | APIError::InvalidDescription(_)
         | APIError::InvalidDescriptionHash(_)
         | APIError::InvalidDetails(_)
         | APIError::InvalidEstimationBlocks

--- a/src/uniffi_api/tests.rs
+++ b/src/uniffi_api/tests.rs
@@ -48,6 +48,7 @@ mod uniffi_smoke_tests {
             asset_id: None,
             asset_amount: None,
             payment_hash: None,
+            description: None,
             description_hash: None,
             min_final_cltv_expiry_delta: None,
         });
@@ -423,6 +424,7 @@ mod uniffi_smoke_tests {
             payee_pubkey: "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
                 .to_string(),
             preimage: expected_preimage.clone(),
+            description: None,
             description_hash: None,
         };
 

--- a/src/uniffi_api/types.rs
+++ b/src/uniffi_api/types.rs
@@ -139,6 +139,7 @@ pub struct Payment {
     pub updated_at: u64,
     pub payee_pubkey: PublicKey,
     pub preimage: Option<String>,
+    pub description: Option<String>,
     pub description_hash: Option<String>,
 }
 
@@ -465,6 +466,7 @@ pub struct LnInvoiceRequest {
     pub asset_id: Option<ContractId>,
     pub asset_amount: Option<u64>,
     pub payment_hash: Option<PaymentHash>,
+    pub description: Option<String>,
     pub description_hash: Option<String>,
     pub min_final_cltv_expiry_delta: Option<u16>,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ use lightning::{
     util::persist::KVStoreSync,
     util::ser::{Writeable, Writer},
 };
-use lightning_invoice::Bolt11Invoice;
+use lightning_invoice::{Bolt11Invoice, Bolt11InvoiceDescription, Description};
 use magic_crypt::{new_magic_crypt, MagicCryptTrait};
 use rgb_lib::{bdk_wallet::keys::bip39::Mnemonic, BitcoinNetwork, ContractId};
 use rln_migration::{Migrator, MigratorTrait};
@@ -558,6 +558,17 @@ pub(crate) fn description_hash_from_invoice(invoice: &Bolt11Invoice) -> Option<[
     }
 }
 
+// Empty direct descriptions surface as None.
+pub(crate) fn description_from_invoice(invoice: &Bolt11Invoice) -> Option<String> {
+    match invoice.description() {
+        lightning_invoice::Bolt11InvoiceDescriptionRef::Direct(description) => {
+            let description = description.to_string();
+            (!description.is_empty()).then_some(description)
+        }
+        _ => None,
+    }
+}
+
 pub(crate) async fn do_connect_peer(
     pubkey: PublicKey,
     address: SocketAddr,
@@ -862,6 +873,31 @@ pub(crate) fn validate_and_parse_payment_hash(
         return Err(APIError::InvalidPaymentHash(payment_hash_str.to_string()));
     }
     Ok(PaymentHash(payment_hash_vec.unwrap().try_into().unwrap()))
+}
+
+pub(crate) fn validate_and_parse_description(
+    description_str: &str,
+) -> Result<lightning_invoice::Description, APIError> {
+    lightning_invoice::Description::new(description_str.to_string())
+        .map_err(|e| APIError::InvalidDescription(e.to_string()))
+}
+
+pub(crate) fn parse_invoice_description(
+    description: Option<&str>,
+    description_hash: Option<&str>,
+) -> Result<Bolt11InvoiceDescription, APIError> {
+    match (description, description_hash) {
+        (Some(_), Some(_)) => Err(APIError::InvalidRequest(s!(
+            "cannot provide both description and description_hash"
+        ))),
+        (Some(description), None) => Ok(Bolt11InvoiceDescription::Direct(
+            validate_and_parse_description(description)?,
+        )),
+        (None, Some(description_hash)) => Ok(Bolt11InvoiceDescription::Hash(
+            validate_and_parse_description_hash(description_hash)?,
+        )),
+        (None, None) => Ok(Bolt11InvoiceDescription::Direct(Description::empty())),
+    }
 }
 
 pub(crate) fn validate_and_parse_description_hash(


### PR DESCRIPTION
Add support for the BOLT11 description field (the d tag) everywhere description_hash is already exposed: /lninvoice accepts an optional description (mutually exclusive with description_hash), /decodelninvoice returns it, and /getpayment / /listpayments carry it, persisted on PaymentInfo as a backward-compatible TLV. Mirrored across SDK, uniffi, c-ffi and openapi.yaml; existing behavior is unchanged when the field is omitted. Covered by e2e and SDK tests, including persistence across restart.