### PR TITLE
chore: bump rgb-lib to v0.3.0-beta.34

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ magic-crypt = "4.0.1"
 rand = "0.8.5"
 regex = { version = "1.11", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.32", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.34", features = [
     "electrum",
     "esplora",
 ] }


### PR DESCRIPTION
Automated bump of rgb-lib to [v0.3.0-beta.34](https://github.com/UTEXO-Protocol/rgb-lib/releases/tag/v0.3.0-beta.34).