### PR TITLE
sdk: attempt linked-asset swap routing in send_payment

### DIFF
--- a/bindings/c-ffi/Cargo.lock
+++ b/bindings/c-ffi/Cargo.lock
@@ -2758,6 +2758,7 @@ dependencies = [
 name = "lightning"
 version = "0.2.2"
 dependencies = [
+ "amplify",
  "bech32 0.11.1",
  "bincode",
  "bitcoin",
@@ -2771,6 +2772,7 @@ dependencies = [
  "musig2",
  "possiblyrandom 0.2.0",
  "rgb-lib",
+ "rgb-strict-encoding",
  "serde",
  "tokio",
 ]

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -3246,15 +3246,6 @@ pub(crate) async fn send_payment(
             }
         };
 
-        // If the invoice's asset isn't covered by any of our own channels,
-        // look for a channel funded in a *linked* asset to a peer that also
-        // has a channel to the recipient, and swap in flight across it.
-        // Mirrors routes.rs's `/sendpayment` handler — this SDK path (used
-        // by every binding: uniffi/mobile, c-ffi, and transitively wasm-sdk
-        // where it delegates here) previously had no linked-asset awareness
-        // at all, so a payer whose only route to an invoice's asset was
-        // through a link would fail locally before ever attempting the
-        // payment.
         if let Some((contract_id, asset_amount)) = rgb_payment {
             if !has_sufficient_asset_channel(unlocked_state, contract_id, asset_amount, amt_msat) {
                 if let Some((linked_contract_id, host_pubkey)) = find_linked_asset_channel(

--- a/src/sdk/mod.rs
+++ b/src/sdk/mod.rs
@@ -1,7 +1,10 @@
 // NOTE: This module mirrors core behavior from `src/routes.rs` for SDK consumers.
 // If route-level business logic changes, keep SDK equivalents in sync.
 
-use crate::asset_link::create_asset_link;
+use crate::asset_link::{
+    create_asset_link, find_linked_asset_channel, has_sufficient_asset_channel,
+    send_linked_asset_payment,
+};
 use crate::async_order::{
     write_async_payments_next_hash_index, AsyncOrderNewResultWire,
     AsyncOrderOutboundInvoiceResultWire,
@@ -3242,6 +3245,45 @@ pub(crate) async fn send_payment(
                 )));
             }
         };
+
+        // If the invoice's asset isn't covered by any of our own channels,
+        // look for a channel funded in a *linked* asset to a peer that also
+        // has a channel to the recipient, and swap in flight across it.
+        // Mirrors routes.rs's `/sendpayment` handler — this SDK path (used
+        // by every binding: uniffi/mobile, c-ffi, and transitively wasm-sdk
+        // where it delegates here) previously had no linked-asset awareness
+        // at all, so a payer whose only route to an invoice's asset was
+        // through a link would fail locally before ever attempting the
+        // payment.
+        if let Some((contract_id, asset_amount)) = rgb_payment {
+            if !has_sufficient_asset_channel(unlocked_state, contract_id, asset_amount, amt_msat) {
+                if let Some((linked_contract_id, host_pubkey)) = find_linked_asset_channel(
+                    unlocked_state,
+                    contract_id,
+                    asset_amount,
+                    amt_msat,
+                    invoice.recover_payee_pub_key(),
+                ) {
+                    let linked_payment = send_linked_asset_payment(
+                        unlocked_state,
+                        &invoice,
+                        contract_id,
+                        linked_contract_id,
+                        asset_amount,
+                        amt_msat,
+                        host_pubkey,
+                    )
+                    .await?;
+
+                    return Ok(SendPaymentData {
+                        payment_id: hex_str(&linked_payment.payment_id.0),
+                        payment_hash: Some(hex_str(&linked_payment.payment_hash.0)),
+                        payment_secret: Some(hex_str(&linked_payment.payment_secret.0)),
+                        status: linked_payment.status,
+                    });
+                }
+            }
+        }
 
         let secret = payment_secret;
         unlocked_state.add_outbound_payment(


### PR DESCRIPTION
## Summary

 (UniFFI/mobile, c-ffi) never attempts linked-asset swap routing. Linked-asset swap routing has been added to the REST daemon's `POST /sendpayment` handler in `src/routes. rs '. But the SDK-facing send_payment is missing this logic.

## Impact

Any payer using UniFFI/mobile or c-ffi cannot pay an invoice for an asset it has no direct channel for, even if it has a channel in that asset's linked parent/child and a valid route exists through a peer holding both sides.

The payment fails locally before any network round-trip because `has_sufficient_asset_channel` is never checked and the linked-asset fallback is never attempted.

The same topology works through the REST daemon's `/sendpayment`, which confirms that the swap mechanism itself works — including link setup, `NodeAssetLinkAuthorizer`, and HTLC forwarding in `asset_link.rs`. The missing part is only the payer-side SDK entry point.

## Root cause

`sdk::send_payment` (`src/sdk/mod.rs`) duplicates most of the invoice parsing and `rgb_payment` derivation from the REST `send_payment` handler, but it is missing the block that runs immediately afterward in `routes.rs`:

`has_sufficient_asset_channel` → `find_linked_asset_channel` → `send_linked_asset_payment`

Since `sdk::send_payment` is used by `uniffi_api::SdkNode::sendpayment`, and c-ffi also calls the same `SdkNode`, this affects every binding using that path while the standalone REST daemon works correctly.

## Separate issue: WASM

`bindings/wasm-sdk` has its own independent `send_payment_value` / `send_payment_json` implementation in `src/ln_node.rs` and does not call `sdk::send_payment`.

It likely has the same linked-asset gap, but it needs to be handled separately because its send-payment implementation and call path are independent from this patch.
