### PR TITLE
Fix block-sync-only all-target compilation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        mode: [rest-uniffi-with-vls, wasm-without-vls]
+        mode: [rest-uniffi-with-vls, wasm-without-vls, block-sync-all-targets]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -49,6 +49,8 @@ jobs:
             else
               echo "bindings/wasm-sdk/Cargo.toml not found; skipping direct wasm-sdk cargo check in this repository layout"
             fi
+          elif [ "${{ matrix.mode }}" = "block-sync-all-targets" ]; then
+            cargo check --locked --all-targets --no-default-features --features "block-sync,electrum,esplora"
           else
             echo "unknown matrix mode: ${{ matrix.mode }}"
             exit 1

--- a/src/test/esplora_indexer_defaults.rs
+++ b/src/test/esplora_indexer_defaults.rs
@@ -1,10 +1,10 @@
-#[cfg(feature = "esplora")]
+#[cfg(all(feature = "esplora", feature = "transaction-sync"))]
 use std::collections::BTreeMap;
 
 use lightning::chain::chaininterface::ConfirmationTarget;
 
 use crate::ldk_chain_backend::default_fee_buckets;
-#[cfg(feature = "esplora")]
+#[cfg(all(feature = "esplora", feature = "transaction-sync"))]
 use crate::ldk_chain_backend::transaction_sync::{
     estimate_fee_rate_sat_per_kw, interpolate_fee_rate,
 };
@@ -29,7 +29,7 @@ fn default_fee_buckets_populates_all_targets() {
     }
 }
 
-#[cfg(feature = "esplora")]
+#[cfg(all(feature = "esplora", feature = "transaction-sync"))]
 #[test]
 fn interpolation_handles_exact_match() {
     let mut m = BTreeMap::new();
@@ -37,7 +37,7 @@ fn interpolation_handles_exact_match() {
     assert_eq!(interpolate_fee_rate(&m, 6), Some(12.0));
 }
 
-#[cfg(feature = "esplora")]
+#[cfg(all(feature = "esplora", feature = "transaction-sync"))]
 #[test]
 fn interpolation_linearly_interpolates_between_buckets() {
     let mut m = BTreeMap::new();
@@ -47,7 +47,7 @@ fn interpolation_linearly_interpolates_between_buckets() {
     assert!((v - 60.0).abs() < 0.001, "got {v}");
 }
 
-#[cfg(feature = "esplora")]
+#[cfg(all(feature = "esplora", feature = "transaction-sync"))]
 #[test]
 fn interpolation_falls_back_to_default_when_empty() {
     let m: BTreeMap<u16, f64> = BTreeMap::new();


### PR DESCRIPTION
Fixes #168

## Summary

- Gate the Esplora interpolation helpers and tests on both `esplora` and `transaction-sync`.
- Keep the backend-independent default fee-bucket test available to block-sync-only builds.
- Add the documented block-sync-only all-target combination to CI's feature matrix.

## Root cause

`src/test/esplora_indexer_defaults.rs` imported `ldk_chain_backend::transaction_sync` whenever `esplora` was enabled, even though that module exists only when `transaction-sync` is enabled. The documented `block-sync,electrum,esplora` combination therefore failed while compiling test targets.

## Verification

- Before the fix:
  - `cargo +1.94.0 check --locked --all-targets --no-default-features --features "block-sync,electrum,esplora"`
  - failed with E0432 at `src/test/esplora_indexer_defaults.rs:8`.
- After the fix:
  - the same command completed successfully in 1m26s.
- `cargo +1.94.0 fmt --all -- --check`: passed.
- Workflow YAML parse with PyYAML 6.0.1: passed.
- `git diff --check`: passed.
- A focused default-feature test binary build was attempted with `CARGO_BUILD_JOBS=1` but stopped after about six minutes while still compiling; no test result is claimed. The unchanged default-feature path remains covered by repository CI.

## Scope

Test feature gates and CI coverage only; runtime behavior and public APIs are unchanged.
