### PR TITLE
Add Link to the OpenAPI TransferKind enum

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4303,6 +4303,7 @@ components:
         - Send
         - Inflation
         - Burn
+        - Link
     TransferStatus:
       type: string
       enum:


### PR DESCRIPTION
Fixes #166

## Summary

- Add the runtime `Link` transfer kind to the OpenAPI `TransferKind` enum.
- Bring `/listtransfers` response validation back in sync with the Rust model.

## Why

`TransferKind::Link` can be serialized by the runtime, but the same revision's OpenAPI schema admitted only the other six variants.

## Verification

- RED before fix: the source-to-schema parity test reported `['Link']` as missing.
- GREEN after fix: the focused enum parity test passed.
- `openapi.yaml` parses successfully with PyYAML 6.0.1.
- `git diff --check`: passed.
- Three-way compatibility with PR #165: clean (`git merge-tree --write-tree`).

## Scope

Specification-only change; no daemon, network, or runtime behavior changed.
