### PR TITLE
Fix empty VSS URL handling in config files

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -259,7 +259,10 @@ fn resolve_user_args(
     let lsp_base_url = args.lsp_base_url.or(lsp.base_url);
     let lsp_bearer_token = args.lsp_bearer_token.or(lsp.bearer_token);
 
-    let vss_url = args.vss_url.or(vss.url);
+    let vss_url = match args.vss_url {
+        Some(url) => Some(url),
+        None => vss.url.filter(|url| !url.is_empty()),
+    };
     let vss_allow_http = args.vss_allow_http || vss.allow_http.unwrap_or(false);
     let vss_allow_empty_restore =
         args.vss_allow_empty_restore || vss.allow_empty_restore.unwrap_or(false);
@@ -482,5 +485,35 @@ mod tests {
     fn invalid_policy_in_file_rejected() {
         let res = resolve(&base(&[]), "[rgb]\nfee_rate_sat_vb = 0\n");
         assert!(matches!(res, Err(AppError::InvalidConfig(_))));
+    }
+
+    #[test]
+    fn empty_vss_url_disables_vss() {
+        let ua = resolve(&base(&[]), "[vss]\nurl = \"\"\n").unwrap();
+        assert!(ua.vss_url.is_none());
+    }
+
+    #[test]
+    fn cli_vss_url_overrides_file_value() {
+        let cli_url = "https://cli.example.com/vss";
+        for file_url in ["", "https://file.example.com/vss"] {
+            let ua = resolve(
+                &base(&["--vss-url", cli_url]),
+                &format!("[vss]\nurl = \"{file_url}\"\n"),
+            )
+            .unwrap();
+            assert_eq!(ua.vss_url.as_deref(), Some(cli_url));
+        }
+    }
+
+    #[test]
+    fn blank_cli_vss_url_is_rejected() {
+        for cli_url in ["", "   "] {
+            let res = resolve(
+                &base(&["--vss-url", cli_url]),
+                "[vss]\nurl = \"https://file.example.com/vss\"\n",
+            );
+            assert!(matches!(res, Err(AppError::InvalidVssConfig(_))));
+        }
     }
 }


### PR DESCRIPTION
Fixes #161

## Summary

- Treat an empty `[vss].url` from the TOML file as disabled, matching `sample-config.toml`.
- Preserve CLI precedence: a valid `--vss-url` still overrides the file, while explicit blank CLI values remain validation errors.
- Add regression coverage for the empty-file sentinel and CLI/file precedence matrix.

## Why

The resolver previously preserved `url = ""` as `Some("")` and passed it to `validate_vss_url`, causing startup to fail even though the sample config documents an empty value as VSS disabled.

## Verification

- RED before fix: `args::tests::empty_vss_url_disables_vss` failed with `InvalidVssConfig`.
- Default-feature argument tests: 19 passed.
- `vss`-feature argument tests: 19 passed.
- Config tests: 44 passed.
- `cargo +1.94.0 clippy --locked --lib -- -D warnings`: passed.
- `cargo +1.94.0 fmt -- --check`: passed.
- `git diff --check`: passed.

## Scope

No network or regtest service was used. The full integration suite was not run because it requires the shared regtest service stack; the change is limited to startup argument resolution and its unit tests.
