### PR TITLE
Refresh the C-FFI lockfile for locked builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,5 +39,8 @@ jobs:
         with:
           toolchain: ${{matrix.toolchain}}
           rustflags: ""
+      - name: Verify C-FFI lockfile
+        if: matrix.name == 'linux' && matrix.toolchain == '1.94.0'
+        run: cargo metadata --locked --manifest-path bindings/c-ffi/Cargo.toml --format-version 1 > /dev/null
       - name: Build
         run: cargo build --release --features "uniffi,vls,vss"

--- a/bindings/c-ffi/Cargo.lock
+++ b/bindings/c-ffi/Cargo.lock
@@ -4762,7 +4762,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib"
 version = "0.3.0-beta.7"
-source = "git+https://github.com/dcorral/rgb-lib.git?rev=94b6221ea9bf04562d89c21c9f074f4ecfbddd5d#94b6221ea9bf04562d89c21c9f074f4ecfbddd5d"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.34#62a8c3a045901147b3b06aed9f1e61f345695dce"
 dependencies = [
  "amplify",
  "base64 0.22.1",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "rgb-lib-migration"
 version = "0.3.0-beta.5"
-source = "git+https://github.com/dcorral/rgb-lib.git?rev=94b6221ea9bf04562d89c21c9f074f4ecfbddd5d#94b6221ea9bf04562d89c21c9f074f4ecfbddd5d"
+source = "git+https://github.com/UTEXO-Protocol/rgb-lib.git?tag=v0.3.0-beta.34#62a8c3a045901147b3b06aed9f1e61f345695dce"
 dependencies = [
  "sea-orm-migration 2.0.2",
  "tokio",
@@ -7750,7 +7750,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #170

## Summary

- Refresh the standalone C-FFI lockfile to match the root crate's UTEXO `rgb-lib` v0.3.0-beta.34 pin.
- Add a Linux/Rust 1.94 CI metadata check that fails when the committed C-FFI lockfile drifts again.

## Root cause

`bindings/c-ffi/Cargo.toml` consumes the root crate by path, but its committed lockfile still resolved `rgb-lib` and `rgb-lib-migration` from an obsolete `dcorral/rgb-lib` revision. Cargo therefore needed to rewrite the lockfile before dependency resolution, which made every `--locked` C-FFI command fail.

## Verification

- RED before the fix:
  - `cargo +1.94.0 metadata --locked --manifest-path bindings/c-ffi/Cargo.toml --format-version 1`
  - exited 101 with `cannot update the lock file ... because --locked was passed`.
- GREEN after the fix:
  - the same locked metadata command passed and resolved 755 packages.
  - `CARGO_BUILD_JOBS=1 cargo +1.94.0 build --locked --manifest-path bindings/c-ffi/Cargo.toml` passed in 26m11s.
- `cargo +1.94.0 fmt --all -- --check`: passed.
- `cargo +1.94.0 fmt --manifest-path bindings/c-ffi/Cargo.toml -- --check`: passed.
- Workflow YAML parse with PyYAML 6.0.1: passed.
- `git diff --check`: passed.

## Scope

Lockfile and CI guard only. No C-FFI API or runtime behavior changed.
