### PR TITLE
chore: bump rgb-lib to v0.3.0-beta.35-bfa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ lightning-transaction-sync = { version = "0.2.0", optional = true }
 rand = "0.8.5"
 regex = { version = "1.11", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.34", default-features = false }
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.35-bfa", default-features = false }
 psrgbt = { package = "rgb-psbt-utils", version = "=0.11.1-rc.11", default-features = false }
 rln-migration = { path = "migration" }
 # Pinned fork/branch for RGB compatibility work; CI and clones do not require a sibling checkout.


### PR DESCRIPTION
Automated bump of rgb-lib to [v0.3.0-beta.35-bfa](https://github.com/UTEXO-Protocol/rgb-lib/releases/tag/v0.3.0-beta.35-bfa).