### PR TITLE
Fix cancel HODL invoice OpenAPI schema reference

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -181,7 +181,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/InvoiceCancelRequest'
+              $ref: '#/components/schemas/CancelHodlInvoiceRequest'
       responses:
         '200':
           description: Successful operation


### PR DESCRIPTION
Fixes #164

## Summary

- Point `/cancelhodlinvoice` at the existing `CancelHodlInvoiceRequest` component.
- Remove the unresolved `InvoiceCancelRequest` local OpenAPI reference.

## Why

The request body referenced a component that does not exist, while both the defined schema and Rust request type use `CancelHodlInvoiceRequest`.

## Verification

- RED before fix: the local-reference contract test reported `['InvoiceCancelRequest']` as unresolved.
- GREEN after fix: all local `#/components/schemas/*` references resolve (1 focused test passed).
- `openapi.yaml` parses successfully with PyYAML 6.0.1.
- `git diff --check`: passed.

## Scope

Specification-only change; no daemon, network, or runtime behavior changed.
